### PR TITLE
Improve ergonomics for common operations.

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "oneiros",
       "source": "./dist",
       "description": "Local-first continuity and collaboration for agents.",
-      "version": "0.0.5-rc4"
+      "version": "0.0.5"
     }
   ]
 }

--- a/crates/oneiros-model/src/entities/cognition.rs
+++ b/crates/oneiros-model/src/entities/cognition.rs
@@ -12,4 +12,26 @@ pub struct Cognition {
     pub created_at: DateTime<Utc>,
 }
 
+impl Cognition {
+    fn as_table_row(&self) -> String {
+        let short_id = &self.id.to_string()[..8];
+        let texture = format!("{}", self.texture);
+        let content = self.content.as_str();
+        let truncated = if content.len() > 80 {
+            let end = content.floor_char_boundary(80);
+            format!("{}...", &content[..end])
+        } else {
+            content.to_string()
+        };
+
+        format!("{short_id}  {texture:<12} {truncated}")
+    }
+}
+
+impl core::fmt::Display for Cognition {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.as_table_row())
+    }
+}
+
 domain_id!(CognitionId);

--- a/crates/oneiros-model/src/entities/experience.rs
+++ b/crates/oneiros-model/src/entities/experience.rs
@@ -13,4 +13,44 @@ pub struct Experience {
     pub created_at: DateTime<Utc>,
 }
 
+impl Experience {
+    fn as_table_row(&self) -> String {
+        let short_id = &self.id.to_string()[..8];
+        let sensation = format!("{}", self.sensation);
+        let description = self.description.as_str();
+        let truncated = if description.len() > 80 {
+            let end = description.floor_char_boundary(80);
+            format!("{}...", &description[..end])
+        } else {
+            description.to_string()
+        };
+        let ref_count = self.refs.len();
+
+        format!("{short_id}  {sensation:<12} {truncated} ({ref_count} refs)")
+    }
+
+    pub fn as_detail(&self) -> String {
+        let mut lines = vec![
+            format!("Experience {}", self.id),
+            format!("  Sensation: {}", self.sensation),
+            format!("  Description: {}", self.description),
+        ];
+
+        lines.push(format!("  Refs: ({})", self.refs.len()));
+        for r in &self.refs {
+            lines.push(format!("    {r}"));
+        }
+
+        lines.push(format!("  Created: {}", self.created_at));
+
+        lines.join("\n")
+    }
+}
+
+impl core::fmt::Display for Experience {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.as_table_row())
+    }
+}
+
 domain_id!(ExperienceId);

--- a/crates/oneiros-model/src/entities/memory.rs
+++ b/crates/oneiros-model/src/entities/memory.rs
@@ -12,4 +12,26 @@ pub struct Memory {
     pub created_at: DateTime<Utc>,
 }
 
+impl Memory {
+    fn as_table_row(&self) -> String {
+        let short_id = &self.id.to_string()[..8];
+        let level = format!("{}", self.level);
+        let content = self.content.as_str();
+        let truncated = if content.len() > 80 {
+            let end = content.floor_char_boundary(80);
+            format!("{}...", &content[..end])
+        } else {
+            content.to_string()
+        };
+
+        format!("{short_id}  {level:<12} {truncated}")
+    }
+}
+
+impl core::fmt::Display for Memory {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.as_table_row())
+    }
+}
+
 domain_id!(MemoryId);

--- a/crates/oneiros-model/src/values/record_ref.rs
+++ b/crates/oneiros-model/src/values/record_ref.rs
@@ -10,6 +10,18 @@ pub struct RecordRef {
     pub role: Option<Label>,
 }
 
