### PR TITLE
chore: release v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiros"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-client"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-db"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-detect-project-name"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "tempfile",
  "toml 0.8.23",
@@ -1191,11 +1191,11 @@ dependencies = [
 
 [[package]]
 name = "oneiros-fs"
-version = "0.0.1"
+version = "0.0.2"
 
 [[package]]
 name = "oneiros-model"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "chrono",
  "data-encoding",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-outcomes"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "oneiros-outcomes-derive",
  "serde",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-outcomes-derive"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "oneiros-outcomes",
  "pretty_assertions",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-service"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "axum",
  "chrono",
@@ -1256,14 +1256,14 @@ dependencies = [
 
 [[package]]
 name = "oneiros-skill"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "oneiros-templates"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "askama",
  "chrono",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-terminal"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "inquire",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 repository = "https://github.com/esmevane/oneiros"
 license = "MIT"

--- a/crates/oneiros/CHANGELOG.md
+++ b/crates/oneiros/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/esmevane/oneiros/compare/oneiros-v0.0.1...oneiros-v0.0.2) - 2026-02-14
+
+### Added
+
+- oneiros project init
+- System init, readme, migrations.
+- Project detection
+
+### Other
+
+- Skill support.
+- Dream, introspect, reflect.
+- Rename {report_outcome,structured_output}
+- Structured output.
+- Service manager.
+- Storage
+- Memory.
+- Cognition.
+- Agents.
+- Memory levels.
+- Textures.
+- Outcomes, as a macro.
+- Personas and tickets.
+- Outcomes.
+- Fix commands module typo.
+- Remove todo
+- Add dist.

--- a/dist/.claude-plugin/plugin.json
+++ b/dist/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oneiros",
   "description": "Keep your agent continuity separate from your model session",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "JC McCormick",
     "url": "https://github.com/esmevane"

--- a/dist/skills/oneiros/SKILL.md
+++ b/dist/skills/oneiros/SKILL.md
@@ -6,7 +6,7 @@ description: >
   mentions of dreaming, introspection, reflection, memory, cognition, personas,
   textures, levels, or brain management.
 allowed-tools: "Read,Bash(oneiros:*)"
-version: "0.0.1"
+version: "0.0.2"
 author: "JC McCormick <https://github.com/esmevane>"
 license: "MIT"
 ---


### PR DESCRIPTION



## 🤖 New release

* `oneiros`: 0.0.1 -> 0.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.2](https://github.com/esmevane/oneiros/compare/oneiros-v0.0.1...oneiros-v0.0.2) - 2026-02-14

### Added

- oneiros project init
- System init, readme, migrations.
- Project detection

### Other

- Skill support.
- Dream, introspect, reflect.
- Rename {report_outcome,structured_output}
- Structured output.
- Service manager.
- Storage
- Memory.
- Cognition.
- Agents.
- Memory levels.
- Textures.
- Outcomes, as a macro.
- Personas and tickets.
- Outcomes.
- Fix commands module typo.
- Remove todo
- Add dist.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).