### PR TITLE
fix: mark project name as not published

### DIFF
--- a/crates/oneiros-detect-project-name/Cargo.toml
+++ b/crates/oneiros-detect-project-name/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 description = "Strategy-based project root and name detection for oneiros."
 repository.workspace = true
 license.workspace = true
+publish = false
 
 [dependencies]
 toml.workspace = true


### PR DESCRIPTION
Whoops! It tried to publish a local crate. We don't need that. This commit flags that crate as private. It'll get compiled into our main crate but not sent out for distribution.