### PR TITLE
Outcomes, as a macro.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +477,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -870,7 +882,7 @@ name = "oneiros-detect-project-name"
 version = "0.0.1"
 dependencies = [
  "tempfile",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -894,8 +906,23 @@ dependencies = [
 name = "oneiros-outcomes"
 version = "0.0.1"
 dependencies = [
+ "oneiros-outcomes-derive",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "oneiros-outcomes-derive"
+version = "0.0.1"
+dependencies = [
+ "oneiros-outcomes",
+ "pretty_assertions",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "tracing",
+ "trybuild",
 ]
 
 [[package]]
@@ -993,6 +1020,26 @@ dependencies = [
  "embedded-io 0.6.1",
  "heapless",
  "serde",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1191,6 +1238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,6 +1381,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1418,9 +1489,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d7e18e3dd1d31e0ee5e863a8091ffec2fcc271636586042452b656a22c8ee1"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -1433,6 +1519,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,9 +1535,18 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.7+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
+dependencies = [
  "winnow",
 ]
 
@@ -1451,6 +1555,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
@@ -1547,6 +1657,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.0.0+spec-1.1.0",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1713,6 +1838,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1889,6 +2023,12 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,14 @@ oneiros-detect-project-name = { path = "crates/oneiros-detect-project-name" }
 oneiros-fs = { path = "crates/oneiros-fs" }
 oneiros-model = { path = "crates/oneiros-model" }
 oneiros-outcomes = { path = "crates/oneiros-outcomes" }
+oneiros-outcomes-derive = { path = "crates/oneiros-outcomes-derive" }
 oneiros-service = { path = "crates/oneiros-service" }
 oneiros-terminal = { path = "crates/oneiros-terminal" }
 postcard = { version = "1", features = ["alloc"] }
+pretty_assertions = "1"
+prettyplease = "0.2"
+proc-macro2 = "1"
+quote = "1"
 rusqlite = { version = "0.31", features = [
   "bundled",
   "functions",
@@ -40,6 +45,7 @@ rusqlite = { version = "0.31", features = [
 ] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
+syn = { version = "2", features = ["extra-traits", "full", "parsing"] }
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
@@ -47,6 +53,7 @@ toml = "0.8"
 tower = { version = "0.5.3", features = ["util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+trybuild = "1"
 uuid = { version = "1", features = ["serde", "v4", "v7"] }
 whoami = "1"
 

--- a/crates/oneiros-outcomes-derive/Cargo.toml
+++ b/crates/oneiros-outcomes-derive/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "oneiros-outcomes-derive"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+
+[dev-dependencies]
+oneiros-outcomes = { path = "../oneiros-outcomes" }
+pretty_assertions.workspace = true
+prettyplease.workspace = true
+tracing.workspace = true
+trybuild.workspace = true

--- a/crates/oneiros-outcomes-derive/src/codegen.rs
+++ b/crates/oneiros-outcomes-derive/src/codegen.rs
@@ -1,0 +1,595 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::LitStr;
+
+use crate::parse::{FieldModel, FormatArgs, Level, OutcomeConfig, OutcomeModel, VariantModel};
+
+/// Generate all trait implementations from the parsed model.
+pub fn codegen(model: &OutcomeModel) -> TokenStream {
+    let reportable_impl = gen_reportable(model);
+    let from_impls = gen_from_impls(model);
+
+    quote! {
+        #reportable_impl
+        #from_impls
+    }
+}
+
+/// Generate the `Reportable` impl for the enum.
+fn gen_reportable(model: &OutcomeModel) -> TokenStream {
+    let ident = &model.ident;
+    let (impl_generics, ty_generics, where_clause) = model.generics.split_for_impl();
+
+    let level_arms = model.variants.iter().map(gen_level_arm);
+    let message_arms = model.variants.iter().map(gen_message_arm);
+    let log_message_arms = model.variants.iter().map(gen_log_message_arm);
+    let prompt_arms = model.variants.iter().map(gen_prompt_arm);
+
+    // Only override log_message if any variant has an explicit log.
+    let has_any_log = model.variants.iter().any(|v| match &v.config {
+        OutcomeConfig::Explicit { log, .. } => log.is_some(),
+        OutcomeConfig::Transparent { .. } => true,
+    });
+
+    // Only override prompt if any variant has an explicit prompt.
+    let has_any_prompt = model.variants.iter().any(|v| match &v.config {
+        OutcomeConfig::Explicit { prompt, .. } => prompt.is_some(),
+        OutcomeConfig::Transparent { .. } => true,
+    });
+
+    let log_message_method = if has_any_log {
+        quote! {
+            fn log_message(&self) -> String {
+                match self {
+                    #(#log_message_arms)*
+                }
+            }
+        }
+    } else {
+        TokenStream::new()
+    };
+
+    let prompt_method = if has_any_prompt {
+        quote! {
+            fn prompt(&self) -> Option<String> {
+                match self {
+                    #(#prompt_arms)*
+                }
+            }
+        }
+    } else {
+        TokenStream::new()
+    };
+
+    quote! {
+        impl #impl_generics oneiros_outcomes::Reportable for #ident #ty_generics #where_clause {
+            fn level(&self) -> tracing::Level {
+                match self {
+                    #(#level_arms)*
+                }
+            }
+
+            fn message(&self) -> String {
+                match self {
+                    #(#message_arms)*
+                }
+            }
+
+            #log_message_method
+            #prompt_method
+        }
+    }
+}
+
+/// Generate the destructuring pattern for a variant's fields.
+fn destructure_pattern(variant: &VariantModel) -> TokenStream {
+    let ident = &variant.ident;
+    if variant.fields.is_empty() {
+        quote! { Self::#ident }
+    } else {
+        let bindings = variant.fields.iter().map(field_binding);
+        // Check if fields are named or positional.
+        match &variant.fields[0].member {
+            syn::Member::Named(_) => quote! { Self::#ident { #(#bindings),* } },
+            syn::Member::Unnamed(_) => quote! { Self::#ident(#(#bindings),*) },
+        }
+    }
+}
+
+/// Generate the binding name for a field.
+fn field_binding(field: &FieldModel) -> TokenStream {
+    match &field.member {
+        syn::Member::Named(ident) => quote! { #ident },
+        syn::Member::Unnamed(idx) => {
+            let var = format_ident!("_{}", idx.index);
+            quote! { #var }
+        }
+    }
+}
+
+/// Rewrite a format string, replacing `{0}` → `{_0}`, `{1}` → `{_1}`, etc.
+/// Leaves named references like `{name}` and format specs like `{0:?}` intact
+/// (the named ones are already valid bindings from destructuring, and the
+/// positional ones just need the `_` prefix to match our binding names).
+fn rewrite_format_str(fmt: &LitStr) -> LitStr {
+    let value = fmt.value();
+    let mut result = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '{' {
+            result.push('{');
+            // Check for escaped brace `{{`
+            if chars.peek() == Some(&'{') {
+                result.push(chars.next().unwrap());
+                continue;
+            }
+            // Check for a digit (positional field reference)
+            if chars.peek().is_some_and(|c| c.is_ascii_digit()) {
+                result.push('_');
+                // Let the rest of the content through (digits, format specs, etc.)
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    LitStr::new(&result, fmt.span())
+}
+
+/// Generate a `format!(...)` call from a `FormatArgs`.
+/// Rewrites positional references in the format string (`{0}` → `{_0}`).
+/// Dot-prefix rewriting (`.0` → `_0`) is handled during parsing.
+fn format_call(fmt_args: &FormatArgs) -> TokenStream {
+    let fmt = rewrite_format_str(&fmt_args.fmt);
+    let args = &fmt_args.args;
+
+    if args.is_empty() {
+        quote! { format!(#fmt) }
+    } else {
+        quote! { format!(#fmt, #(#args),*) }
+    }
+}
+
+fn gen_level_arm(variant: &VariantModel) -> TokenStream {
+    let pat = destructure_pattern(variant);
+
+    match &variant.config {
+        OutcomeConfig::Transparent { .. } => {
+            let inner = field_binding(&variant.fields[0]);
+            quote! { #pat => #inner.level(), }
+        }
+        OutcomeConfig::Explicit { level, .. } => {
+            let level_token = level_to_tokens(*level);
+            quote! { #pat => #level_token, }
+        }
+    }
+}
+
+fn gen_message_arm(variant: &VariantModel) -> TokenStream {
+    let pat = destructure_pattern(variant);
+
+    match &variant.config {
+        OutcomeConfig::Transparent { .. } => {
+            let inner = field_binding(&variant.fields[0]);
+            quote! { #pat => #inner.message(), }
+        }
+        OutcomeConfig::Explicit { message, .. } => {
+            let call = format_call(message);
+            quote! { #pat => #call, }
+        }
+    }
+}
+
+fn gen_log_message_arm(variant: &VariantModel) -> TokenStream {
+    let pat = destructure_pattern(variant);
+
+    match &variant.config {
+        OutcomeConfig::Transparent { .. } => {
+            let inner = field_binding(&variant.fields[0]);
+            quote! { #pat => #inner.log_message(), }
+        }
+        OutcomeConfig::Explicit { log, message, .. } => {
+            let call = match log {
+                Some(log_fmt) => format_call(log_fmt),
+                None => format_call(message),
+            };
+            quote! { #pat => #call, }
+        }
+    }
+}
+
+fn gen_prompt_arm(variant: &VariantModel) -> TokenStream {
+    let pat = destructure_pattern(variant);
+
+    match &variant.config {
+        OutcomeConfig::Transparent { .. } => {
+            let inner = field_binding(&variant.fields[0]);
+            quote! { #pat => #inner.prompt(), }
+        }
+        OutcomeConfig::Explicit { prompt, .. } => match prompt {
+            Some(prompt_fmt) => {
+                let call = format_call(prompt_fmt);
+                quote! { #pat => Some(#call), }
+            }
+            None => {
+                quote! { #pat => None, }
+            }
+        },
+    }
+}
+
+fn level_to_tokens(level: Level) -> TokenStream {
+    match level {
+        Level::Trace => quote! { tracing::Level::TRACE },
+        Level::Debug => quote! { tracing::Level::DEBUG },
+        Level::Info => quote! { tracing::Level::INFO },
+        Level::Warn => quote! { tracing::Level::WARN },
+        Level::Error => quote! { tracing::Level::ERROR },
+    }
+}
+
+/// Generate `From` impls for every `#[from]` field.
+fn gen_from_impls(model: &OutcomeModel) -> TokenStream {
+    let ident = &model.ident;
+
+    let impls: Vec<_> = model
+        .variants
+        .iter()
+        .flat_map(|v| v.fields.iter().filter(|f| f.is_from).map(move |f| (v, f)))
+        .map(|(v, f)| {
+            let (impl_generics, ty_generics, where_clause) = model.generics.split_for_impl();
+            let variant_ident = &v.ident;
+            let from_ty = &f.ty;
+
+            let body = match &f.member {
+                syn::Member::Named(name) => {
+                    quote! { #ident::#variant_ident { #name: value } }
+                }
+                syn::Member::Unnamed(_) => {
+                    quote! { #ident::#variant_ident(value) }
+                }
+            };
+
+            quote! {
+                impl #impl_generics From<#from_ty> for #ident #ty_generics #where_clause {
+                    fn from(value: #from_ty) -> Self {
+                        #body
+                    }
+                }
+            }
+        })
+        .collect();
+
+    quote! { #(#impls)* }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+
+    fn pretty(tokens: TokenStream) -> String {
+        let file = syn::parse2::<syn::File>(tokens).expect("generated code should be valid Rust");
+        prettyplease::unparse(&file)
+    }
+
+    fn codegen_from_input(input: TokenStream) -> String {
+        let derive_input: syn::DeriveInput = syn::parse2(input).unwrap();
+        let model = parse::parse(&derive_input).unwrap();
+        pretty(codegen(&model))
+    }
+
+    #[test]
+    fn simple_unit_variant() {
+        let actual = codegen_from_input(quote! {
+            enum TestOutcome {
+                #[outcome(message("hello world"))]
+                Simple,
+            }
+        });
+
+        let expected = pretty(quote! {
+            impl oneiros_outcomes::Reportable for TestOutcome {
+                fn level(&self) -> tracing::Level {
+                    match self {
+                        Self::Simple => tracing::Level::INFO,
+                    }
+                }
+                fn message(&self) -> String {
+                    match self {
+                        Self::Simple => format!("hello world"),
+                    }
+                }
+            }
+        });
+
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn tuple_variant_with_positional_args() {
+        // User writes {0}, {1} — codegen rewrites to {_0}, {_1}
+        let actual = codegen_from_input(quote! {
+            enum TestOutcome {
+                #[outcome(message("found {0} at {1}"))]
+                Found(String, String),
+            }
+        });
+
+        let expected = pretty(quote! {
+            impl oneiros_outcomes::Reportable for TestOutcome {
+                fn level(&self) -> tracing::Level {
+                    match self {
+                        Self::Found(_0, _1) => tracing::Level::INFO,
+                    }
+                }
+                fn message(&self) -> String {
+                    match self {
+                        Self::Found(_0, _1) => format!("found {_0} at {_1}"),
+                    }
+                }
+            }
+        });
+
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn variant_with_custom_level() {
+        let actual = codegen_from_input(quote! {
+            enum TestOutcome {
+                #[outcome(message("bad thing"), level = "warn")]
+                Bad,
+                #[outcome(message("good thing"))]
+                Good,
+            }
+        });
+
+        let expected = pretty(quote! {
+            impl oneiros_outcomes::Reportable for TestOutcome {
+                fn level(&self) -> tracing::Level {
+                    match self {
+                        Self::Bad => tracing::Level::WARN,
+                        Self::Good => tracing::Level::INFO,
+                    }
+                }
+                fn message(&self) -> String {
+                    match self {
+                        Self::Bad => format!("bad thing"),
+                        Self::Good => format!("good thing"),
+                    }
+                }
+            }
+        });
+
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn variant_with_log_and_prompt() {
+        let actual = codegen_from_input(quote! {
+            enum TestOutcome {
+                #[outcome(
+                    message("initialized {0}"),
+                    log("tenant {0} init complete"),
+                    prompt("run doctor next")
+                )]
+                Done(String),
+            }
+        });
+
+        let expected = pretty(quote! {
+            impl oneiros_outcomes::Reportable for TestOutcome {
+                fn level(&self) -> tracing::Level {
+                    match self {
+                        Self::Done(_0) => tracing::Level::INFO,
+                    }
+                }
+                fn message(&self) -> String {
+                    match self {
+                        Self::Done(_0) => format!("initialized {_0}"),
+                    }
+                }
+                fn log_message(&self) -> String {
+                    match self {
+                        Self::Done(_0) => format!("tenant {_0} init complete"),
+                    }
+                }
+                fn prompt(&self) -> Option<String> {
+                    match self {
+                        Self::Done(_0) => Some(format!("run doctor next")),
+                    }
+                }
+            }
+        });
+
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn transparent_variant() {
+        let actual = codegen_from_input(quote! {
+            enum Outer {
+                #[outcome(transparent)]
+                Inner(InnerOutcome),
+            }
+        });
+
+        let expected = pretty(quote! {
+            impl oneiros_outcomes::Reportable for Outer {
+                fn level(&self) -> tracing::Level {
+                    match self {
+                        Self::Inner(_0) => _0.level(),
+                    }
+                }
+                fn message(&self) -> String {
+                    match self {
+                        Self::Inner(_0) => _0.message(),
+                    }
+                }
+                fn log_message(&self) -> String {
+                    match self {
+                        Self::Inner(_0) => _0.log_message(),
+                    }
+                }
+                fn prompt(&self) -> Option<String> {
+                    match self {
+                        Self::Inner(_0) => _0.prompt(),
+                    }
+                }
+            }
+        });
+
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn from_generates_from_impl() {
+        let actual = codegen_from_input(quote! {
+            enum Outer {
+                #[outcome(transparent)]
+                Inner(#[from] InnerOutcome),
+            }
+        });
+
+        // Should contain both Reportable and From impls.
+        assert!(actual.contains("impl From<InnerOutcome> for Outer"));
+        assert!(actual.contains("Outer::Inner(value)"));
+    }
+
+    #[test]
+    fn multiple_from_impls() {
+        let actual = codegen_from_input(quote! {
+            enum Parent {
+                #[outcome(transparent)]
+                A(#[from] ChildA),
+                #[outcome(transparent)]
+                B(#[from] ChildB),
+            }
+        });
+
+        assert!(actual.contains("impl From<ChildA> for Parent"));
+        assert!(actual.contains("impl From<ChildB> for Parent"));
+    }
+
+    #[test]
+    fn message_with_dot_prefix_args() {
+        // User writes .0.display() — codegen rewrites to _0.display()
+        let actual = codegen_from_input(quote! {
+            enum TestOutcome {
+                #[outcome(message("path: {}", .0.display()))]
+                Found(std::path::PathBuf),
+            }
+        });
+
+        let expected = pretty(quote! {
+            impl oneiros_outcomes::Reportable for TestOutcome {
+                fn level(&self) -> tracing::Level {
+                    match self {
+                        Self::Found(_0) => tracing::Level::INFO,
+                    }
+                }
+                fn message(&self) -> String {
+                    match self {
+                        Self::Found(_0) => format!("path: {}", _0.display()),
+                    }
+                }
+            }
+        });
+
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn format_string_rewrites_positional_with_format_spec() {
+        // {0:?} should become {_0:?}
+        let actual = codegen_from_input(quote! {
+            enum TestOutcome {
+                #[outcome(message("debug: {0:?}"))]
+                Debug(String),
+            }
+        });
+
+        assert!(actual.contains(r#"format!("debug: {_0:?}")"#));
+    }
+
+    #[test]
+    fn escaped_braces_are_preserved() {
+        let actual = codegen_from_input(quote! {
+            enum TestOutcome {
+                #[outcome(message("literal {{braces}}"))]
+                Escaped,
+            }
+        });
+
+        assert!(actual.contains(r#"format!("literal {{braces}}")"#));
+    }
+
+    #[test]
+    fn dot_prefix_named_field_rewrites() {
+        // .field in trailing args should just remove the dot
+        let actual = codegen_from_input(quote! {
+            enum TestOutcome {
+                #[outcome(message("hi {}", .name))]
+                Named { name: String },
+            }
+        });
+
+        let expected = pretty(quote! {
+            impl oneiros_outcomes::Reportable for TestOutcome {
+                fn level(&self) -> tracing::Level {
+                    match self {
+                        Self::Named { name } => tracing::Level::INFO,
+                    }
+                }
+                fn message(&self) -> String {
+                    match self {
+                        Self::Named { name } => format!("hi {}", name),
+                    }
+                }
+            }
+        });
+
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn log_fallback_to_message_when_no_log() {
+        // When some variants have log and others don't, the log_message method
+        // should fall back to the message format for variants without log.
+        let actual = codegen_from_input(quote! {
+            enum TestOutcome {
+                #[outcome(message("user msg"), log("internal log"))]
+                WithLog,
+                #[outcome(message("just message"))]
+                WithoutLog,
+            }
+        });
+
+        let expected = pretty(quote! {
+            impl oneiros_outcomes::Reportable for TestOutcome {
+                fn level(&self) -> tracing::Level {
+                    match self {
+                        Self::WithLog => tracing::Level::INFO,
+                        Self::WithoutLog => tracing::Level::INFO,
+                    }
+                }
+                fn message(&self) -> String {
+                    match self {
+                        Self::WithLog => format!("user msg"),
+                        Self::WithoutLog => format!("just message"),
+                    }
+                }
+                fn log_message(&self) -> String {
+                    match self {
+                        Self::WithLog => format!("internal log"),
+                        Self::WithoutLog => format!("just message"),
+                    }
+                }
+            }
+        });
+
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+}

--- a/crates/oneiros-outcomes-derive/src/lib.rs
+++ b/crates/oneiros-outcomes-derive/src/lib.rs
@@ -1,0 +1,14 @@
+mod codegen;
+mod parse;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(Outcome, attributes(outcome, from))]
+pub fn derive_outcome(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    match parse::parse(&input) {
+        Ok(model) => codegen::codegen(&model).into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}

--- a/crates/oneiros-outcomes-derive/src/parse.rs
+++ b/crates/oneiros-outcomes-derive/src/parse.rs
@@ -1,0 +1,513 @@
+use proc_macro2::Span;
+use syn::parse::ParseStream;
+use syn::spanned::Spanned;
+use syn::{Attribute, DeriveInput, Fields, Ident, LitStr, Token, Type};
+
+/// The parsed domain model for an entire `#[derive(Outcome)]` enum.
+#[derive(Debug)]
+pub struct OutcomeModel {
+    pub ident: Ident,
+    pub generics: syn::Generics,
+    pub variants: Vec<VariantModel>,
+}
+
+/// A single enum variant with its parsed attributes and fields.
+#[derive(Debug)]
+pub struct VariantModel {
+    pub ident: Ident,
+    pub fields: Vec<FieldModel>,
+    pub config: OutcomeConfig,
+}
+
+/// A single field within a variant.
+#[derive(Debug)]
+pub struct FieldModel {
+    pub member: syn::Member,
+    pub ty: Type,
+    pub is_from: bool,
+}
+
+/// The `#[outcome(...)]` configuration for a variant.
+#[derive(Debug)]
+pub enum OutcomeConfig {
+    Transparent {
+        span: Span,
+    },
+    Explicit {
+        message: FormatArgs,
+        level: Level,
+        log: Option<FormatArgs>,
+        prompt: Option<FormatArgs>,
+    },
+}
+
+/// A parsed format string with optional trailing arguments, e.g. `message("foo {}", bar.baz())`.
+#[derive(Debug)]
+pub struct FormatArgs {
+    pub fmt: LitStr,
+    pub args: Vec<proc_macro2::TokenStream>,
+}
+
+/// A parsed log level, defaulting to Info.
+#[derive(Clone, Copy, Debug, Default)]
+pub enum Level {
+    Trace,
+    Debug,
+    #[default]
+    Info,
+    Warn,
+    Error,
+}
+
+impl Level {
+    fn from_str(s: &str, span: Span) -> syn::Result<Self> {
+        match s {
+            "trace" => Ok(Level::Trace),
+            "debug" => Ok(Level::Debug),
+            "info" => Ok(Level::Info),
+            "warn" => Ok(Level::Warn),
+            "error" => Ok(Level::Error),
+            _ => Err(syn::Error::new(
+                span,
+                format!("invalid level \"{s}\", expected one of: trace, debug, info, warn, error"),
+            )),
+        }
+    }
+}
+
+/// Parse a `DeriveInput` into our domain model.
+pub fn parse(input: &DeriveInput) -> syn::Result<OutcomeModel> {
+    let data = match &input.data {
+        syn::Data::Enum(data) => data,
+        _ => {
+            return Err(syn::Error::new_spanned(
+                input,
+                "Outcome can only be derived for enums",
+            ));
+        }
+    };
+
+    let variants = data
+        .variants
+        .iter()
+        .map(parse_variant)
+        .collect::<syn::Result<Vec<_>>>()?;
+
+    Ok(OutcomeModel {
+        ident: input.ident.clone(),
+        generics: input.generics.clone(),
+        variants,
+    })
+}
+
+fn parse_variant(variant: &syn::Variant) -> syn::Result<VariantModel> {
+    let config = parse_outcome_attr(&variant.attrs, &variant.ident)?;
+    let fields = parse_fields(&variant.fields)?;
+
+    if let OutcomeConfig::Transparent { span } = &config
+        && fields.len() != 1
+    {
+        return Err(syn::Error::new(
+            *span,
+            "transparent outcome requires exactly one field",
+        ));
+    }
+
+    Ok(VariantModel {
+        ident: variant.ident.clone(),
+        fields,
+        config,
+    })
+}
+
+fn parse_fields(fields: &Fields) -> syn::Result<Vec<FieldModel>> {
+    match fields {
+        Fields::Named(named) => named
+            .named
+            .iter()
+            .map(|f| {
+                let is_from = has_from_attr(&f.attrs);
+                Ok(FieldModel {
+                    member: syn::Member::Named(f.ident.clone().unwrap()),
+                    ty: f.ty.clone(),
+                    is_from,
+                })
+            })
+            .collect(),
+        Fields::Unnamed(unnamed) => unnamed
+            .unnamed
+            .iter()
+            .enumerate()
+            .map(|(i, f)| {
+                let is_from = has_from_attr(&f.attrs);
+                Ok(FieldModel {
+                    member: syn::Member::Unnamed(syn::Index {
+                        index: i as u32,
+                        span: f.span(),
+                    }),
+                    ty: f.ty.clone(),
+                    is_from,
+                })
+            })
+            .collect(),
+        Fields::Unit => Ok(Vec::new()),
+    }
+}
+
+fn has_from_attr(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|a| a.path().is_ident("from"))
+}
+
+/// Parse the `#[outcome(...)]` attribute from a variant's attributes.
+fn parse_outcome_attr(attrs: &[Attribute], variant_ident: &Ident) -> syn::Result<OutcomeConfig> {
+    let outcome_attr = attrs
+        .iter()
+        .find(|a| a.path().is_ident("outcome"))
+        .ok_or_else(|| {
+            syn::Error::new(
+                variant_ident.span(),
+                format!("missing #[outcome(...)] attribute on variant `{variant_ident}`"),
+            )
+        })?;
+
+    outcome_attr.parse_args_with(parse_outcome_config)
+}
+
+/// The inner parser for `#[outcome(...)]` content.
+fn parse_outcome_config(input: ParseStream) -> syn::Result<OutcomeConfig> {
+    // Check for `transparent` keyword first.
+    if input.peek(syn::Ident) {
+        let ident: Ident = input.fork().parse()?;
+        if ident == "transparent" {
+            let ident: Ident = input.parse()?;
+            if !input.is_empty() {
+                return Err(syn::Error::new(
+                    input.span(),
+                    "unexpected tokens after `transparent`",
+                ));
+            }
+            return Ok(OutcomeConfig::Transparent { span: ident.span() });
+        }
+    }
+
+    let mut message: Option<FormatArgs> = None;
+    let mut level: Option<Level> = None;
+    let mut log: Option<FormatArgs> = None;
+    let mut prompt: Option<FormatArgs> = None;
+
+    while !input.is_empty() {
+        let key: Ident = input.parse()?;
+        match key.to_string().as_str() {
+            "message" => {
+                let content;
+                syn::parenthesized!(content in input);
+                message = Some(parse_format_args(&content)?);
+            }
+            "log" => {
+                let content;
+                syn::parenthesized!(content in input);
+                log = Some(parse_format_args(&content)?);
+            }
+            "prompt" => {
+                let content;
+                syn::parenthesized!(content in input);
+                prompt = Some(parse_format_args(&content)?);
+            }
+            "level" => {
+                input.parse::<Token![=]>()?;
+                let lit: LitStr = input.parse()?;
+                level = Some(Level::from_str(&lit.value(), lit.span())?);
+            }
+            other => {
+                return Err(syn::Error::new(
+                    key.span(),
+                    format!("unknown outcome attribute `{other}`"),
+                ));
+            }
+        }
+
+        // Consume optional trailing comma.
+        if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+        }
+    }
+
+    let message = message.ok_or_else(|| {
+        syn::Error::new(
+            input.span(),
+            "missing required `message(\"...\")` in #[outcome(...)]",
+        )
+    })?;
+
+    Ok(OutcomeConfig::Explicit {
+        message,
+        level: level.unwrap_or_default(),
+        log,
+        prompt,
+    })
+}
+
+/// Parse `"format string", arg1, arg2, ...` within parentheses.
+/// Supports thiserror-style dot-prefix syntax: `.0` becomes `_0`, `.field` becomes `field`.
+fn parse_format_args(input: ParseStream) -> syn::Result<FormatArgs> {
+    let fmt: LitStr = input.parse()?;
+    let mut args = Vec::new();
+
+    while input.peek(Token![,]) {
+        input.parse::<Token![,]>()?;
+        if input.is_empty() {
+            break;
+        }
+
+        // Check for dot-prefix syntax (`.0`, `.field`)
+        if input.peek(Token![.]) {
+            let dot_span = input.parse::<Token![.]>()?.span;
+
+            let prefix = if input.peek(syn::LitInt) {
+                // `.0` → `_0`
+                let lit: syn::LitInt = input.parse()?;
+                quote::format_ident!("_{}", lit.to_string(), span = lit.span())
+            } else if input.peek(syn::Ident) {
+                // `.field` → `field`
+                input.parse::<Ident>()?
+            } else {
+                return Err(syn::Error::new(
+                    dot_span,
+                    "expected field index or name after `.`",
+                ));
+            };
+
+            // Collect remaining tokens until comma or end to form the
+            // full expression (handles method chains, closures, turbofish, etc.)
+            let mut rest_tokens = proc_macro2::TokenStream::new();
+            while !input.is_empty() && !input.peek(Token![,]) {
+                let tt: proc_macro2::TokenTree = input.parse()?;
+                rest_tokens.extend(std::iter::once(tt));
+            }
+            args.push(quote::quote!(#prefix #rest_tokens));
+        } else {
+            // Normal expression (includes `name = expr` for named format args)
+            let expr: syn::Expr = input.parse()?;
+            args.push(quote::quote!(#expr));
+        }
+    }
+
+    Ok(FormatArgs { fmt, args })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_input(tokens: proc_macro2::TokenStream) -> syn::Result<OutcomeModel> {
+        let input: DeriveInput = syn::parse2(tokens)?;
+        parse(&input)
+    }
+
+    #[test]
+    fn parses_simple_message() {
+        let model = parse_input(quote::quote! {
+            enum TestOutcome {
+                #[outcome(message("hello world"))]
+                Simple,
+            }
+        })
+        .unwrap();
+
+        assert_eq!(model.ident, "TestOutcome");
+        assert_eq!(model.variants.len(), 1);
+        assert_eq!(model.variants[0].ident, "Simple");
+        assert!(model.variants[0].fields.is_empty());
+
+        match &model.variants[0].config {
+            OutcomeConfig::Explicit { message, level, .. } => {
+                assert_eq!(message.fmt.value(), "hello world");
+                assert!(message.args.is_empty());
+                assert!(matches!(level, Level::Info));
+            }
+            _ => panic!("expected Explicit config"),
+        }
+    }
+
+    #[test]
+    fn parses_message_with_level() {
+        let model = parse_input(quote::quote! {
+            enum TestOutcome {
+                #[outcome(message("warning!"), level = "warn")]
+                Bad,
+            }
+        })
+        .unwrap();
+
+        match &model.variants[0].config {
+            OutcomeConfig::Explicit { level, .. } => {
+                assert!(matches!(level, Level::Warn));
+            }
+            _ => panic!("expected Explicit config"),
+        }
+    }
+
+    #[test]
+    fn parses_message_with_format_args() {
+        let model = parse_input(quote::quote! {
+            enum TestOutcome {
+                #[outcome(message("hello {}", .0.display()))]
+                WithArgs(String),
+            }
+        })
+        .unwrap();
+
+        match &model.variants[0].config {
+            OutcomeConfig::Explicit { message, .. } => {
+                assert_eq!(message.fmt.value(), "hello {}");
+                assert_eq!(message.args.len(), 1);
+                // .0.display() should have been rewritten to _0.display()
+                let arg_str = message.args[0].to_string();
+                assert!(arg_str.contains("_0"), "expected _0 in arg, got: {arg_str}");
+            }
+            _ => panic!("expected Explicit config"),
+        }
+    }
+
+    #[test]
+    fn parses_all_attributes() {
+        let model = parse_input(quote::quote! {
+            enum TestOutcome {
+                #[outcome(
+                    message("user msg {0}"),
+                    log("log msg {0}"),
+                    prompt("do this next"),
+                    level = "debug"
+                )]
+                Full(String),
+            }
+        })
+        .unwrap();
+
+        match &model.variants[0].config {
+            OutcomeConfig::Explicit {
+                message,
+                level,
+                log,
+                prompt,
+            } => {
+                assert_eq!(message.fmt.value(), "user msg {0}");
+                assert!(matches!(level, Level::Debug));
+                assert_eq!(log.as_ref().unwrap().fmt.value(), "log msg {0}");
+                assert_eq!(prompt.as_ref().unwrap().fmt.value(), "do this next");
+            }
+            _ => panic!("expected Explicit config"),
+        }
+    }
+
+    #[test]
+    fn parses_transparent() {
+        let model = parse_input(quote::quote! {
+            enum TestOutcome {
+                #[outcome(transparent)]
+                Inner(InnerOutcome),
+            }
+        })
+        .unwrap();
+
+        assert!(matches!(
+            model.variants[0].config,
+            OutcomeConfig::Transparent { .. }
+        ));
+    }
+
+    #[test]
+    fn parses_from_on_field() {
+        let model = parse_input(quote::quote! {
+            enum TestOutcome {
+                #[outcome(transparent)]
+                Inner(#[from] InnerOutcome),
+            }
+        })
+        .unwrap();
+
+        assert!(model.variants[0].fields[0].is_from);
+    }
+
+    #[test]
+    fn rejects_missing_outcome_attr() {
+        let result = parse_input(quote::quote! {
+            enum TestOutcome {
+                NoAttr,
+            }
+        });
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("missing #[outcome(...)"));
+    }
+
+    #[test]
+    fn rejects_missing_message() {
+        let result = parse_input(quote::quote! {
+            enum TestOutcome {
+                #[outcome(level = "warn")]
+                NoMessage,
+            }
+        });
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("missing required `message"));
+    }
+
+    #[test]
+    fn rejects_invalid_level() {
+        let result = parse_input(quote::quote! {
+            enum TestOutcome {
+                #[outcome(message("hi"), level = "critical")]
+                Bad,
+            }
+        });
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("invalid level"));
+    }
+
+    #[test]
+    fn rejects_transparent_with_multiple_fields() {
+        let result = parse_input(quote::quote! {
+            enum TestOutcome {
+                #[outcome(transparent)]
+                Multi(String, String),
+            }
+        });
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("exactly one field"));
+    }
+
+    #[test]
+    fn rejects_structs() {
+        let result = parse_input(quote::quote! {
+            struct NotAnEnum {
+                field: String,
+            }
+        });
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("enums"));
+    }
+
+    #[test]
+    fn rejects_unknown_attribute() {
+        let result = parse_input(quote::quote! {
+            enum TestOutcome {
+                #[outcome(message("hi"), bogus = "what")]
+                Bad,
+            }
+        });
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("unknown outcome attribute"));
+    }
+}

--- a/crates/oneiros-outcomes/Cargo.toml
+++ b/crates/oneiros-outcomes/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
+oneiros-outcomes-derive.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/oneiros-outcomes/src/lib.rs
+++ b/crates/oneiros-outcomes/src/lib.rs
@@ -1,8 +1,11 @@
 mod outcomes;
 mod reportable;
+mod reporter;
 
 #[cfg(test)]
 mod tests;
 
+pub use oneiros_outcomes_derive::Outcome;
 pub use outcomes::Outcomes;
 pub use reportable::Reportable;
+pub use reporter::{ConsoleReporter, Reporter};

--- a/crates/oneiros-outcomes/src/outcomes.rs
+++ b/crates/oneiros-outcomes/src/outcomes.rs
@@ -82,7 +82,7 @@ impl<T: Reportable> Outcomes<T> {
         let loc = Location::caller();
         let file = loc.file();
         let line = loc.line();
-        let message = outcome.message();
+        let message = outcome.log_message();
         let level = outcome.level();
 
         dyn_event!(level, file, line, message);

--- a/crates/oneiros-outcomes/src/reportable.rs
+++ b/crates/oneiros-outcomes/src/reportable.rs
@@ -3,7 +3,19 @@
 /// Implementors provide the tracing level and human-readable message.
 /// The `Outcomes` collection handles the actual tracing emission and
 /// caller location capture.
+///
+/// - `message()` is the user-facing display text.
+/// - `log_message()` is the tracing output; defaults to `message()`.
+/// - `prompt()` is optional actionable guidance text.
 pub trait Reportable {
     fn level(&self) -> tracing::Level;
     fn message(&self) -> String;
+
+    fn log_message(&self) -> String {
+        self.message()
+    }
+
+    fn prompt(&self) -> Option<String> {
+        None
+    }
 }

--- a/crates/oneiros-outcomes/src/reporter.rs
+++ b/crates/oneiros-outcomes/src/reporter.rs
@@ -1,0 +1,22 @@
+use crate::Reportable;
+
+/// A consumer of outcomes that presents them to the user.
+///
+/// Separating reporting from the outcome types allows different
+/// presentation strategies (console, TUI, structured output, etc.)
+/// without changing the outcome definitions.
+pub trait Reporter {
+    fn report(&self, outcome: &dyn Reportable);
+}
+
+/// Prints outcomes to stdout: message first, then prompt if present.
+pub struct ConsoleReporter;
+
+impl Reporter for ConsoleReporter {
+    fn report(&self, outcome: &dyn Reportable) {
+        println!("{}", outcome.message());
+        if let Some(prompt) = outcome.prompt() {
+            println!("{}", prompt);
+        }
+    }
+}

--- a/crates/oneiros/src/cli/outcomes.rs
+++ b/crates/oneiros/src/cli/outcomes.rs
@@ -1,39 +1,16 @@
 use crate::*;
+use oneiros_outcomes::Outcome;
 
+#[derive(Outcome)]
 pub enum CliOutcomes {
-    Doctor(DoctorOutcomes),
-    Persona(PersonaOutcomes),
-    Project(ProjectOutcomes),
-    Service(ServiceOutcomes),
-    System(SystemOutcomes),
-}
-
-impl From<DoctorOutcomes> for CliOutcomes {
-    fn from(outcome: DoctorOutcomes) -> Self {
-        CliOutcomes::Doctor(outcome)
-    }
-}
-
-impl From<PersonaOutcomes> for CliOutcomes {
-    fn from(outcome: PersonaOutcomes) -> Self {
-        CliOutcomes::Persona(outcome)
-    }
-}
-
-impl From<ProjectOutcomes> for CliOutcomes {
-    fn from(outcome: ProjectOutcomes) -> Self {
-        CliOutcomes::Project(outcome)
-    }
-}
-
-impl From<ServiceOutcomes> for CliOutcomes {
-    fn from(outcome: ServiceOutcomes) -> Self {
-        CliOutcomes::Service(outcome)
-    }
-}
-
-impl From<SystemOutcomes> for CliOutcomes {
-    fn from(outcome: SystemOutcomes) -> Self {
-        CliOutcomes::System(outcome)
-    }
+    #[outcome(transparent)]
+    Doctor(#[from] DoctorOutcomes),
+    #[outcome(transparent)]
+    Persona(#[from] PersonaOutcomes),
+    #[outcome(transparent)]
+    Project(#[from] ProjectOutcomes),
+    #[outcome(transparent)]
+    Service(#[from] ServiceOutcomes),
+    #[outcome(transparent)]
+    System(#[from] SystemOutcomes),
 }

--- a/crates/oneiros/src/commands/doctor/outcomes.rs
+++ b/crates/oneiros/src/commands/doctor/outcomes.rs
@@ -1,55 +1,26 @@
+use oneiros_outcomes::Outcome;
 use std::path::PathBuf;
 
-#[derive(Clone)]
+#[derive(Clone, Outcome)]
 pub enum DoctorOutcomes {
+    #[outcome(message("Project '{0}' detected at '{}'.", .1.display()))]
     ProjectDetected(String, PathBuf),
+    #[outcome(message("No project detected."), level = "warn")]
     NoProjectDetected,
+    #[outcome(message("System is initialized."))]
     Initialized,
+    #[outcome(message("System is not initialized."), level = "warn")]
     NotInitialized,
+    #[outcome(message("Database found at '{}'.", .0.display()))]
     DatabaseOk(PathBuf),
+    #[outcome(message("Database not found at '{}': {1}", .0.display()), level = "warn")]
     NoDatabaseFound(PathBuf, String),
+    #[outcome(message("Event log is ready with {0} events."))]
     EventLogReady(usize),
+    #[outcome(message("Event log error: {0}"), level = "warn")]
     NoEventLog(String),
+    #[outcome(message("Config file found at '{}'.", .0.display()))]
     ConfigOk(PathBuf),
+    #[outcome(message("Config file not found at '{}'.", .0.display()), level = "warn")]
     NoConfigFound(PathBuf),
-}
-
-impl oneiros_outcomes::Reportable for DoctorOutcomes {
-    fn level(&self) -> tracing::Level {
-        match self {
-            Self::NoProjectDetected
-            | Self::NotInitialized
-            | Self::NoDatabaseFound(_, _)
-            | Self::NoEventLog(_)
-            | Self::NoConfigFound(_) => tracing::Level::WARN,
-            Self::ProjectDetected(_, _)
-            | Self::Initialized
-            | Self::DatabaseOk(_)
-            | Self::EventLogReady(_)
-            | Self::ConfigOk(_) => tracing::Level::INFO,
-        }
-    }
-
-    fn message(&self) -> String {
-        match self {
-            Self::ProjectDetected(name, root) => {
-                format!("Project '{name}' detected at '{}'.", root.display())
-            }
-            Self::NoProjectDetected => "No project detected.".into(),
-            Self::Initialized => "System is initialized.".into(),
-            Self::NotInitialized => "System is not initialized.".into(),
-            Self::DatabaseOk(path) => format!("Database found at '{}'.", path.display()),
-            Self::NoDatabaseFound(path, error) => {
-                format!("Database not found at '{}': {error}", path.display())
-            }
-            Self::EventLogReady(count) => {
-                format!("Event log is ready with {count} events.")
-            }
-            Self::NoEventLog(error) => format!("Event log error: {error}"),
-            Self::ConfigOk(path) => format!("Config file found at '{}'.", path.display()),
-            Self::NoConfigFound(path) => {
-                format!("Config file not found at '{}'.", path.display())
-            }
-        }
-    }
 }

--- a/crates/oneiros/src/commands/persona/list/outcomes.rs
+++ b/crates/oneiros/src/commands/persona/list/outcomes.rs
@@ -1,26 +1,11 @@
 use oneiros_model::Persona;
+use oneiros_outcomes::Outcome;
 
-#[derive(Clone)]
+#[derive(Clone, Outcome)]
 pub enum ListPersonasOutcomes {
+    #[outcome(message("No personas configured."))]
     NoPersonas,
+
+    #[outcome(message("Personas: {0:?}"))]
     Personas(Vec<Persona>),
-}
-
-impl oneiros_outcomes::Reportable for ListPersonasOutcomes {
-    fn level(&self) -> tracing::Level {
-        match self {
-            Self::NoPersonas => tracing::Level::INFO,
-            Self::Personas(_) => tracing::Level::INFO,
-        }
-    }
-
-    fn message(&self) -> String {
-        match self {
-            Self::NoPersonas => "No personas configured.".into(),
-            Self::Personas(personas) => {
-                let names: Vec<&str> = personas.iter().map(|p| p.name.as_str()).collect();
-                format!("Personas: {}", names.join(", "))
-            }
-        }
-    }
 }

--- a/crates/oneiros/src/commands/persona/outcomes.rs
+++ b/crates/oneiros/src/commands/persona/outcomes.rs
@@ -1,33 +1,14 @@
 use crate::*;
+use oneiros_outcomes::Outcome;
 
-#[derive(Clone)]
+#[derive(Clone, Outcome)]
 pub enum PersonaOutcomes {
-    Set(SetPersonaOutcomes),
-    Remove(RemovePersonaOutcomes),
-    List(ListPersonasOutcomes),
-    Show(ShowPersonaOutcomes),
-}
-
-impl From<SetPersonaOutcomes> for PersonaOutcomes {
-    fn from(value: SetPersonaOutcomes) -> Self {
-        Self::Set(value)
-    }
-}
-
-impl From<RemovePersonaOutcomes> for PersonaOutcomes {
-    fn from(value: RemovePersonaOutcomes) -> Self {
-        Self::Remove(value)
-    }
-}
-
-impl From<ListPersonasOutcomes> for PersonaOutcomes {
-    fn from(value: ListPersonasOutcomes) -> Self {
-        Self::List(value)
-    }
-}
-
-impl From<ShowPersonaOutcomes> for PersonaOutcomes {
-    fn from(value: ShowPersonaOutcomes) -> Self {
-        Self::Show(value)
-    }
+    #[outcome(transparent)]
+    Set(#[from] SetPersonaOutcomes),
+    #[outcome(transparent)]
+    Remove(#[from] RemovePersonaOutcomes),
+    #[outcome(transparent)]
+    List(#[from] ListPersonasOutcomes),
+    #[outcome(transparent)]
+    Show(#[from] ShowPersonaOutcomes),
 }

--- a/crates/oneiros/src/commands/persona/remove/outcomes.rs
+++ b/crates/oneiros/src/commands/persona/remove/outcomes.rs
@@ -1,20 +1,8 @@
 use oneiros_model::PersonaName;
+use oneiros_outcomes::Outcome;
 
-#[derive(Clone)]
+#[derive(Clone, Outcome)]
 pub enum RemovePersonaOutcomes {
+    #[outcome(message("Persona '{0}' removed."))]
     PersonaRemoved(PersonaName),
-}
-
-impl oneiros_outcomes::Reportable for RemovePersonaOutcomes {
-    fn level(&self) -> tracing::Level {
-        match self {
-            Self::PersonaRemoved(_) => tracing::Level::INFO,
-        }
-    }
-
-    fn message(&self) -> String {
-        match self {
-            Self::PersonaRemoved(name) => format!("Persona '{name}' removed."),
-        }
-    }
 }

--- a/crates/oneiros/src/commands/persona/set/outcomes.rs
+++ b/crates/oneiros/src/commands/persona/set/outcomes.rs
@@ -1,20 +1,8 @@
 use oneiros_model::PersonaName;
+use oneiros_outcomes::Outcome;
 
-#[derive(Clone)]
+#[derive(Clone, Outcome)]
 pub enum SetPersonaOutcomes {
+    #[outcome(message("Persona '{0}' set."))]
     PersonaSet(PersonaName),
-}
-
-impl oneiros_outcomes::Reportable for SetPersonaOutcomes {
-    fn level(&self) -> tracing::Level {
-        match self {
-            Self::PersonaSet(_) => tracing::Level::INFO,
-        }
-    }
-
-    fn message(&self) -> String {
-        match self {
-            Self::PersonaSet(name) => format!("Persona '{name}' set."),
-        }
-    }
 }

--- a/crates/oneiros/src/commands/persona/show/outcomes.rs
+++ b/crates/oneiros/src/commands/persona/show/outcomes.rs
@@ -1,25 +1,8 @@
 use oneiros_model::Persona;
+use oneiros_outcomes::Outcome;
 
-#[derive(Clone)]
+#[derive(Clone, Outcome)]
 pub enum ShowPersonaOutcomes {
+    #[outcome(message("Persona '{}'\n  Description: {}\n  Prompt: {}", .0.name, .0.description, .0.prompt))]
     PersonaDetails(Persona),
-}
-
-impl oneiros_outcomes::Reportable for ShowPersonaOutcomes {
-    fn level(&self) -> tracing::Level {
-        match self {
-            Self::PersonaDetails(_) => tracing::Level::INFO,
-        }
-    }
-
-    fn message(&self) -> String {
-        match self {
-            Self::PersonaDetails(info) => {
-                format!(
-                    "Persona '{}'\n  Description: {}\n  Prompt: {}",
-                    info.name, info.description, info.prompt,
-                )
-            }
-        }
-    }
 }

--- a/crates/oneiros/src/commands/project/init/outcomes.rs
+++ b/crates/oneiros/src/commands/project/init/outcomes.rs
@@ -1,29 +1,11 @@
+use oneiros_model::BrainName;
+use oneiros_outcomes::Outcome;
 use std::path::PathBuf;
 
-use oneiros_model::BrainName;
-
-#[derive(Clone)]
+#[derive(Clone, Outcome)]
 pub enum InitProjectOutcomes {
+    #[outcome(message("Brain '{0}' created at {}.", .1.display()))]
     BrainCreated(BrainName, PathBuf),
+    #[outcome(message("Brain '{0}' already exists."))]
     BrainAlreadyExists(BrainName),
-}
-
-impl oneiros_outcomes::Reportable for InitProjectOutcomes {
-    fn level(&self) -> tracing::Level {
-        match self {
-            Self::BrainCreated(_, _) => tracing::Level::INFO,
-            Self::BrainAlreadyExists(_) => tracing::Level::INFO,
-        }
-    }
-
-    fn message(&self) -> String {
-        match self {
-            Self::BrainCreated(name, path) => {
-                format!("Brain '{name}' created at {}.", path.display())
-            }
-            Self::BrainAlreadyExists(name) => {
-                format!("Brain '{name}' already exists.")
-            }
-        }
-    }
 }

--- a/crates/oneiros/src/commands/project/outcomes.rs
+++ b/crates/oneiros/src/commands/project/outcomes.rs
@@ -1,12 +1,8 @@
 use crate::*;
+use oneiros_outcomes::Outcome;
 
-#[derive(Clone)]
+#[derive(Clone, Outcome)]
 pub enum ProjectOutcomes {
-    Init(InitProjectOutcomes),
-}
-
-impl From<InitProjectOutcomes> for ProjectOutcomes {
-    fn from(value: InitProjectOutcomes) -> Self {
-        Self::Init(value)
-    }
+    #[outcome(transparent)]
+    Init(#[from] InitProjectOutcomes),
 }

--- a/crates/oneiros/src/commands/service/outcomes.rs
+++ b/crates/oneiros/src/commands/service/outcomes.rs
@@ -1,19 +1,10 @@
 use crate::*;
+use oneiros_outcomes::Outcome;
 
-#[derive(Clone)]
+#[derive(Clone, Outcome)]
 pub enum ServiceOutcomes {
-    Run(RunServiceOutcomes),
-    Status(ServiceStatusOutcomes),
-}
-
-impl From<RunServiceOutcomes> for ServiceOutcomes {
-    fn from(value: RunServiceOutcomes) -> Self {
-        Self::Run(value)
-    }
-}
-
-impl From<ServiceStatusOutcomes> for ServiceOutcomes {
-    fn from(value: ServiceStatusOutcomes) -> Self {
-        Self::Status(value)
-    }
+    #[outcome(transparent)]
+    Run(#[from] RunServiceOutcomes),
+    #[outcome(transparent)]
+    Status(#[from] ServiceStatusOutcomes),
 }

--- a/crates/oneiros/src/commands/service/run/outcomes.rs
+++ b/crates/oneiros/src/commands/service/run/outcomes.rs
@@ -1,25 +1,10 @@
+use oneiros_outcomes::Outcome;
 use std::path::PathBuf;
 
-#[derive(Clone)]
+#[derive(Clone, Outcome)]
 pub enum RunServiceOutcomes {
+    #[outcome(message("Service starting on {}.", .0.display()))]
     ServiceStarting(PathBuf),
+    #[outcome(message("Service stopped."))]
     ServiceStopped,
-}
-
-impl oneiros_outcomes::Reportable for RunServiceOutcomes {
-    fn level(&self) -> tracing::Level {
-        match self {
-            Self::ServiceStarting(_) => tracing::Level::INFO,
-            Self::ServiceStopped => tracing::Level::INFO,
-        }
-    }
-
-    fn message(&self) -> String {
-        match self {
-            Self::ServiceStarting(path) => {
-                format!("Service starting on {}.", path.display())
-            }
-            Self::ServiceStopped => "Service stopped.".into(),
-        }
-    }
 }

--- a/crates/oneiros/src/commands/service/status/outcomes.rs
+++ b/crates/oneiros/src/commands/service/status/outcomes.rs
@@ -1,23 +1,9 @@
-#[derive(Clone)]
+use oneiros_outcomes::Outcome;
+
+#[derive(Clone, Outcome)]
 pub enum ServiceStatusOutcomes {
+    #[outcome(message("Service is running."))]
     ServiceRunning,
+    #[outcome(message("Service is not running: {0}"), level = "warn")]
     ServiceNotRunning(String),
-}
-
-impl oneiros_outcomes::Reportable for ServiceStatusOutcomes {
-    fn level(&self) -> tracing::Level {
-        match self {
-            Self::ServiceRunning => tracing::Level::INFO,
-            Self::ServiceNotRunning(_) => tracing::Level::WARN,
-        }
-    }
-
-    fn message(&self) -> String {
-        match self {
-            Self::ServiceRunning => "Service is running.".into(),
-            Self::ServiceNotRunning(reason) => {
-                format!("Service is not running: {reason}")
-            }
-        }
-    }
 }

--- a/crates/oneiros/src/commands/system/init/outcomes.rs
+++ b/crates/oneiros/src/commands/system/init/outcomes.rs
@@ -1,45 +1,27 @@
 use crate::*;
+use oneiros_outcomes::Outcome;
 
-#[derive(Clone)]
+#[derive(Clone, Outcome)]
 pub enum InitSystemOutcomes {
+    #[outcome(message("Ensured directories exist."), level = "debug")]
     EnsuredDirectories,
+    #[outcome(message("Database ready at {0:?}."), level = "debug")]
     DatabaseReady(std::path::PathBuf),
+    #[outcome(message("System already initialized."))]
     HostAlreadyInitialized,
+    #[outcome(message("Resolved tenant name: {0}"), level = "debug")]
     ResolvedTenant(TenantName),
+    #[outcome(message("Logged tenant_created event."), level = "debug")]
     TenantCreated,
+    #[outcome(message("Logged actor_created event."), level = "debug")]
     ActorCreated,
+    #[outcome(message("Created config file at {0:?}."), level = "debug")]
     ConfigurationEnsured(std::path::PathBuf),
+    #[outcome(message("System initialized for '{0}'."))]
     SystemInitialized(TenantName),
+    #[outcome(
+        message("Could not resolve tenant name, using default."),
+        level = "warn"
+    )]
     UnresolvedTenant,
-}
-
-impl oneiros_outcomes::Reportable for InitSystemOutcomes {
-    fn level(&self) -> tracing::Level {
-        match self {
-            Self::UnresolvedTenant => tracing::Level::WARN,
-            Self::HostAlreadyInitialized | Self::SystemInitialized(_) => tracing::Level::INFO,
-            Self::EnsuredDirectories
-            | Self::DatabaseReady(_)
-            | Self::ResolvedTenant(_)
-            | Self::TenantCreated
-            | Self::ActorCreated
-            | Self::ConfigurationEnsured(_) => tracing::Level::DEBUG,
-        }
-    }
-
-    fn message(&self) -> String {
-        match self {
-            Self::UnresolvedTenant => "Could not resolve tenant name, using default.".into(),
-            Self::EnsuredDirectories => "Ensured directories exist.".into(),
-            Self::DatabaseReady(db_path) => format!("Database ready at {db_path:?}."),
-            Self::HostAlreadyInitialized => "System already initialized.".into(),
-            Self::ResolvedTenant(name) => format!("Resolved tenant name: {name}"),
-            Self::TenantCreated => "Logged tenant_created event.".into(),
-            Self::ActorCreated => "Logged actor_created event.".into(),
-            Self::ConfigurationEnsured(config_path) => {
-                format!("Created config file at {config_path:?}.")
-            }
-            Self::SystemInitialized(name) => format!("System initialized for '{name}'."),
-        }
-    }
 }

--- a/crates/oneiros/src/commands/system/outcomes.rs
+++ b/crates/oneiros/src/commands/system/outcomes.rs
@@ -1,12 +1,8 @@
 use crate::*;
+use oneiros_outcomes::Outcome;
 
-#[derive(Clone)]
+#[derive(Clone, Outcome)]
 pub enum SystemOutcomes {
-    InitOutcome(InitSystemOutcomes),
-}
-
-impl From<InitSystemOutcomes> for SystemOutcomes {
-    fn from(value: InitSystemOutcomes) -> Self {
-        Self::InitOutcome(value)
-    }
+    #[outcome(transparent)]
+    InitOutcome(#[from] InitSystemOutcomes),
 }


### PR DESCRIPTION
This adds a macro wrapper for our Outcomes concept, which functions a lot like `thiserror` does. That lets us aggregate a bunch of these things without quite as much ceremony, hopefully, and in a way that will be intuitive to anyone who already manages their error stack with the thiserror crate.