### PR TITLE
Service manager.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +296,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +392,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deranged"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,7 +422,27 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -420,6 +464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +480,26 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87b881ab2524b96a5ce932056c7482ba6152e2226fed3936b3e592adeb95ca6d"
+dependencies = [
+ "codepage",
+ "encoding_rs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -665,6 +735,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +935,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -954,6 +1039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1084,7 @@ dependencies = [
  "oneiros-terminal",
  "serde",
  "serde_json",
+ "service-manager",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1166,6 +1258,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1282,12 @@ dependencies = [
  "heapless",
  "serde",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pretty_assertions"
@@ -1205,6 +1316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1295,6 +1415,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -1302,7 +1435,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1412,6 +1545,22 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "service-manager"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73b205a13c82cdd9fd05e22d5f4ff0269f656adf68732c4d4e4f11360975ebb"
+dependencies = [
+ "cfg-if",
+ "dirs",
+ "encoding-utils",
+ "encoding_rs",
+ "log",
+ "plist",
+ "which",
+ "xml-rs",
 ]
 
 [[package]]
@@ -1552,7 +1701,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1612,6 +1761,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1992,6 +2172,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,6 +2295,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -2136,6 +2346,22 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
@@ -2144,7 +2370,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.53.1",
  "windows_i686_msvc 0.53.1",
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
@@ -2156,6 +2382,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2171,6 +2403,12 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
@@ -2183,9 +2421,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -2201,6 +2451,12 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
@@ -2210,6 +2466,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2225,6 +2487,12 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
@@ -2234,6 +2502,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2255,6 +2529,12 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ rusqlite = { version = "0.31", features = [
 ] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
+service-manager = "0.10"
 sha2 = "0.10"
 syn = { version = "2", features = ["extra-traits", "full", "parsing"] }
 tempfile = "3"

--- a/crates/oneiros-fs/src/lib.rs
+++ b/crates/oneiros-fs/src/lib.rs
@@ -5,6 +5,17 @@ impl FileOps {
         std::fs::create_dir_all(path)
     }
 
+    pub fn read(&self, path: impl AsRef<std::path::Path>) -> Result<Vec<u8>, std::io::Error> {
+        std::fs::read(path)
+    }
+
+    pub fn read_to_string(
+        &self,
+        path: impl AsRef<std::path::Path>,
+    ) -> Result<String, std::io::Error> {
+        std::fs::read_to_string(path)
+    }
+
     pub fn write(
         &self,
         path: impl AsRef<std::path::Path>,

--- a/crates/oneiros/Cargo.toml
+++ b/crates/oneiros/Cargo.toml
@@ -29,6 +29,7 @@ oneiros-service.workspace = true
 oneiros-terminal.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+service-manager.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/oneiros/src/commands/doctor/mod.rs
+++ b/crates/oneiros/src/commands/doctor/mod.rs
@@ -2,6 +2,7 @@ mod error;
 mod outcomes;
 
 use clap::Args;
+use oneiros_client::Client;
 use oneiros_db::Database;
 use oneiros_outcomes::Outcomes;
 use std::path::PathBuf;
@@ -58,6 +59,13 @@ impl Doctor {
             checks.emit(DoctorOutcomes::ConfigOk(context.config_path()));
         } else {
             checks.emit(DoctorOutcomes::NoConfigFound(context.config_path()));
+        }
+
+        let client = Client::new(context.socket_path());
+
+        match client.health().await {
+            Ok(()) => checks.emit(DoctorOutcomes::ServiceRunning),
+            Err(error) => checks.emit(DoctorOutcomes::ServiceNotRunning(error.to_string())),
         }
 
         Ok(checks)

--- a/crates/oneiros/src/commands/doctor/outcomes.rs
+++ b/crates/oneiros/src/commands/doctor/outcomes.rs
@@ -23,4 +23,8 @@ pub enum DoctorOutcomes {
     ConfigOk(PathBuf),
     #[outcome(message("Config file not found at '{}'.", .0.display()), level = "warn")]
     NoConfigFound(PathBuf),
+    #[outcome(message("Service is running."))]
+    ServiceRunning,
+    #[outcome(message("Service is not running: {0}"), level = "warn")]
+    ServiceNotRunning(String),
 }

--- a/crates/oneiros/src/commands/service/install/mod.rs
+++ b/crates/oneiros/src/commands/service/install/mod.rs
@@ -1,0 +1,48 @@
+mod outcomes;
+
+use std::ffi::OsString;
+
+use clap::Args;
+use oneiros_outcomes::Outcomes;
+use service_manager::*;
+
+pub(crate) use outcomes::InstallServiceOutcomes;
+
+use crate::*;
+
+#[derive(Clone, Args)]
+pub(crate) struct InstallService;
+
+impl InstallService {
+    pub(crate) async fn run(
+        &self,
+        context: Context,
+    ) -> Result<Outcomes<InstallServiceOutcomes>, ServiceCommandError> {
+        let mut outcomes = Outcomes::new();
+
+        let label = context.service_label();
+
+        let mut manager = <dyn ServiceManager>::native()?;
+        manager.set_level(ServiceLevel::User)?;
+
+        context.files().ensure_dir(context.log_dir())?;
+
+        manager.install(ServiceInstallCtx {
+            label: label.parse()?,
+            program: context.current_exe()?,
+            args: vec![OsString::from("service"), OsString::from("run")],
+            contents: None,
+            username: None,
+            working_directory: Some(context.data_dir.clone()),
+            environment: None,
+            autostart: true,
+            restart_policy: RestartPolicy::OnFailure {
+                delay_secs: Some(5),
+            },
+        })?;
+
+        outcomes.emit(InstallServiceOutcomes::ServiceInstalled(label));
+
+        Ok(outcomes)
+    }
+}

--- a/crates/oneiros/src/commands/service/install/outcomes.rs
+++ b/crates/oneiros/src/commands/service/install/outcomes.rs
@@ -1,0 +1,7 @@
+use oneiros_outcomes::Outcome;
+
+#[derive(Clone, Outcome)]
+pub enum InstallServiceOutcomes {
+    #[outcome(message("Service installed as '{0}'."))]
+    ServiceInstalled(String),
+}

--- a/crates/oneiros/src/commands/service/mod.rs
+++ b/crates/oneiros/src/commands/service/mod.rs
@@ -1,12 +1,20 @@
 mod error;
+mod install;
 mod outcomes;
 mod run;
+mod start;
 mod status;
+mod stop;
+mod uninstall;
 
 pub(crate) use error::ServiceCommandError;
+pub(crate) use install::{InstallService, InstallServiceOutcomes};
 pub(crate) use outcomes::ServiceOutcomes;
 pub(crate) use run::{RunService, RunServiceOutcomes};
+pub(crate) use start::{StartService, StartServiceOutcomes};
 pub(crate) use status::{ServiceStatusOutcomes, Status};
+pub(crate) use stop::{StopService, StopServiceOutcomes};
+pub(crate) use uninstall::{UninstallService, UninstallServiceOutcomes};
 
 use clap::{Args, Subcommand};
 use oneiros_outcomes::Outcomes;
@@ -23,6 +31,10 @@ impl ServiceOps {
         context: crate::Context,
     ) -> Result<Outcomes<ServiceOutcomes>, ServiceCommandError> {
         Ok(match &self.command {
+            ServiceCommands::Install(install) => install.run(context).await?.map_into(),
+            ServiceCommands::Uninstall(uninstall) => uninstall.run(context).await?.map_into(),
+            ServiceCommands::Start(start) => start.run(context).await?.map_into(),
+            ServiceCommands::Stop(stop) => stop.run(context).await?.map_into(),
             ServiceCommands::Run(run) => run.run(context).await?.map_into(),
             ServiceCommands::Status(status) => status.run(context).await?.map_into(),
         })
@@ -31,6 +43,14 @@ impl ServiceOps {
 
 #[derive(Clone, Subcommand)]
 pub(crate) enum ServiceCommands {
+    /// Install oneiros as a managed user service.
+    Install(InstallService),
+    /// Remove the managed oneiros service.
+    Uninstall(UninstallService),
+    /// Start the managed oneiros service.
+    Start(StartService),
+    /// Stop the managed oneiros service.
+    Stop(StopService),
     /// Start oneiros in the foreground.
     Run(RunService),
     /// Check if oneiros is running.

--- a/crates/oneiros/src/commands/service/outcomes.rs
+++ b/crates/oneiros/src/commands/service/outcomes.rs
@@ -4,6 +4,14 @@ use oneiros_outcomes::Outcome;
 #[derive(Clone, Outcome)]
 pub enum ServiceOutcomes {
     #[outcome(transparent)]
+    Install(#[from] InstallServiceOutcomes),
+    #[outcome(transparent)]
+    Uninstall(#[from] UninstallServiceOutcomes),
+    #[outcome(transparent)]
+    Start(#[from] StartServiceOutcomes),
+    #[outcome(transparent)]
+    Stop(#[from] StopServiceOutcomes),
+    #[outcome(transparent)]
     Run(#[from] RunServiceOutcomes),
     #[outcome(transparent)]
     Status(#[from] ServiceStatusOutcomes),

--- a/crates/oneiros/src/commands/service/start/mod.rs
+++ b/crates/oneiros/src/commands/service/start/mod.rs
@@ -1,0 +1,51 @@
+mod outcomes;
+
+use clap::Args;
+use oneiros_client::Client;
+use oneiros_outcomes::Outcomes;
+use service_manager::*;
+
+pub(crate) use outcomes::StartServiceOutcomes;
+
+use crate::*;
+
+#[derive(Clone, Args)]
+pub(crate) struct StartService;
+
+impl StartService {
+    pub(crate) async fn run(
+        &self,
+        context: Context,
+    ) -> Result<Outcomes<StartServiceOutcomes>, ServiceCommandError> {
+        let mut outcomes = Outcomes::new();
+
+        let label: ServiceLabel = context.service_label().parse()?;
+
+        let mut manager = <dyn ServiceManager>::native()?;
+        manager.set_level(ServiceLevel::User)?;
+
+        manager.start(ServiceStartCtx { label })?;
+
+        outcomes.emit(StartServiceOutcomes::Started);
+
+        // Brief health check with backoff to confirm the service came up.
+        let client = Client::new(context.socket_path());
+        let delays = context.health_check_delays();
+
+        for delay in delays {
+            tokio::time::sleep(*delay).await;
+
+            if client.health().await.is_ok() {
+                outcomes.emit(StartServiceOutcomes::Healthy);
+                return Ok(outcomes);
+            }
+        }
+
+        let total: std::time::Duration = delays.iter().sum();
+        outcomes.emit(StartServiceOutcomes::StartedButUnhealthy(format!(
+            "health check did not succeed within {total:.0?}"
+        )));
+
+        Ok(outcomes)
+    }
+}

--- a/crates/oneiros/src/commands/service/start/outcomes.rs
+++ b/crates/oneiros/src/commands/service/start/outcomes.rs
@@ -1,0 +1,14 @@
+use oneiros_outcomes::Outcome;
+
+#[derive(Clone, Outcome)]
+pub enum StartServiceOutcomes {
+    #[outcome(message("Service started."))]
+    Started,
+    #[outcome(message("Service is running."))]
+    Healthy,
+    #[outcome(
+        message("Service started but health check failed: {0}"),
+        level = "warn"
+    )]
+    StartedButUnhealthy(String),
+}

--- a/crates/oneiros/src/commands/service/status/mod.rs
+++ b/crates/oneiros/src/commands/service/status/mod.rs
@@ -18,7 +18,16 @@ impl Status {
     ) -> Result<Outcomes<ServiceStatusOutcomes>, ServiceCommandError> {
         let mut outcomes = Outcomes::new();
 
-        let client = Client::new(context.socket_path());
+        let socket_path = context.socket_path();
+
+        outcomes.emit(ServiceStatusOutcomes::SocketPath(socket_path.clone()));
+
+        if !socket_path.exists() {
+            outcomes.emit(ServiceStatusOutcomes::NoSocket);
+            return Ok(outcomes);
+        }
+
+        let client = Client::new(&socket_path);
 
         match client.health().await {
             Ok(()) => outcomes.emit(ServiceStatusOutcomes::ServiceRunning),

--- a/crates/oneiros/src/commands/service/status/outcomes.rs
+++ b/crates/oneiros/src/commands/service/status/outcomes.rs
@@ -1,7 +1,15 @@
 use oneiros_outcomes::Outcome;
+use std::path::PathBuf;
 
 #[derive(Clone, Outcome)]
 pub enum ServiceStatusOutcomes {
+    #[outcome(message("Socket: {}", .0.display()))]
+    SocketPath(PathBuf),
+    #[outcome(
+        message("No socket file found. Service has not been started."),
+        level = "warn"
+    )]
+    NoSocket,
     #[outcome(message("Service is running."))]
     ServiceRunning,
     #[outcome(message("Service is not running: {0}"), level = "warn")]

--- a/crates/oneiros/src/commands/service/stop/mod.rs
+++ b/crates/oneiros/src/commands/service/stop/mod.rs
@@ -1,0 +1,32 @@
+mod outcomes;
+
+use clap::Args;
+use oneiros_outcomes::Outcomes;
+use service_manager::*;
+
+pub(crate) use outcomes::StopServiceOutcomes;
+
+use crate::*;
+
+#[derive(Clone, Args)]
+pub(crate) struct StopService;
+
+impl StopService {
+    pub(crate) async fn run(
+        &self,
+        context: Context,
+    ) -> Result<Outcomes<StopServiceOutcomes>, ServiceCommandError> {
+        let mut outcomes = Outcomes::new();
+
+        let label: ServiceLabel = context.service_label().parse()?;
+
+        let mut manager = <dyn ServiceManager>::native()?;
+        manager.set_level(ServiceLevel::User)?;
+
+        manager.stop(ServiceStopCtx { label })?;
+
+        outcomes.emit(StopServiceOutcomes::ServiceStopped);
+
+        Ok(outcomes)
+    }
+}

--- a/crates/oneiros/src/commands/service/stop/outcomes.rs
+++ b/crates/oneiros/src/commands/service/stop/outcomes.rs
@@ -1,0 +1,7 @@
+use oneiros_outcomes::Outcome;
+
+#[derive(Clone, Outcome)]
+pub enum StopServiceOutcomes {
+    #[outcome(message("Service stopped."))]
+    ServiceStopped,
+}

--- a/crates/oneiros/src/commands/service/uninstall/mod.rs
+++ b/crates/oneiros/src/commands/service/uninstall/mod.rs
@@ -1,0 +1,37 @@
+mod outcomes;
+
+use clap::Args;
+use oneiros_outcomes::Outcomes;
+use service_manager::*;
+
+pub(crate) use outcomes::UninstallServiceOutcomes;
+
+use crate::*;
+
+#[derive(Clone, Args)]
+pub(crate) struct UninstallService;
+
+impl UninstallService {
+    pub(crate) async fn run(
+        &self,
+        context: Context,
+    ) -> Result<Outcomes<UninstallServiceOutcomes>, ServiceCommandError> {
+        let mut outcomes = Outcomes::new();
+
+        let label: ServiceLabel = context.service_label().parse()?;
+
+        let mut manager = <dyn ServiceManager>::native()?;
+        manager.set_level(ServiceLevel::User)?;
+
+        // Best-effort stop before uninstall.
+        let _ = manager.stop(ServiceStopCtx {
+            label: label.clone(),
+        });
+
+        manager.uninstall(ServiceUninstallCtx { label })?;
+
+        outcomes.emit(UninstallServiceOutcomes::ServiceUninstalled);
+
+        Ok(outcomes)
+    }
+}

--- a/crates/oneiros/src/commands/service/uninstall/outcomes.rs
+++ b/crates/oneiros/src/commands/service/uninstall/outcomes.rs
@@ -1,0 +1,7 @@
+use oneiros_outcomes::Outcome;
+
+#[derive(Clone, Outcome)]
+pub enum UninstallServiceOutcomes {
+    #[outcome(message("Service uninstalled."))]
+    ServiceUninstalled,
+}

--- a/crates/oneiros/src/commands/storage/get/mod.rs
+++ b/crates/oneiros/src/commands/storage/get/mod.rs
@@ -31,7 +31,7 @@ impl GetStorage {
             .get_storage_content(&context.ticket_token()?, &self.key)
             .await?;
 
-        std::fs::write(&self.output, &content)?;
+        context.files().write(&self.output, &content)?;
 
         outcomes.emit(GetStorageOutcomes::ContentWritten(
             self.key.clone(),

--- a/crates/oneiros/src/commands/storage/set/mod.rs
+++ b/crates/oneiros/src/commands/storage/set/mod.rs
@@ -30,7 +30,7 @@ impl SetStorage {
         let mut outcomes = Outcomes::new();
 
         let client = Client::new(context.socket_path());
-        let data = std::fs::read(&self.file)?;
+        let data = context.files().read(&self.file)?;
 
         let entry = client
             .set_storage(&context.ticket_token()?, &self.key, data, &self.description)

--- a/crates/oneiros/src/context/mod.rs
+++ b/crates/oneiros/src/context/mod.rs
@@ -7,12 +7,20 @@ use oneiros_fs::FileOps;
 use oneiros_model::Token;
 use oneiros_terminal::TerminalOps;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 pub(crate) use error::ContextError;
 
 const QUALIFIER: &str = "com";
 const ORGANIZATION: &str = "esmevane";
 const APPLICATION: &str = "oneiros";
+
+const HEALTH_CHECK_DELAYS: &[Duration] = &[
+    Duration::from_millis(200),
+    Duration::from_millis(400),
+    Duration::from_millis(800),
+    Duration::from_millis(1600),
+];
 
 pub(crate) struct Context {
     /// The detected project (name and root path), if any.
@@ -71,17 +79,42 @@ impl Context {
 
     /// Store a ticket token for a brain.
     pub(crate) fn store_ticket(&self, brain_name: &str, token: &str) -> Result<(), std::io::Error> {
+        let files = self.files();
         let path = self.ticket_path(brain_name);
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
+            files.ensure_dir(parent)?;
         }
-        std::fs::write(path, token)
+        files.write(path, token)
     }
 
     /// Retrieve the ticket token for the current project's brain.
     pub(crate) fn ticket_token(&self) -> Result<Token, error::ContextError> {
         let name = self.project_name().ok_or(error::ContextError::NoProject)?;
-        Ok(std::fs::read_to_string(self.ticket_path(name)).map(Token)?)
+        Ok(self
+            .files()
+            .read_to_string(self.ticket_path(name))
+            .map(Token)?)
+    }
+
+    /// The service manager label, derived from the same qualifier/org/app
+    /// constants used for platform directory resolution.
+    pub(crate) fn service_label(&self) -> String {
+        format!("{QUALIFIER}.{ORGANIZATION}.{APPLICATION}")
+    }
+
+    /// Path to the log directory for service stdout/stderr.
+    pub(crate) fn log_dir(&self) -> PathBuf {
+        self.data_dir.join("logs")
+    }
+
+    /// Path to the current executable.
+    pub(crate) fn current_exe(&self) -> Result<PathBuf, std::io::Error> {
+        std::env::current_exe()
+    }
+
+    /// Retry delays for health check polling after service start.
+    pub(crate) fn health_check_delays(&self) -> &[Duration] {
+        HEALTH_CHECK_DELAYS
     }
 
     /// Check if initialized.


### PR DESCRIPTION
The oneiros service currently only operates directly from a given terminal, using the `run` command. This commit does the work to set up the background mode via the service-manager-rs crate, giving us the following extra commands: start | stop | status | install | uninstall.

Closes #11 