### PR TITLE
Only tag the main binary during release.

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,6 @@
+[workspace]
+git_tag_enable = false
+
+[[package]]
+name = "oneiros"
+git_tag_enable = true


### PR DESCRIPTION
We had a ton of noise for the last round of debugging. Turns out, release plz creates a tag for every crate. That's awesome! But not what we want - because each of those trigger an attempt to build in dist. We only want the main crate to show up in our releases page / binaries.