### PR TITLE
chore: release v0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiros"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-client"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-db"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "rusqlite",
  "serde",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-detect-project-name"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "tempfile",
  "toml 0.8.23",
@@ -1191,11 +1191,11 @@ dependencies = [
 
 [[package]]
 name = "oneiros-fs"
-version = "0.0.3"
+version = "0.0.4"
 
 [[package]]
 name = "oneiros-model"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "chrono",
  "data-encoding",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-outcomes"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "oneiros-outcomes-derive",
  "serde",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-outcomes-derive"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "oneiros-outcomes",
  "pretty_assertions",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-service"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "axum",
  "chrono",
@@ -1256,14 +1256,14 @@ dependencies = [
 
 [[package]]
 name = "oneiros-skill"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "oneiros-templates"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "askama",
  "chrono",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-terminal"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "inquire",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 repository = "https://github.com/esmevane/oneiros"
 license = "MIT"
@@ -25,17 +25,17 @@ http-body-util = "0.1.3"
 hyper = { version = "1.8", features = ["full"] }
 hyper-util = { version = "0.1.20", features = ["tokio"] }
 inquire = "0.7"
-oneiros-client = { path = "crates/oneiros-client", version = "0.0.3" }
-oneiros-db = { path = "crates/oneiros-db", version = "0.0.3" }
-oneiros-detect-project-name = { path = "crates/oneiros-detect-project-name", version = "0.0.3" }
-oneiros-fs = { path = "crates/oneiros-fs", version = "0.0.3" }
-oneiros-model = { path = "crates/oneiros-model", version = "0.0.3" }
-oneiros-outcomes = { path = "crates/oneiros-outcomes", version = "0.0.3" }
-oneiros-outcomes-derive = { path = "crates/oneiros-outcomes-derive", version = "0.0.3" }
-oneiros-service = { path = "crates/oneiros-service", version = "0.0.3" }
-oneiros-skill = { path = "crates/oneiros-skill", version = "0.0.3" }
-oneiros-templates = { path = "crates/oneiros-templates", version = "0.0.3" }
-oneiros-terminal = { path = "crates/oneiros-terminal", version = "0.0.3" }
+oneiros-client = { path = "crates/oneiros-client", version = "0.0.4" }
+oneiros-db = { path = "crates/oneiros-db", version = "0.0.4" }
+oneiros-detect-project-name = { path = "crates/oneiros-detect-project-name", version = "0.0.4" }
+oneiros-fs = { path = "crates/oneiros-fs", version = "0.0.4" }
+oneiros-model = { path = "crates/oneiros-model", version = "0.0.4" }
+oneiros-outcomes = { path = "crates/oneiros-outcomes", version = "0.0.4" }
+oneiros-outcomes-derive = { path = "crates/oneiros-outcomes-derive", version = "0.0.4" }
+oneiros-service = { path = "crates/oneiros-service", version = "0.0.4" }
+oneiros-skill = { path = "crates/oneiros-skill", version = "0.0.4" }
+oneiros-templates = { path = "crates/oneiros-templates", version = "0.0.4" }
+oneiros-terminal = { path = "crates/oneiros-terminal", version = "0.0.4" }
 postcard = { version = "1", features = ["alloc"] }
 pretty_assertions = "1"
 prettyplease = "0.2"

--- a/crates/oneiros/CHANGELOG.md
+++ b/crates/oneiros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/esmevane/oneiros/compare/oneiros-v0.0.3...oneiros-v0.0.4) - 2026-02-14
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.0.2](https://github.com/esmevane/oneiros/compare/oneiros-v0.0.1...oneiros-v0.0.2) - 2026-02-14
 
 ### Added

--- a/dist/.claude-plugin/plugin.json
+++ b/dist/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oneiros",
   "description": "Keep your agent continuity separate from your model session",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": {
     "name": "JC McCormick",
     "url": "https://github.com/esmevane"

--- a/dist/skills/oneiros/SKILL.md
+++ b/dist/skills/oneiros/SKILL.md
@@ -6,7 +6,7 @@ description: >
   mentions of dreaming, introspection, reflection, memory, cognition, personas,
   textures, levels, or brain management.
 allowed-tools: "Read,Bash(oneiros:*)"
-version: "0.0.3"
+version: "0.0.4"
 author: "JC McCormick <https://github.com/esmevane>"
 license: "MIT"
 ---


### PR DESCRIPTION



## 🤖 New release

* `oneiros-db`: 0.0.3 -> 0.0.4
* `oneiros-model`: 0.0.3 -> 0.0.4
* `oneiros-client`: 0.0.3 -> 0.0.4
* `oneiros-detect-project-name`: 0.0.3 -> 0.0.4
* `oneiros-fs`: 0.0.3 -> 0.0.4
* `oneiros-outcomes-derive`: 0.0.3 -> 0.0.4
* `oneiros-outcomes`: 0.0.3 -> 0.0.4
* `oneiros-service`: 0.0.3 -> 0.0.4
* `oneiros-skill`: 0.0.3 -> 0.0.4
* `oneiros-templates`: 0.0.3 -> 0.0.4
* `oneiros-terminal`: 0.0.3 -> 0.0.4
* `oneiros`: 0.0.3 -> 0.0.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `oneiros-db`

<blockquote>

## [0.0.3](https://github.com/esmevane/oneiros/compare/oneiros-db-v0.0.2...oneiros-db-v0.0.3) - 2026-02-14

### Other

- Crate fixes
</blockquote>




## `oneiros-fs`

<blockquote>

## [0.0.3](https://github.com/esmevane/oneiros/compare/oneiros-fs-v0.0.2...oneiros-fs-v0.0.3) - 2026-02-14

### Other

- Crate fixes
</blockquote>




## `oneiros-skill`

<blockquote>

## [0.0.3](https://github.com/esmevane/oneiros/compare/oneiros-skill-v0.0.2...oneiros-skill-v0.0.3) - 2026-02-14

### Other

- Crate fixes
</blockquote>


## `oneiros-terminal`

<blockquote>

## [0.0.3](https://github.com/esmevane/oneiros/compare/oneiros-terminal-v0.0.2...oneiros-terminal-v0.0.3) - 2026-02-14

### Other

- Crate fixes
</blockquote>

## `oneiros`

<blockquote>

## [0.0.4](https://github.com/esmevane/oneiros/compare/oneiros-v0.0.3...oneiros-v0.0.4) - 2026-02-14

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).