### PR TITLE
Bookmark MCP & MCP Auth.

### DIFF
--- a/crates/oneiros-engine/src/domains/bookmark/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/features/mcp.rs
@@ -1,0 +1,107 @@
+use crate::*;
+
+pub struct BookmarkTools;
+
+impl BookmarkTools {
+    pub const fn defs(&self) -> &'static [ToolDef] {
+        bookmark_mcp::tool_defs()
+    }
+
+    pub const fn names(&self) -> &'static [&'static str] {
+        bookmark_mcp::tool_names()
+    }
+
+    pub async fn dispatch(
+        &self,
+        state: &ServerState,
+        tool_name: &str,
+        params: &str,
+    ) -> Result<serde_json::Value, ToolError> {
+        bookmark_mcp::dispatch(state, tool_name, params).await
+    }
+}
+
+mod bookmark_mcp {
+    use crate::*;
+
+    pub const fn tool_defs() -> &'static [ToolDef] {
+        &[
+            ToolDef {
+                name: "list_bookmarks",
+                description: "List all bookmarks for the current brain",
+                input_schema: schema_for::<ListBookmarks>,
+            },
+            ToolDef {
+                name: "create_bookmark",
+                description: "Create a new bookmark — fork the current timeline",
+                input_schema: schema_for::<CreateBookmark>,
+            },
+            ToolDef {
+                name: "switch_bookmark",
+                description: "Switch to a different bookmark",
+                input_schema: schema_for::<SwitchBookmark>,
+            },
+            ToolDef {
+                name: "merge_bookmark",
+                description: "Merge a bookmark into the active bookmark",
+                input_schema: schema_for::<MergeBookmark>,
+            },
+        ]
+    }
+
+    pub const fn tool_names() -> &'static [&'static str] {
+        &[
+            "list_bookmarks",
+            "create_bookmark",
+            "switch_bookmark",
+            "merge_bookmark",
+        ]
+    }
+
+    pub async fn dispatch(
+        state: &ServerState,
+        tool_name: &str,
+        params: &str,
+    ) -> Result<serde_json::Value, ToolError> {
+        let system = state.system_context();
+        let brain = &state.config().brain;
+
+        let value = match tool_name {
+            "list_bookmarks" => {
+                let request: ListBookmarks = serde_json::from_str(params).unwrap_or_default();
+                BookmarkService::list(&system, brain, &request)
+                    .await
+                    .map_err(Error::from)?
+            }
+            "create_bookmark" => BookmarkService::create(
+                &system,
+                state.canons(),
+                brain,
+                &serde_json::from_str(params)?,
+            )
+            .await
+            .map_err(Error::from)?,
+            "switch_bookmark" => BookmarkService::switch(
+                &system,
+                state.canons(),
+                state.config(),
+                brain,
+                &serde_json::from_str(params)?,
+            )
+            .await
+            .map_err(Error::from)?,
+            "merge_bookmark" => BookmarkService::merge(
+                &system,
+                state.canons(),
+                state.config(),
+                brain,
+                &serde_json::from_str(params)?,
+            )
+            .await
+            .map_err(Error::from)?,
+            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+        };
+
+        Ok(serde_json::to_value(value)?)
+    }
+}

--- a/crates/oneiros-engine/src/domains/bookmark/features/mod.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/features/mod.rs
@@ -1,9 +1,11 @@
 mod cli;
 mod http;
+mod mcp;
 mod projections;
 mod skills;
 
 pub use cli::*;
 pub use http::*;
+pub use mcp::*;
 pub use projections::*;
 pub use skills::*;

