### PR TITLE
Rename {report_outcome,structured_output}

### DIFF
--- a/crates/oneiros/src/cli/mod.rs
+++ b/crates/oneiros/src/cli/mod.rs
@@ -29,7 +29,7 @@ pub(crate) struct Cli {
 impl Cli {
     pub(crate) fn report(&self, outcomes: &Outcomes<CliOutcomes>) {
         for outcome in outcomes {
-            self.output.report_outcome(outcome);
+            self.output.structured_output(outcome);
         }
     }
 

--- a/crates/oneiros/src/cli/output_format.rs
+++ b/crates/oneiros/src/cli/output_format.rs
@@ -13,7 +13,7 @@ pub(crate) enum OutputFormat {
 }
 
 impl OutputFormat {
-    pub(crate) fn report_outcome<T: Reportable + Serialize>(&self, outcome: &T) {
+    pub(crate) fn structured_output<T: Reportable + Serialize>(&self, outcome: &T) {
         match self {
             Self::Prompt => PromptReporter.report(outcome),
             Self::Quiet => QuietReporter.report(outcome),


### PR DESCRIPTION
I think this is a better name given the #30 goals.