+impl core::fmt::Display for RecordRef {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let short_id = &self.id.to_string()[..8];
+        let kind = &self.kind;
+
+        match &self.role {
+            Some(role) => write!(f, "{short_id}:{kind} [{role}]"),
+            None => write!(f, "{short_id}:{kind}"),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum RecordKind {

--- a/crates/oneiros/src/commands/cognition/error.rs
+++ b/crates/oneiros/src/commands/cognition/error.rs
@@ -1,4 +1,4 @@
-use crate::ContextError;
+use crate::{ContextError, PrefixError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum CognitionCommandError {
@@ -7,4 +7,7 @@ pub enum CognitionCommandError {
 
     #[error(transparent)]
     Context(#[from] ContextError),
+
+    #[error(transparent)]
+    PrefixResolve(#[from] PrefixError),
 }

--- a/crates/oneiros/src/commands/cognition/list/mod.rs
+++ b/crates/oneiros/src/commands/cognition/list/mod.rs
@@ -39,7 +39,9 @@ impl ListCognitions {
         if cognitions.is_empty() {
             outcomes.emit(ListCognitionsOutcomes::NoCognitions);
         } else {
-            outcomes.emit(ListCognitionsOutcomes::Cognitions(cognitions));
+            outcomes.emit(ListCognitionsOutcomes::Cognitions(outcomes::CognitionList(
+                cognitions,
+            )));
         }
 
         Ok(outcomes)

--- a/crates/oneiros/src/commands/cognition/list/outcomes.rs
+++ b/crates/oneiros/src/commands/cognition/list/outcomes.rs
@@ -1,6 +1,23 @@
 use oneiros_model::Cognition;
 use oneiros_outcomes::Outcome;
 
+#[derive(Clone, serde::Serialize)]
+#[serde(transparent)]
+pub struct CognitionList(pub Vec<Cognition>);
+
+impl core::fmt::Display for CognitionList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let display = self
+            .0
+            .iter()
+            .map(|cognition| format!("{cognition}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        write!(f, "{display}")
+    }
+}
+
 #[derive(Clone, serde::Serialize, Outcome)]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ListCognitionsOutcomes {
@@ -8,10 +25,10 @@ pub enum ListCognitionsOutcomes {
     NoCognitions,
 
     #[outcome(
-        message("Cognitions: {0:?}"),
+        message("{0}"),
         prompt(
             "Which of these are still working threads? Consolidate what's crystallized with `oneiros memory add <agent>`."
         )
     )]
-    Cognitions(Vec<Cognition>),
+    Cognitions(CognitionList),
 }

--- a/crates/oneiros/src/commands/experience/error.rs
+++ b/crates/oneiros/src/commands/experience/error.rs
@@ -1,4 +1,4 @@
-use crate::ContextError;
+use crate::{ContextError, PrefixError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum ExperienceCommandError {
@@ -7,6 +7,9 @@ pub enum ExperienceCommandError {
 
     #[error(transparent)]
     Context(#[from] ContextError),
+
+    #[error(transparent)]
+    PrefixResolve(#[from] PrefixError),
 
     #[error("Invalid ref format: {0}")]
     InvalidRefFormat(String),

--- a/crates/oneiros/src/commands/experience/list/mod.rs
+++ b/crates/oneiros/src/commands/experience/list/mod.rs
@@ -39,7 +39,9 @@ impl ListExperiences {
         if experiences.is_empty() {
             outcomes.emit(ListExperiencesOutcomes::NoExperiences);
         } else {
-            outcomes.emit(ListExperiencesOutcomes::Experiences(experiences));
+            outcomes.emit(ListExperiencesOutcomes::Experiences(
+                outcomes::ExperienceList(experiences),
+            ));
         }
 
         Ok(outcomes)

--- a/crates/oneiros/src/commands/experience/list/outcomes.rs
+++ b/crates/oneiros/src/commands/experience/list/outcomes.rs
@@ -1,6 +1,23 @@
 use oneiros_model::Experience;
 use oneiros_outcomes::Outcome;
 
+#[derive(Clone, serde::Serialize)]
+#[serde(transparent)]
+pub struct ExperienceList(pub Vec<Experience>);
+
+impl core::fmt::Display for ExperienceList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let display = self
+            .0
+            .iter()
+            .map(|experience| format!("{experience}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        write!(f, "{display}")
+    }
+}
+
 #[derive(Clone, serde::Serialize, Outcome)]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ListExperiencesOutcomes {
@@ -8,8 +25,8 @@ pub enum ListExperiencesOutcomes {
     NoExperiences,
 
     #[outcome(
-        message("Experiences: {0:?}"),
+        message("{0}"),
         prompt("Which threads are still growing? Extend with `oneiros experience ref add`.")
     )]
-    Experiences(Vec<Experience>),
+    Experiences(ExperienceList),
 }

--- a/crates/oneiros/src/commands/experience/mod.rs
+++ b/crates/oneiros/src/commands/experience/mod.rs
@@ -16,7 +16,35 @@ pub(crate) use show::{ShowExperience, ShowExperienceOutcomes};
 pub(crate) use update::{UpdateExperience, UpdateExperienceOutcomes};
 
 use clap::{Args, Subcommand};
+use oneiros_client::Client;
+use oneiros_model::{Id, RecordKind, Token};
 use oneiros_outcomes::Outcomes;
+
+pub(super) async fn list_ids_for_kind(
+    client: &Client,
+    token: &Token,
+    kind: &RecordKind,
+) -> Result<Vec<Id>, ExperienceCommandError> {
+    let ids = match kind {
+        RecordKind::Cognition => {
+            let all = client.list_cognitions(token, None, None).await?;
+            all.iter().map(|c| c.id.0).collect()
+        }
+        RecordKind::Memory => {
+            let all = client.list_memories(token, None, None).await?;
+            all.iter().map(|m| m.id.0).collect()
+        }
+        RecordKind::Experience => {
+            let all = client.list_experiences(token, None, None).await?;
+            all.iter().map(|e| e.id.0).collect()
+        }
+        RecordKind::Storage => {
+            vec![]
+        }
+    };
+
+    Ok(ids)
+}
 
 #[derive(Clone, Args)]
 pub(crate) struct ExperienceOps {

--- a/crates/oneiros/src/commands/experience/show/outcomes.rs
+++ b/crates/oneiros/src/commands/experience/show/outcomes.rs
@@ -1,14 +1,24 @@
 use oneiros_model::Experience;
 use oneiros_outcomes::Outcome;
 
+#[derive(Clone, serde::Serialize)]
+#[serde(transparent)]
+pub struct ExperienceDetail(pub Experience);
+
+impl core::fmt::Display for ExperienceDetail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.as_detail())
+    }
+}
+
 #[derive(Clone, serde::Serialize, Outcome)]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ShowExperienceOutcomes {
     #[outcome(
-        message("Experience details: {0:?}"),
+        message("{0}"),
         prompt(
             "Does this connect to anything new? Add with `oneiros experience ref add <id> <record_id> <record_kind>`."
         )
     )]
-    ExperienceDetails(Experience),
+    ExperienceDetails(ExperienceDetail),
 }

--- a/crates/oneiros/src/commands/memory/error.rs
+++ b/crates/oneiros/src/commands/memory/error.rs
@@ -1,4 +1,4 @@
-use crate::ContextError;
+use crate::{ContextError, PrefixError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum MemoryCommandError {
@@ -7,4 +7,7 @@ pub enum MemoryCommandError {
 
     #[error(transparent)]
     Context(#[from] ContextError),
+
+    #[error(transparent)]
+    PrefixResolve(#[from] PrefixError),
 }

--- a/crates/oneiros/src/commands/memory/list/mod.rs
+++ b/crates/oneiros/src/commands/memory/list/mod.rs
@@ -39,7 +39,9 @@ impl ListMemories {
         if memories.is_empty() {
             outcomes.emit(ListMemoriesOutcomes::NoMemories);
         } else {
-            outcomes.emit(ListMemoriesOutcomes::Memories(memories));
+            outcomes.emit(ListMemoriesOutcomes::Memories(outcomes::MemoryList(
+                memories,
+            )));
         }
 
         Ok(outcomes)

--- a/crates/oneiros/src/commands/memory/list/outcomes.rs
+++ b/crates/oneiros/src/commands/memory/list/outcomes.rs
@@ -1,6 +1,23 @@
 use oneiros_model::Memory;
 use oneiros_outcomes::Outcome;
 
+#[derive(Clone, serde::Serialize)]
+#[serde(transparent)]
+pub struct MemoryList(pub Vec<Memory>);
+
+impl core::fmt::Display for MemoryList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let display = self
+            .0
+            .iter()
+            .map(|memory| format!("{memory}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        write!(f, "{display}")
+    }
+}
+
 #[derive(Clone, serde::Serialize, Outcome)]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ListMemoriesOutcomes {
@@ -8,10 +25,10 @@ pub enum ListMemoriesOutcomes {
     NoMemories,
 
     #[outcome(
-        message("Memories: {0:?}"),
+        message("{0}"),
         prompt(
             "Which of these are still true? Has anything shifted since they were consolidated?"
         )
     )]
-    Memories(Vec<Memory>),
+    Memories(MemoryList),
 }

--- a/crates/oneiros/src/lib.rs
+++ b/crates/oneiros/src/lib.rs
@@ -4,6 +4,7 @@ mod context;
 mod error;
 mod gauge;
 mod logging;
+mod prefix_id;
 
 use clap::Parser;
 
@@ -13,6 +14,7 @@ pub(crate) use context::*;
 pub(crate) use logging::*;
 pub(crate) use oneiros_model::projections;
 pub(crate) use oneiros_model::*;
+pub(crate) use prefix_id::*;
 
 pub use error::*;
 

--- a/crates/oneiros/src/prefix_id.rs
+++ b/crates/oneiros/src/prefix_id.rs
@@ -1,0 +1,161 @@
+use oneiros_model::Id;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PrefixError {
+    #[error("No match found for prefix '{0}'")]
+    NotFound(String),
+
+    #[error("Ambiguous prefix '{0}' — matches {1} IDs")]
+    Ambiguous(String, usize),
+
+    #[error("Prefix must be at least 8 hex characters, got: '{0}'")]
+    TooShort(String),
+
+    #[error("Prefix contains non-hex characters: '{0}'")]
+    InvalidHex(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct PrefixId(PrefixIdInner);
+
+#[derive(Clone, Debug)]
+enum PrefixIdInner {
+    Full(Id),
+    Prefix(String),
+}
+
+impl PrefixId {
+    /// If this is a full UUID, return it directly as an `Id`.
+    pub fn as_full_id(&self) -> Option<Id> {
+        match &self.0 {
+            PrefixIdInner::Full(id) => Some(*id),
+            PrefixIdInner::Prefix(_) => None,
+        }
+    }
+
+    /// Resolve this prefix against a set of known IDs.
+    /// Full UUIDs pass through directly. Prefixes are matched
+    /// against the hex representation (no dashes) of each ID.
+    pub fn resolve(&self, known_ids: &[Id]) -> Result<Id, PrefixError> {
+        match &self.0 {
+            PrefixIdInner::Full(id) => Ok(*id),
+            PrefixIdInner::Prefix(prefix) => {
+                let matches: Vec<_> = known_ids
+                    .iter()
+                    .filter(|id| {
+                        let hex = id.to_string().replace('-', "");
+                        hex.starts_with(prefix.as_str())
+                    })
+                    .collect();
+
+                match matches.len() {
+                    0 => Err(PrefixError::NotFound(prefix.clone())),
+                    1 => Ok(*matches[0]),
+                    n => Err(PrefixError::Ambiguous(prefix.clone(), n)),
+                }
+            }
+        }
+    }
+}
+
+impl core::fmt::Display for PrefixId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match &self.0 {
+            PrefixIdInner::Full(id) => write!(f, "{id}"),
+            PrefixIdInner::Prefix(prefix) => write!(f, "{prefix}"),
+        }
+    }
+}
+
+impl core::str::FromStr for PrefixId {
+    type Err = PrefixError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(id) = s.parse::<Id>() {
+            return Ok(Self(PrefixIdInner::Full(id)));
+        }
+
+        let cleaned = s.replace('-', "");
+
+        if cleaned.len() < 8 {
+            return Err(PrefixError::TooShort(s.to_string()));
+        }
+
+        if !cleaned.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(PrefixError::InvalidHex(s.to_string()));
+        }
+
+        Ok(Self(PrefixIdInner::Prefix(cleaned)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_id(s: &str) -> Id {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn full_uuid_parses_and_resolves() {
+        let uuid_str = "019c5ea2-ba84-7cf1-8113-3db9b418c82c";
+        let prefix: PrefixId = uuid_str.parse().unwrap();
+
+        assert!(prefix.as_full_id().is_some());
+        assert_eq!(prefix.to_string(), uuid_str);
+
+        let resolved = prefix.resolve(&[]).unwrap();
+        assert_eq!(resolved.to_string(), uuid_str);
+    }
+
+    #[test]
+    fn short_prefix_parses() {
+        let prefix: PrefixId = "019c5ea2".parse().unwrap();
+        assert!(prefix.as_full_id().is_none());
+    }
+
+    #[test]
+    fn too_short_prefix_rejected() {
+        let result: Result<PrefixId, _> = "019c5e".parse();
+        assert!(matches!(result, Err(PrefixError::TooShort(_))));
+    }
+
+    #[test]
+    fn non_hex_rejected() {
+        let result: Result<PrefixId, _> = "019c5eXZ".parse();
+        assert!(matches!(result, Err(PrefixError::InvalidHex(_))));
+    }
+
+    #[test]
+    fn prefix_resolves_unique_match() {
+        let id1 = make_id("019c5ea2-ba84-7cf1-8113-3db9b418c82c");
+        let id2 = make_id("019c5ea7-0000-7000-8000-000000000000");
+        let known = vec![id1, id2];
+
+        let prefix: PrefixId = "019c5ea2".parse().unwrap();
+        let resolved = prefix.resolve(&known).unwrap();
+        assert_eq!(resolved, id1);
+    }
+
+    #[test]
+    fn prefix_errors_on_ambiguous() {
+        let id1 = make_id("019c5ea2-ba84-7cf1-8113-3db9b418c82c");
+        let id2 = make_id("019c5ea2-0000-7000-8000-000000000000");
+        let known = vec![id1, id2];
+
+        let prefix: PrefixId = "019c5ea2".parse().unwrap();
+        let result = prefix.resolve(&known);
+        assert!(matches!(result, Err(PrefixError::Ambiguous(_, 2))));
+    }
+
+    #[test]
+    fn prefix_errors_on_no_match() {
+        let id1 = make_id("019c5ea2-ba84-7cf1-8113-3db9b418c82c");
+        let known = vec![id1];
+
+        let prefix: PrefixId = "aabbccdd".parse().unwrap();
+        let result = prefix.resolve(&known);
+        assert!(matches!(result, Err(PrefixError::NotFound(_))));
+    }
+}


### PR DESCRIPTION
Working with uuids and stuff like that - it's annoying. Even for robots. And definitely for humans. This commit:

- Makes list and show outputs a lot nicer.
- Creates the concept of a short id, the prefix of a uuid.
- Permits short ids and uuids in a bunch of commands.