--- a/crates/oneiros-engine/src/domains/bookmark/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/protocol/requests.rs
@@ -25,7 +25,7 @@ pub struct MergeBookmark {
     pub source: BookmarkName,
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
+#[derive(Builder, Debug, Clone, Default, Serialize, Deserialize, JsonSchema, Args)]
 pub struct ListBookmarks {
     #[command(flatten)]
     #[serde(flatten)]

--- a/crates/oneiros-engine/src/http/server.rs
+++ b/crates/oneiros-engine/src/http/server.rs
@@ -58,22 +58,13 @@ impl Server {
             .route("/dashboard/config", routing::get(dashboard_config));
 
         // MCP streamable HTTP transport — each session gets its own EngineToolBox
-        // that shares the server's broadcast channel for event observability.
+        // backed by the shared ServerState for full access to canons, config,
+        // and per-request context resolution.
         let state = ServerState::new(self.config.clone());
         state.hydrate();
         let mcp_state = state.clone();
         let mcp_service = StreamableHttpService::new(
-            move || {
-                let context = mcp_state
-                    .project_context(mcp_state.config().clone())
-                    .unwrap_or_else(|_| {
-                        ProjectContext::with_broadcast(
-                            mcp_state.config().clone(),
-                            mcp_state.broadcast().clone(),
-                        )
-                    });
-                Ok(EngineToolBox::new(context))
-            },
+            move || Ok(EngineToolBox::new(mcp_state.clone())),
             Arc::new(LocalSessionManager::default()),
             Default::default(),
         );

--- a/crates/oneiros-engine/src/mcp.rs
+++ b/crates/oneiros-engine/src/mcp.rs
@@ -3,6 +3,13 @@
 //! Each domain owns its tool catalog in `features/mcp.rs`. This module
 //! collects them into an rmcp ServerHandler, routing tool calls to the
 //! appropriate domain dispatcher.
+//!
+//! Session authentication: if the MCP client sends an `Authorization:
+//! Bearer <token>` header during the initialize handshake, the session
+//! resolves to the brain associated with that token. Without a token,
+//! the session uses the server's default brain.
+
+use std::sync::OnceLock;
 
 use rmcp::model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo, Tool};
 use rmcp::{ErrorData, ServerHandler};
@@ -38,6 +45,7 @@ fn all_tools() -> Vec<&'static ToolDef> {
         TenantTools.defs(),
         BrainTools.defs(),
         TicketTools.defs(),
+        BookmarkTools.defs(),
         LevelTools.defs(),
         TextureTools.defs(),
         SensationTools.defs(),
@@ -59,83 +67,138 @@ fn all_tools() -> Vec<&'static ToolDef> {
 }
 
 /// Domain dispatch table — routes tool names to domain dispatchers.
+///
+/// Derives ProjectContext or SystemContext from ServerState as needed.
+/// Bookmark tools get ServerState directly for CanonIndex access.
 async fn dispatch(
-    context: &ProjectContext,
+    state: &ServerState,
+    config: &Config,
     tool_name: &str,
     params: &str,
 ) -> Result<serde_json::Value, ToolError> {
+    // Bookmark tools — need ServerState for CanonIndex
+    if BookmarkTools.names().contains(&tool_name) {
+        return BookmarkTools.dispatch(state, tool_name, params).await;
+    }
+
+    // All other tools work through ProjectContext
+    let context = state
+        .project_context(config.clone())
+        .map_err(|e| ToolError::Domain(e.to_string()))?;
+
     // System domains
     if ActorTools.names().contains(&tool_name) {
-        return ActorTools.dispatch(context, tool_name, params).await;
+        return ActorTools.dispatch(&context, tool_name, params).await;
     }
     if TenantTools.names().contains(&tool_name) {
-        return TenantTools.dispatch(context, tool_name, params).await;
+        return TenantTools.dispatch(&context, tool_name, params).await;
     }
     if BrainTools.names().contains(&tool_name) {
-        return BrainTools.dispatch(context, tool_name, params).await;
+        return BrainTools.dispatch(&context, tool_name, params).await;
     }
     if TicketTools.names().contains(&tool_name) {
-        return TicketTools.dispatch(context, tool_name, params).await;
+        return TicketTools.dispatch(&context, tool_name, params).await;
     }
     // Project domains
     if LevelTools.names().contains(&tool_name) {
-        return LevelTools.dispatch(context, tool_name, params).await;
+        return LevelTools.dispatch(&context, tool_name, params).await;
     }
     if TextureTools.names().contains(&tool_name) {
-        return TextureTools.dispatch(context, tool_name, params).await;
+        return TextureTools.dispatch(&context, tool_name, params).await;
     }
     if SensationTools.names().contains(&tool_name) {
-        return SensationTools.dispatch(context, tool_name, params).await;
+        return SensationTools.dispatch(&context, tool_name, params).await;
     }
     if NatureTools.names().contains(&tool_name) {
-        return NatureTools.dispatch(context, tool_name, params).await;
+        return NatureTools.dispatch(&context, tool_name, params).await;
     }
     if PersonaTools.names().contains(&tool_name) {
-        return PersonaTools.dispatch(context, tool_name, params).await;
+        return PersonaTools.dispatch(&context, tool_name, params).await;
     }
     if UrgeTools.names().contains(&tool_name) {
-        return UrgeTools.dispatch(context, tool_name, params).await;
+        return UrgeTools.dispatch(&context, tool_name, params).await;
     }
     if AgentTools.names().contains(&tool_name) {
-        return AgentTools.dispatch(context, tool_name, params).await;
+        return AgentTools.dispatch(&context, tool_name, params).await;
     }
     if CognitionTools.names().contains(&tool_name) {
-        return CognitionTools.dispatch(context, tool_name, params).await;
+        return CognitionTools.dispatch(&context, tool_name, params).await;
     }
     if MemoryTools.names().contains(&tool_name) {
-        return MemoryTools.dispatch(context, tool_name, params).await;
+        return MemoryTools.dispatch(&context, tool_name, params).await;
     }
     if ExperienceTools.names().contains(&tool_name) {
-        return ExperienceTools.dispatch(context, tool_name, params).await;
+        return ExperienceTools.dispatch(&context, tool_name, params).await;
     }
     if ConnectionTools.names().contains(&tool_name) {
-        return ConnectionTools.dispatch(context, tool_name, params).await;
+        return ConnectionTools.dispatch(&context, tool_name, params).await;
     }
     if ContinuityTools.names().contains(&tool_name) {
-        return ContinuityTools.dispatch(context, tool_name, params).await;
+        return ContinuityTools.dispatch(&context, tool_name, params).await;
     }
     if SearchTools.names().contains(&tool_name) {
-        return SearchTools.dispatch(context, tool_name, params).await;
+        return SearchTools.dispatch(&context, tool_name, params).await;
     }
     if StorageTools.names().contains(&tool_name) {
-        return StorageTools.dispatch(context, tool_name, params).await;
+        return StorageTools.dispatch(&context, tool_name, params).await;
     }
     if PressureTools.names().contains(&tool_name) {
-        return PressureTools.dispatch(context, tool_name, params).await;
+        return PressureTools.dispatch(&context, tool_name, params).await;
     }
 
     Err(ToolError::UnknownTool(tool_name.to_string()))
 }
 
-/// MCP tool server wrapping the project context.
+/// Resolve a brain-specific config from a Bearer token.
+///
+/// Follows the same validation as the HTTP auth layer: decode the
+/// self-describing token, verify the ticket exists, and resolve the
+/// brain name.
+async fn resolve_config_from_token(state: &ServerState, token_str: &str) -> Option<Config> {
+    let token = Token::from(token_str).decode().ok()?;
+
+    let system = state.config().system();
+    let ticket = TicketRepo::new(&system)
+        .get_by_token(token_str)
+        .await
+        .ok()
+        .flatten()?;
+
+    if ticket.actor_id != token.actor_id || ticket.brain_id != token.brain_id {
+        return None;
+    }
+
+    let mut config = state.config().clone();
+    config.brain = ticket.brain_name;
+    Some(config)
+}
+
+/// MCP tool server wrapping the server state.
+///
+/// Each MCP session gets its own `EngineToolBox`. During the initialize
+/// handshake, if a Bearer token is present, the session resolves to
+/// the brain associated with that token. Otherwise it uses the server's
+/// default brain config.
 #[derive(Clone)]
 pub struct EngineToolBox {
-    context: ProjectContext,
+    state: ServerState,
+    /// Session-resolved config, set during initialize from Bearer token.
+    /// Falls back to state.config() if not set.
+    session_config: OnceLock<Config>,
 }
 
 impl EngineToolBox {
-    pub fn new(context: ProjectContext) -> Self {
-        Self { context }
+    pub fn new(state: ServerState) -> Self {
+        Self {
+            state,
+            session_config: OnceLock::new(),
+        }
+    }
+
+    /// The config for this session — resolved from token if authenticated,
+    /// otherwise the server default.
+    fn config(&self) -> &Config {
+        self.session_config.get().unwrap_or(self.state.config())
     }
 }
 
@@ -144,6 +207,28 @@ impl ServerHandler for EngineToolBox {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_server_info(
             Implementation::new("oneiros-engine", env!("CARGO_PKG_VERSION")),
         )
+    }
+
+    async fn initialize(
+        &self,
+        request: rmcp::model::InitializeRequestParams,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<rmcp::model::InitializeResult, ErrorData> {
+        // Extract Bearer token from HTTP headers if present
+        if let Some(parts) = context.extensions.get::<axum::http::request::Parts>()
+            && let Some(auth) = parts.headers.get("authorization")
+            && let Some(token_str) = auth.to_str().ok().and_then(|s| s.strip_prefix("Bearer "))
+            && let Some(config) = resolve_config_from_token(&self.state, token_str).await
+        {
+            let _ = self.session_config.set(config);
+        }
+
+        // Delegate to default initialization
+        if context.peer.peer_info().is_none() {
+            context.peer.set_peer_info(request);
+        }
+
+        Ok(self.get_info())
     }
 
     async fn list_tools(
@@ -179,7 +264,7 @@ impl ServerHandler for EngineToolBox {
         let params = serde_json::to_string(&request.arguments.unwrap_or_default())
             .unwrap_or_else(|_| "{}".to_string());
 
-        match dispatch(&self.context, tool_name, &params).await {
+        match dispatch(&self.state, self.config(), tool_name, &params).await {
             Ok(value) => Ok(CallToolResult::success(vec![
                 Content::json(value).expect("content"),
             ])),

--- a/crates/oneiros-engine/src/tests/workflows/mcp.rs
+++ b/crates/oneiros-engine/src/tests/workflows/mcp.rs
@@ -28,6 +28,50 @@ fn extract_sse_json(body: &str) -> serde_json::Value {
     serde_json::from_str(json_str).expect("data: line should be valid JSON")
 }
 
+/// Helper: perform the MCP initialize handshake with a Bearer token, returning the session ID.
+async fn mcp_initialize_with_token(
+    http: &reqwest::Client,
+    url: &str,
+    token: &Token,
+) -> Option<String> {
+    let init_resp = mcp_post(http, url)
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "test-auth", "version": "0.1.0" }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert!(
+        init_resp.status().is_success(),
+        "MCP initialize should succeed"
+    );
+
+    let session_id = init_resp
+        .headers()
+        .get("mcp-session-id")
+        .map(|v| v.to_str().unwrap().to_string());
+
+    let mut notif = mcp_post(http, url).json(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+    }));
+    if let Some(ref sid) = session_id {
+        notif = notif.header("mcp-session-id", sid);
+    }
+    notif.send().await.unwrap();
+
+    session_id
+}
+
 /// Helper: perform the MCP initialize handshake, returning the session ID.
 async fn mcp_initialize(http: &reqwest::Client, url: &str) -> Option<String> {
     let init_resp = mcp_post(http, url)
@@ -171,6 +215,92 @@ async fn mcp_session() -> Result<(), Box<dyn core::error::Error>> {
     let cmd_result = app.command("persona show mcp-persona").await?;
     let cmd_json = serde_json::to_value(cmd_result.response())?;
     assert_eq!(cmd_json["data"]["name"], "mcp-persona");
+
+    Ok(())
+}
+
+/// Helper: call an MCP tool and return the result JSON.
+async fn mcp_call_tool(
+    http: &reqwest::Client,
+    url: &str,
+    session_id: &Option<String>,
+    id: u64,
+    tool_name: &str,
+    arguments: serde_json::Value,
+) -> serde_json::Value {
+    let mut req = mcp_post(http, url).json(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {
+            "name": tool_name,
+            "arguments": arguments
+        }
+    }));
+    if let Some(sid) = session_id {
+        req = req.header("mcp-session-id", sid);
+    }
+    let resp = req.send().await.unwrap();
+    assert!(resp.status().is_success());
+    let body = resp.text().await.unwrap();
+    extract_sse_json(&body)
+}
+
+#[tokio::test]
+async fn mcp_session_auth() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_system()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let token = app.token().expect("project should have a token");
+    let http = reqwest::Client::new();
+    let url = app.mcp_url();
+
+    // Initialize with Bearer token
+    let session_id = mcp_initialize_with_token(&http, &url, &token).await;
+
+    // Create a persona through the authenticated session
+    let result = mcp_call_tool(
+        &http,
+        &url,
+        &session_id,
+        3,
+        "set_persona",
+        serde_json::json!({
+            "name": "auth-persona",
+            "description": "Created via authenticated MCP",
+            "prompt": "You were born from a token"
+        }),
+    )
+    .await;
+
+    // Should succeed (not isError)
+    let is_error = result["result"]["isError"].as_bool().unwrap_or(false);
+    assert!(
+        !is_error,
+        "authenticated tool call should succeed, got: {result}"
+    );
+
+    // Data should be visible through the HTTP REST API (same brain)
+    match app
+        .client()
+        .persona()
+        .get(&PersonaName::new("auth-persona"))
+        .await?
+    {
+        PersonaResponse::PersonaDetails(p) => {
+            assert_eq!(
+                p.data.description.to_string(),
+                "Created via authenticated MCP"
+            );
+        }
+        other => panic!("expected PersonaDetails, got {other:?}"),
+    }
 
     Ok(())
 }


### PR DESCRIPTION
We punted on authentication with MCP a while back and then serendipity saved us from realizing we'd forgotten to complete the work and wire up actual auth. Trying to get the bookmark tools represented revealed the issue though, since we suddenly needed access to the canon and had to thread server state into the tools. So, this commit both adds bookmark mcp and corrects the mcp auth goof.