### PR TITLE
Add release-plz token to workflow.

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,6 +30,7 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-pr:
     name: Release-plz PR
@@ -51,6 +52,7 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Rebuild generated files
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}


### PR DESCRIPTION
Everything seems to be close to functional with the release plz process except it keeps getting a 403. Turns out we're not setting the env var for the Cargo token? I must have picked the wrong options during init.

This commit adds the release-plz token to our workflow env, which will hopefully get the process unblocked.