### PR TITLE
Enum centric ergonomics.

### DIFF
--- a/crates/oneiros-engine/src/domains/actor/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/actor/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct ActorTools;
 
 impl ActorTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         actor_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        actor_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,28 +20,21 @@ impl ActorTools {
 mod actor_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "create_actor",
-                description: "Create a new actor in the system",
-                input_schema: schema_for::<CreateActor>,
-            },
-            ToolDef {
-                name: "get_actor",
-                description: "Look up a specific actor by ID",
-                input_schema: schema_for::<GetActor>,
-            },
-            ToolDef {
-                name: "list_actors",
-                description: "List all actors in the system",
-                input_schema: schema_for::<ListActors>,
-            },
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<CreateActor>::new(
+                ActorRequestType::CreateActor,
+                "Create a new actor in the system",
+            )
+            .def(),
+            Tool::<GetActor>::new(ActorRequestType::GetActor, "Look up a specific actor by ID")
+                .def(),
+            Tool::<ListActors>::new(
+                ActorRequestType::ListActors,
+                "List all actors in the system",
+            )
+            .def(),
         ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &["create_actor", "get_actor", "list_actors"]
     }
 
     pub async fn dispatch(
@@ -53,13 +42,22 @@ mod actor_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
+        let request_type: ActorRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
         let system = SystemContext::new(context.config.clone());
 
-        let value = match tool_name {
-            "create_actor" => ActorService::create(&system, &serde_json::from_str(params)?).await,
-            "get_actor" => ActorService::get(&system, &serde_json::from_str(params)?).await,
-            "list_actors" => ActorService::list(&system, &serde_json::from_str(params)?).await,
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+        let value = match request_type {
+            ActorRequestType::CreateActor => {
+                ActorService::create(&system, &serde_json::from_str(params)?).await
+            }
+            ActorRequestType::GetActor => {
+                ActorService::get(&system, &serde_json::from_str(params)?).await
+            }
+            ActorRequestType::ListActors => {
+                ActorService::list(&system, &serde_json::from_str(params)?).await
+            }
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/actor/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/actor/protocol/events.rs
@@ -1,9 +1,21 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = ActorEventsType, display = "kebab-case")]
 pub enum ActorEvents {
     ActorCreated(Actor),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        assert_eq!(&ActorEventsType::ActorCreated.to_string(), "actor-created");
+    }
 }

--- a/crates/oneiros-engine/src/domains/actor/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/actor/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = ActorResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ActorResponse {
     Created(Response<Actor>),

--- a/crates/oneiros-engine/src/domains/agent/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/agent/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct AgentTools;
 
 impl AgentTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         agent_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        agent_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,43 +20,22 @@ impl AgentTools {
 mod agent_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "create_agent",
-                description: "Bring a new agent into the brain",
-                input_schema: schema_for::<CreateAgent>,
-            },
-            ToolDef {
-                name: "get_agent",
-                description: "Learn about a specific agent",
-                input_schema: schema_for::<GetAgent>,
-            },
-            ToolDef {
-                name: "list_agents",
-                description: "See who's here",
-                input_schema: schema_for::<ListAgents>,
-            },
-            ToolDef {
-                name: "update_agent",
-                description: "Reshape an agent's identity",
-                input_schema: schema_for::<UpdateAgent>,
-            },
-            ToolDef {
-                name: "remove_agent",
-                description: "Remove an agent from the brain",
-                input_schema: schema_for::<RemoveAgent>,
-            },
-        ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &[
-            "create_agent",
-            "get_agent",
-            "list_agents",
-            "update_agent",
-            "remove_agent",
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<CreateAgent>::new(
+                AgentRequestType::CreateAgent,
+                "Bring a new agent into the brain",
+            )
+            .def(),
+            Tool::<GetAgent>::new(AgentRequestType::GetAgent, "Learn about a specific agent").def(),
+            Tool::<ListAgents>::new(AgentRequestType::ListAgents, "See who's here").def(),
+            Tool::<UpdateAgent>::new(AgentRequestType::UpdateAgent, "Reshape an agent's identity")
+                .def(),
+            Tool::<RemoveAgent>::new(
+                AgentRequestType::RemoveAgent,
+                "Remove an agent from the brain",
+            )
+            .def(),
         ]
     }
 
@@ -69,16 +44,27 @@ mod agent_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "create_agent" => AgentService::create(context, &serde_json::from_str(params)?).await,
-            "get_agent" => AgentService::get(context, &serde_json::from_str(params)?).await,
-            "list_agents" => {
+        let request_type: AgentRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            AgentRequestType::CreateAgent => {
+                AgentService::create(context, &serde_json::from_str(params)?).await
+            }
+            AgentRequestType::GetAgent => {
+                AgentService::get(context, &serde_json::from_str(params)?).await
+            }
+            AgentRequestType::ListAgents => {
                 let request: ListAgents = serde_json::from_str(params).unwrap_or_default();
                 AgentService::list(context, &request).await
             }
-            "update_agent" => AgentService::update(context, &serde_json::from_str(params)?).await,
-            "remove_agent" => AgentService::remove(context, &serde_json::from_str(params)?).await,
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+            AgentRequestType::UpdateAgent => {
+                AgentService::update(context, &serde_json::from_str(params)?).await
+            }
+            AgentRequestType::RemoveAgent => {
+                AgentService::remove(context, &serde_json::from_str(params)?).await
+            }
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/agent/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/agent/protocol/events.rs
@@ -1,13 +1,32 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = AgentEventsType, display = "kebab-case")]
 pub enum AgentEvents {
     AgentCreated(Agent),
     AgentUpdated(Agent),
     AgentRemoved(AgentRemoved),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        let cases = [
+            (AgentEventsType::AgentCreated, "agent-created"),
+            (AgentEventsType::AgentUpdated, "agent-updated"),
+            (AgentEventsType::AgentRemoved, "agent-removed"),
+        ];
+        for (event_type, expectation) in cases {
+            assert_eq!(&event_type.to_string(), expectation);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/oneiros-engine/src/domains/agent/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/agent/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = AgentResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum AgentResponse {
     AgentCreated(AgentName),

--- a/crates/oneiros-engine/src/domains/bookmark/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct BookmarkTools;
 
 impl BookmarkTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         bookmark_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        bookmark_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,37 +20,28 @@ impl BookmarkTools {
 mod bookmark_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "list_bookmarks",
-                description: "List all bookmarks for the current brain",
-                input_schema: schema_for::<ListBookmarks>,
-            },
-            ToolDef {
-                name: "create_bookmark",
-                description: "Create a new bookmark — fork the current timeline",
-                input_schema: schema_for::<CreateBookmark>,
-            },
-            ToolDef {
-                name: "switch_bookmark",
-                description: "Switch to a different bookmark",
-                input_schema: schema_for::<SwitchBookmark>,
-            },
-            ToolDef {
-                name: "merge_bookmark",
-                description: "Merge a bookmark into the active bookmark",
-                input_schema: schema_for::<MergeBookmark>,
-            },
-        ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &[
-            "list_bookmarks",
-            "create_bookmark",
-            "switch_bookmark",
-            "merge_bookmark",
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<ListBookmarks>::new(
+                BookmarkRequestType::ListBookmarks,
+                "List all bookmarks for the current brain",
+            )
+            .def(),
+            Tool::<CreateBookmark>::new(
+                BookmarkRequestType::CreateBookmark,
+                "Create a new bookmark — fork the current timeline",
+            )
+            .def(),
+            Tool::<SwitchBookmark>::new(
+                BookmarkRequestType::SwitchBookmark,
+                "Switch to a different bookmark",
+            )
+            .def(),
+            Tool::<MergeBookmark>::new(
+                BookmarkRequestType::MergeBookmark,
+                "Merge a bookmark into the active bookmark",
+            )
+            .def(),
         ]
     }
 
@@ -63,17 +50,21 @@ mod bookmark_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
+        let request_type: BookmarkRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
         let system = state.system_context();
         let brain = &state.config().brain;
 
-        let value = match tool_name {
-            "list_bookmarks" => {
+        let value = match request_type {
+            BookmarkRequestType::ListBookmarks => {
                 let request: ListBookmarks = serde_json::from_str(params).unwrap_or_default();
                 BookmarkService::list(&system, brain, &request)
                     .await
                     .map_err(Error::from)?
             }
-            "create_bookmark" => BookmarkService::create(
+            BookmarkRequestType::CreateBookmark => BookmarkService::create(
                 &system,
                 state.canons(),
                 brain,
@@ -81,16 +72,7 @@ mod bookmark_mcp {
             )
             .await
             .map_err(Error::from)?,
-            "switch_bookmark" => BookmarkService::switch(
-                &system,
-                state.canons(),
-                state.config(),
-                brain,
-                &serde_json::from_str(params)?,
-            )
-            .await
-            .map_err(Error::from)?,
-            "merge_bookmark" => BookmarkService::merge(
+            BookmarkRequestType::SwitchBookmark => BookmarkService::switch(
                 &system,
                 state.canons(),
                 state.config(),
@@ -99,7 +81,15 @@ mod bookmark_mcp {
             )
             .await
             .map_err(Error::from)?,
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+            BookmarkRequestType::MergeBookmark => BookmarkService::merge(
+                &system,
+                state.canons(),
+                state.config(),
+                brain,
+                &serde_json::from_str(params)?,
+            )
+            .await
+            .map_err(Error::from)?,
         };
 
         Ok(serde_json::to_value(value)?)

--- a/crates/oneiros-engine/src/domains/bookmark/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/protocol/events.rs
@@ -1,14 +1,34 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = BookmarkEventsType, display = "kebab-case")]
 pub enum BookmarkEvents {
     BookmarkCreated(BookmarkCreated),
     BookmarkForked(BookmarkForked),
     BookmarkSwitched(BookmarkSwitched),
     BookmarkMerged(BookmarkMerged),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        let cases = [
+            (BookmarkEventsType::BookmarkCreated, "bookmark-created"),
+            (BookmarkEventsType::BookmarkForked, "bookmark-forked"),
+            (BookmarkEventsType::BookmarkSwitched, "bookmark-switched"),
+            (BookmarkEventsType::BookmarkMerged, "bookmark-merged"),
+        ];
+        for (event_type, expectation) in cases {
+            assert_eq!(&event_type.to_string(), expectation);
+        }
+    }
 }
 
 /// Genesis — a bookmark comes into existence (e.g. "main" at brain init).

--- a/crates/oneiros-engine/src/domains/bookmark/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = BookmarkResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum BookmarkResponse {
     Created(BookmarkCreated),

--- a/crates/oneiros-engine/src/domains/brain/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/brain/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct BrainTools;
 
 impl BrainTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         brain_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        brain_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,28 +20,16 @@ impl BrainTools {
 mod brain_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "create_brain",
-                description: "Create a new brain",
-                input_schema: schema_for::<CreateBrain>,
-            },
-            ToolDef {
-                name: "get_brain",
-                description: "Look up a specific brain by name",
-                input_schema: schema_for::<GetBrain>,
-            },
-            ToolDef {
-                name: "list_brains",
-                description: "List all brains",
-                input_schema: schema_for::<ListBrains>,
-            },
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<CreateBrain>::new(BrainRequestType::CreateBrain, "Create a new brain").def(),
+            Tool::<GetBrain>::new(
+                BrainRequestType::GetBrain,
+                "Look up a specific brain by name",
+            )
+            .def(),
+            Tool::<ListBrains>::new(BrainRequestType::ListBrains, "List all brains").def(),
         ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &["create_brain", "get_brain", "list_brains"]
     }
 
     pub async fn dispatch(
@@ -53,13 +37,22 @@ mod brain_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
+        let request_type: BrainRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
         let system = SystemContext::new(context.config.clone());
 
-        let value = match tool_name {
-            "create_brain" => BrainService::create(&system, &serde_json::from_str(params)?).await,
-            "get_brain" => BrainService::get(&system, &serde_json::from_str(params)?).await,
-            "list_brains" => BrainService::list(&system, &serde_json::from_str(params)?).await,
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+        let value = match request_type {
+            BrainRequestType::CreateBrain => {
+                BrainService::create(&system, &serde_json::from_str(params)?).await
+            }
+            BrainRequestType::GetBrain => {
+                BrainService::get(&system, &serde_json::from_str(params)?).await
+            }
+            BrainRequestType::ListBrains => {
+                BrainService::list(&system, &serde_json::from_str(params)?).await
+            }
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/brain/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/brain/protocol/events.rs
@@ -1,9 +1,21 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = BrainEventsType, display = "kebab-case")]
 pub enum BrainEvents {
     BrainCreated(Brain),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        assert_eq!(&BrainEventsType::BrainCreated.to_string(), "brain-created");
+    }
 }

--- a/crates/oneiros-engine/src/domains/brain/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/brain/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = BrainResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum BrainResponse {
     Created(Response<Brain>),

--- a/crates/oneiros-engine/src/domains/cognition/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/cognition/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct CognitionTools;
 
 impl CognitionTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         cognition_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        cognition_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -26,28 +22,20 @@ mod cognition_mcp {
 
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "add_cognition",
-                description: "Record a thought",
-                input_schema: schema_for::<AddCognition>,
-            },
-            ToolDef {
-                name: "get_cognition",
-                description: "Revisit a specific thought",
-                input_schema: schema_for::<GetCognition>,
-            },
-            ToolDef {
-                name: "list_cognitions",
-                description: "Review a stream of thoughts",
-                input_schema: schema_for::<ListCognitions>,
-            },
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<AddCognition>::new(CognitionRequestType::AddCognition, "Record a thought").def(),
+            Tool::<GetCognition>::new(
+                CognitionRequestType::GetCognition,
+                "Revisit a specific thought",
+            )
+            .def(),
+            Tool::<ListCognitions>::new(
+                CognitionRequestType::ListCognitions,
+                "Review a stream of thoughts",
+            )
+            .def(),
         ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &["add_cognition", "get_cognition", "list_cognitions"]
     }
 
     pub async fn dispatch(
@@ -55,13 +43,20 @@ mod cognition_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "add_cognition" => CognitionService::add(context, &serde_json::from_str(params)?).await,
-            "get_cognition" => CognitionService::get(context, &serde_json::from_str(params)?).await,
-            "list_cognitions" => {
+        let request_type: CognitionRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            CognitionRequestType::AddCognition => {
+                CognitionService::add(context, &serde_json::from_str(params)?).await
+            }
+            CognitionRequestType::GetCognition => {
+                CognitionService::get(context, &serde_json::from_str(params)?).await
+            }
+            CognitionRequestType::ListCognitions => {
                 CognitionService::list(context, &serde_json::from_str(params)?).await
             }
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/cognition/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/cognition/protocol/events.rs
@@ -1,9 +1,24 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = CognitionEventsType, display = "kebab-case")]
 pub enum CognitionEvents {
     CognitionAdded(Cognition),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        assert_eq!(
+            &CognitionEventsType::CognitionAdded.to_string(),
+            "cognition-added"
+        );
+    }
 }

--- a/crates/oneiros-engine/src/domains/cognition/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/cognition/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = CognitionResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum CognitionResponse {
     CognitionAdded(Response<Cognition>),

--- a/crates/oneiros-engine/src/domains/connection/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/connection/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct ConnectionTools;
 
 impl ConnectionTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         connection_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        connection_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,37 +20,28 @@ impl ConnectionTools {
 mod connection_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "create_connection",
-                description: "Draw a line between two related things",
-                input_schema: schema_for::<CreateConnection>,
-            },
-            ToolDef {
-                name: "get_connection",
-                description: "Examine a specific connection",
-                input_schema: schema_for::<GetConnection>,
-            },
-            ToolDef {
-                name: "list_connections",
-                description: "See how things connect",
-                input_schema: schema_for::<ListConnections>,
-            },
-            ToolDef {
-                name: "remove_connection",
-                description: "Remove a connection",
-                input_schema: schema_for::<RemoveConnection>,
-            },
-        ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &[
-            "create_connection",
-            "get_connection",
-            "list_connections",
-            "remove_connection",
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<CreateConnection>::new(
+                ConnectionRequestType::CreateConnection,
+                "Draw a line between two related things",
+            )
+            .def(),
+            Tool::<GetConnection>::new(
+                ConnectionRequestType::GetConnection,
+                "Examine a specific connection",
+            )
+            .def(),
+            Tool::<ListConnections>::new(
+                ConnectionRequestType::ListConnections,
+                "See how things connect",
+            )
+            .def(),
+            Tool::<RemoveConnection>::new(
+                ConnectionRequestType::RemoveConnection,
+                "Remove a connection",
+            )
+            .def(),
         ]
     }
 
@@ -63,20 +50,23 @@ mod connection_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "create_connection" => {
+        let request_type: ConnectionRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            ConnectionRequestType::CreateConnection => {
                 ConnectionService::create(context, &serde_json::from_str(params)?).await
             }
-            "get_connection" => {
+            ConnectionRequestType::GetConnection => {
                 ConnectionService::get(context, &serde_json::from_str(params)?).await
             }
-            "list_connections" => {
+            ConnectionRequestType::ListConnections => {
                 ConnectionService::list(context, &serde_json::from_str(params)?).await
             }
-            "remove_connection" => {
+            ConnectionRequestType::RemoveConnection => {
                 ConnectionService::remove(context, &serde_json::from_str(params)?).await
             }
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/connection/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/connection/protocol/events.rs
@@ -1,12 +1,36 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = ConnectionEventsType, display = "kebab-case")]
 pub enum ConnectionEvents {
     ConnectionCreated(Connection),
     ConnectionRemoved(ConnectionRemoved),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        let cases = [
+            (
+                ConnectionEventsType::ConnectionCreated,
+                "connection-created",
+            ),
+            (
+                ConnectionEventsType::ConnectionRemoved,
+                "connection-removed",
+            ),
+        ];
+        for (event_type, expectation) in cases {
+            assert_eq!(&event_type.to_string(), expectation);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/oneiros-engine/src/domains/connection/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/connection/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = ConnectionResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ConnectionResponse {
     ConnectionCreated(Response<Connection>),

--- a/crates/oneiros-engine/src/domains/continuity/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/continuity/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct ContinuityTools;
 
 impl ContinuityTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         continuity_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        continuity_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,73 +20,58 @@ impl ContinuityTools {
 mod continuity_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "wake",
-                description: "Wake an agent — restore identity and begin a session",
-                input_schema: schema_for::<WakeAgent>,
-            },
-            ToolDef {
-                name: "dream",
-                description: "Restore an agent's full identity and cognitive context",
-                input_schema: schema_for::<DreamAgent>,
-            },
-            ToolDef {
-                name: "introspect",
-                description: "Look inward before context compacts — consolidate what matters",
-                input_schema: schema_for::<IntrospectAgent>,
-            },
-            ToolDef {
-                name: "reflect",
-                description: "Pause on something significant",
-                input_schema: schema_for::<ReflectAgent>,
-            },
-            ToolDef {
-                name: "sense",
-                description: "Receive and interpret something from outside your cognitive loop",
-                input_schema: schema_for::<SenseContent>,
-            },
-            ToolDef {
-                name: "sleep",
-                description: "End a session — capture continuity before resting",
-                input_schema: schema_for::<SleepAgent>,
-            },
-            ToolDef {
-                name: "guidebook",
-                description: "Read the cognitive guidebook — learn how your tools work",
-                input_schema: schema_for::<GuidebookAgent>,
-            },
-            ToolDef {
-                name: "emerge",
-                description: "Bring a new agent into existence with full ceremony",
-                input_schema: schema_for::<EmergeAgent>,
-            },
-            ToolDef {
-                name: "recede",
-                description: "Retire an agent — honor their contributions and let them go",
-                input_schema: schema_for::<RecedeAgent>,
-            },
-            ToolDef {
-                name: "status",
-                description: "See an agent's full cognitive dashboard",
-                input_schema: schema_for::<StatusAgent>,
-            },
-        ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &[
-            "wake",
-            "dream",
-            "introspect",
-            "reflect",
-            "sense",
-            "sleep",
-            "guidebook",
-            "emerge",
-            "recede",
-            "status",
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<WakeAgent>::new(
+                ContinuityRequestType::WakeAgent,
+                "Wake an agent — restore identity and begin a session",
+            )
+            .def(),
+            Tool::<DreamAgent>::new(
+                ContinuityRequestType::DreamAgent,
+                "Restore an agent's full identity and cognitive context",
+            )
+            .def(),
+            Tool::<IntrospectAgent>::new(
+                ContinuityRequestType::IntrospectAgent,
+                "Look inward before context compacts — consolidate what matters",
+            )
+            .def(),
+            Tool::<ReflectAgent>::new(
+                ContinuityRequestType::ReflectAgent,
+                "Pause on something significant",
+            )
+            .def(),
+            Tool::<SenseContent>::new(
+                ContinuityRequestType::SenseContent,
+                "Receive and interpret something from outside your cognitive loop",
+            )
+            .def(),
+            Tool::<SleepAgent>::new(
+                ContinuityRequestType::SleepAgent,
+                "End a session — capture continuity before resting",
+            )
+            .def(),
+            Tool::<GuidebookAgent>::new(
+                ContinuityRequestType::GuidebookAgent,
+                "Read the cognitive guidebook — learn how your tools work",
+            )
+            .def(),
+            Tool::<EmergeAgent>::new(
+                ContinuityRequestType::EmergeAgent,
+                "Bring a new agent into existence with full ceremony",
+            )
+            .def(),
+            Tool::<RecedeAgent>::new(
+                ContinuityRequestType::RecedeAgent,
+                "Retire an agent — honor their contributions and let them go",
+            )
+            .def(),
+            Tool::<StatusAgent>::new(
+                ContinuityRequestType::StatusAgent,
+                "See an agent's full cognitive dashboard",
+            )
+            .def(),
         ]
     }
 
@@ -106,44 +87,49 @@ mod continuity_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
+        let request_type: ContinuityRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
         let overrides = parse_overrides(params);
 
-        let value = match tool_name {
-            "wake" => {
+        let value = match request_type {
+            ContinuityRequestType::WakeAgent => {
                 ContinuityService::wake(context, &serde_json::from_str(params)?, &overrides).await
             }
-            "dream" => {
+            ContinuityRequestType::DreamAgent => {
                 ContinuityService::dream(context, &serde_json::from_str(params)?, &overrides).await
             }
-            "introspect" => {
+            ContinuityRequestType::IntrospectAgent => {
                 ContinuityService::introspect(context, &serde_json::from_str(params)?, &overrides)
                     .await
             }
-            "reflect" => {
+            ContinuityRequestType::ReflectAgent => {
                 ContinuityService::reflect(context, &serde_json::from_str(params)?, &overrides)
                     .await
             }
-            "sense" => {
+            ContinuityRequestType::SenseContent => {
                 ContinuityService::sense(context, &serde_json::from_str(params)?, &overrides).await
             }
-            "sleep" => {
+            ContinuityRequestType::SleepAgent => {
                 ContinuityService::sleep(context, &serde_json::from_str(params)?, &overrides).await
             }
-            "guidebook" => Ok(ContinuityService::guidebook(
+            ContinuityRequestType::GuidebookAgent => Ok(ContinuityService::guidebook(
                 context,
                 &serde_json::from_str(params)?,
                 &overrides,
             )
             .map_err(Error::from)?),
-            "emerge" => {
+            ContinuityRequestType::EmergeAgent => {
                 ContinuityService::emerge(context, &serde_json::from_str(params)?, &overrides).await
             }
-            "recede" => ContinuityService::recede(context, &serde_json::from_str(params)?).await,
-            "status" => {
+            ContinuityRequestType::RecedeAgent => {
+                ContinuityService::recede(context, &serde_json::from_str(params)?).await
+            }
+            ContinuityRequestType::StatusAgent => {
                 let request: StatusAgent = serde_json::from_str(params).unwrap_or_default();
                 Ok(ContinuityService::status(context, &request).map_err(Error::from)?)
             }
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/continuity/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/continuity/protocol/events.rs
@@ -1,15 +1,36 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = ContinuityEventsType, display = "kebab-case")]
 pub enum ContinuityEvents {
     Dreamed(ContinuityEvent),
     Introspected(ContinuityEvent),
     Reflected(ContinuityEvent),
     Sensed(SensedEvent),
     Slept(ContinuityEvent),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        let cases = [
+            (ContinuityEventsType::Dreamed, "dreamed"),
+            (ContinuityEventsType::Introspected, "introspected"),
+            (ContinuityEventsType::Reflected, "reflected"),
+            (ContinuityEventsType::Sensed, "sensed"),
+            (ContinuityEventsType::Slept, "slept"),
+        ];
+        for (event_type, expectation) in cases {
+            assert_eq!(&event_type.to_string(), expectation);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/oneiros-engine/src/domains/continuity/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/continuity/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = ContinuityResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ContinuityResponse {
     Emerged(DreamContext),

--- a/crates/oneiros-engine/src/domains/doctor/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/doctor/protocol/responses.rs
@@ -1,3 +1,4 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
@@ -37,7 +38,8 @@ impl core::fmt::Display for LogEventCount {
 }
 
 /// A single diagnostic check item emitted during a doctor checkup.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = DoctorCheckType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum DoctorCheck {
     Initialized,
@@ -58,7 +60,8 @@ pub enum DoctorCheck {
 }
 
 /// All responses the doctor domain can produce.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = DoctorResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum DoctorResponse {
     CheckupStatus(Vec<DoctorCheck>),

--- a/crates/oneiros-engine/src/domains/experience/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/experience/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct ExperienceTools;
 
 impl ExperienceTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         experience_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        experience_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,43 +20,33 @@ impl ExperienceTools {
 mod experience_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "create_experience",
-                description: "Mark a meaningful moment",
-                input_schema: schema_for::<CreateExperience>,
-            },
-            ToolDef {
-                name: "get_experience",
-                description: "Revisit a specific experience",
-                input_schema: schema_for::<GetExperience>,
-            },
-            ToolDef {
-                name: "list_experiences",
-                description: "Survey threads of meaning",
-                input_schema: schema_for::<ListExperiences>,
-            },
-            ToolDef {
-                name: "update_experience_description",
-                description: "Refine an experience's description",
-                input_schema: schema_for::<UpdateExperienceDescription>,
-            },
-            ToolDef {
-                name: "update_experience_sensation",
-                description: "Change an experience's sensation",
-                input_schema: schema_for::<UpdateExperienceSensation>,
-            },
-        ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &[
-            "create_experience",
-            "get_experience",
-            "list_experiences",
-            "update_experience_description",
-            "update_experience_sensation",
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<CreateExperience>::new(
+                ExperienceRequestType::CreateExperience,
+                "Mark a meaningful moment",
+            )
+            .def(),
+            Tool::<GetExperience>::new(
+                ExperienceRequestType::GetExperience,
+                "Revisit a specific experience",
+            )
+            .def(),
+            Tool::<ListExperiences>::new(
+                ExperienceRequestType::ListExperiences,
+                "Survey threads of meaning",
+            )
+            .def(),
+            Tool::<UpdateExperienceDescription>::new(
+                ExperienceRequestType::UpdateExperienceDescription,
+                "Refine an experience's description",
+            )
+            .def(),
+            Tool::<UpdateExperienceSensation>::new(
+                ExperienceRequestType::UpdateExperienceSensation,
+                "Change an experience's sensation",
+            )
+            .def(),
         ]
     }
 
@@ -69,23 +55,26 @@ mod experience_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "create_experience" => {
+        let request_type: ExperienceRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            ExperienceRequestType::CreateExperience => {
                 ExperienceService::create(context, &serde_json::from_str(params)?).await
             }
-            "get_experience" => {
+            ExperienceRequestType::GetExperience => {
                 ExperienceService::get(context, &serde_json::from_str(params)?).await
             }
-            "list_experiences" => {
+            ExperienceRequestType::ListExperiences => {
                 ExperienceService::list(context, &serde_json::from_str(params)?).await
             }
-            "update_experience_description" => {
+            ExperienceRequestType::UpdateExperienceDescription => {
                 ExperienceService::update_description(context, &serde_json::from_str(params)?).await
             }
-            "update_experience_sensation" => {
+            ExperienceRequestType::UpdateExperienceSensation => {
                 ExperienceService::update_sensation(context, &serde_json::from_str(params)?).await
             }
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/experience/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/experience/protocol/events.rs
@@ -1,13 +1,41 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = ExperienceEventsType, display = "kebab-case")]
 pub enum ExperienceEvents {
     ExperienceCreated(Experience),
     ExperienceDescriptionUpdated(ExperienceDescriptionUpdate),
     ExperienceSensationUpdated(ExperienceSensationUpdate),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        let cases = [
+            (
+                ExperienceEventsType::ExperienceCreated,
+                "experience-created",
+            ),
+            (
+                ExperienceEventsType::ExperienceDescriptionUpdated,
+                "experience-description-updated",
+            ),
+            (
+                ExperienceEventsType::ExperienceSensationUpdated,
+                "experience-sensation-updated",
+            ),
+        ];
+        for (event_type, expectation) in cases {
+            assert_eq!(&event_type.to_string(), expectation);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/oneiros-engine/src/domains/experience/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/experience/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = ExperienceResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ExperienceResponse {
     ExperienceCreated(Response<Experience>),

--- a/crates/oneiros-engine/src/domains/level/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/level/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct LevelTools;
 
 impl LevelTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         level_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        level_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,33 +20,29 @@ impl LevelTools {
 mod level_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "set_level",
-                description: "Define how long a kind of memory should be kept",
-                input_schema: schema_for::<SetLevel>,
-            },
-            ToolDef {
-                name: "get_level",
-                description: "Look up a memory retention tier",
-                input_schema: schema_for::<GetLevel>,
-            },
-            ToolDef {
-                name: "list_levels",
-                description: "See all memory retention tiers",
-                input_schema: schema_for::<ListLevels>,
-            },
-            ToolDef {
-                name: "remove_level",
-                description: "Remove a memory retention tier",
-                input_schema: schema_for::<RemoveLevel>,
-            },
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<SetLevel>::new(
+                LevelRequestType::SetLevel,
+                "Define how long a kind of memory should be kept",
+            )
+            .def(),
+            Tool::<GetLevel>::new(
+                LevelRequestType::GetLevel,
+                "Look up a memory retention tier",
+            )
+            .def(),
+            Tool::<ListLevels>::new(
+                LevelRequestType::ListLevels,
+                "See all memory retention tiers",
+            )
+            .def(),
+            Tool::<RemoveLevel>::new(
+                LevelRequestType::RemoveLevel,
+                "Remove a memory retention tier",
+            )
+            .def(),
         ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &["set_level", "get_level", "list_levels", "remove_level"]
     }
 
     pub async fn dispatch(
@@ -58,12 +50,23 @@ mod level_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "set_level" => LevelService::set(context, &serde_json::from_str(params)?).await,
-            "get_level" => LevelService::get(context, &serde_json::from_str(params)?).await,
-            "list_levels" => LevelService::list(context, &serde_json::from_str(params)?).await,
-            "remove_level" => LevelService::remove(context, &serde_json::from_str(params)?).await,
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+        let request_type: LevelRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            LevelRequestType::SetLevel => {
+                LevelService::set(context, &serde_json::from_str(params)?).await
+            }
+            LevelRequestType::GetLevel => {
+                LevelService::get(context, &serde_json::from_str(params)?).await
+            }
+            LevelRequestType::ListLevels => {
+                LevelService::list(context, &serde_json::from_str(params)?).await
+            }
+            LevelRequestType::RemoveLevel => {
+                LevelService::remove(context, &serde_json::from_str(params)?).await
+            }
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/level/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/level/protocol/events.rs
@@ -1,12 +1,30 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = LevelEventsType, display = "kebab-case")]
 pub enum LevelEvents {
     LevelSet(Level),
     LevelRemoved(LevelRemoved),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        let cases = [
+            (LevelEventsType::LevelSet, "level-set"),
+            (LevelEventsType::LevelRemoved, "level-removed"),
+        ];
+        for (event_type, expectation) in cases {
+            assert_eq!(&event_type.to_string(), expectation);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/oneiros-engine/src/domains/level/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/level/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = LevelResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum LevelResponse {
     LevelSet(LevelName),

--- a/crates/oneiros-engine/src/domains/mcp/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/mcp/protocol/responses.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = McpConfigResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum McpConfigResponse {
     McpConfigWritten(PathBuf),

--- a/crates/oneiros-engine/src/domains/memory/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/memory/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct MemoryTools;
 
 impl MemoryTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         memory_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        memory_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,28 +20,17 @@ impl MemoryTools {
 mod memory_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "add_memory",
-                description: "Consolidate something you've learned",
-                input_schema: schema_for::<AddMemory>,
-            },
-            ToolDef {
-                name: "get_memory",
-                description: "Revisit a specific memory",
-                input_schema: schema_for::<GetMemory>,
-            },
-            ToolDef {
-                name: "list_memories",
-                description: "Review what you know",
-                input_schema: schema_for::<ListMemories>,
-            },
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<AddMemory>::new(
+                MemoryRequestType::AddMemory,
+                "Consolidate something you've learned",
+            )
+            .def(),
+            Tool::<GetMemory>::new(MemoryRequestType::GetMemory, "Revisit a specific memory").def(),
+            Tool::<ListMemories>::new(MemoryRequestType::ListMemories, "Review what you know")
+                .def(),
         ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &["add_memory", "get_memory", "list_memories"]
     }
 
     pub async fn dispatch(
@@ -53,11 +38,20 @@ mod memory_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "add_memory" => MemoryService::add(context, &serde_json::from_str(params)?).await,
-            "get_memory" => MemoryService::get(context, &serde_json::from_str(params)?).await,
-            "list_memories" => MemoryService::list(context, &serde_json::from_str(params)?).await,
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+        let request_type: MemoryRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            MemoryRequestType::AddMemory => {
+                MemoryService::add(context, &serde_json::from_str(params)?).await
+            }
+            MemoryRequestType::GetMemory => {
+                MemoryService::get(context, &serde_json::from_str(params)?).await
+            }
+            MemoryRequestType::ListMemories => {
+                MemoryService::list(context, &serde_json::from_str(params)?).await
+            }
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/memory/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/memory/protocol/events.rs
@@ -1,9 +1,21 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = MemoryEventsType, display = "kebab-case")]
 pub enum MemoryEvents {
     MemoryAdded(Memory),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        assert_eq!(&MemoryEventsType::MemoryAdded.to_string(), "memory-added");
+    }
 }

--- a/crates/oneiros-engine/src/domains/memory/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/memory/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = MemoryResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum MemoryResponse {
     MemoryAdded(Response<Memory>),

--- a/crates/oneiros-engine/src/domains/nature/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/nature/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct NatureTools;
 
 impl NatureTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         nature_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        nature_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,33 +20,29 @@ impl NatureTools {
 mod nature_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "set_nature",
-                description: "Define a kind of relationship between things",
-                input_schema: schema_for::<SetNature>,
-            },
-            ToolDef {
-                name: "get_nature",
-                description: "Look up a relationship category",
-                input_schema: schema_for::<GetNature>,
-            },
-            ToolDef {
-                name: "list_natures",
-                description: "See all the kinds of relationships",
-                input_schema: schema_for::<ListNatures>,
-            },
-            ToolDef {
-                name: "remove_nature",
-                description: "Remove a relationship category",
-                input_schema: schema_for::<RemoveNature>,
-            },
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<SetNature>::new(
+                NatureRequestType::SetNature,
+                "Define a kind of relationship between things",
+            )
+            .def(),
+            Tool::<GetNature>::new(
+                NatureRequestType::GetNature,
+                "Look up a relationship category",
+            )
+            .def(),
+            Tool::<ListNatures>::new(
+                NatureRequestType::ListNatures,
+                "See all the kinds of relationships",
+            )
+            .def(),
+            Tool::<RemoveNature>::new(
+                NatureRequestType::RemoveNature,
+                "Remove a relationship category",
+            )
+            .def(),
         ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &["set_nature", "get_nature", "list_natures", "remove_nature"]
     }
 
     pub async fn dispatch(
@@ -58,12 +50,23 @@ mod nature_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "set_nature" => NatureService::set(context, &serde_json::from_str(params)?).await,
-            "get_nature" => NatureService::get(context, &serde_json::from_str(params)?).await,
-            "list_natures" => NatureService::list(context, &serde_json::from_str(params)?).await,
-            "remove_nature" => NatureService::remove(context, &serde_json::from_str(params)?).await,
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+        let request_type: NatureRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            NatureRequestType::SetNature => {
+                NatureService::set(context, &serde_json::from_str(params)?).await
+            }
+            NatureRequestType::GetNature => {
+                NatureService::get(context, &serde_json::from_str(params)?).await
+            }
+            NatureRequestType::ListNatures => {
+                NatureService::list(context, &serde_json::from_str(params)?).await
+            }
+            NatureRequestType::RemoveNature => {
+                NatureService::remove(context, &serde_json::from_str(params)?).await
+            }
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/nature/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/nature/protocol/events.rs
@@ -1,12 +1,30 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = NatureEventsType, display = "kebab-case")]
 pub enum NatureEvents {
     NatureSet(Nature),
     NatureRemoved(NatureRemoved),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        let cases = [
+            (NatureEventsType::NatureSet, "nature-set"),
+            (NatureEventsType::NatureRemoved, "nature-removed"),
+        ];
+        for (event_type, expectation) in cases {
+            assert_eq!(&event_type.to_string(), expectation);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/oneiros-engine/src/domains/nature/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/nature/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = NatureResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum NatureResponse {
     NatureSet(NatureName),

--- a/crates/oneiros-engine/src/domains/persona/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/persona/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct PersonaTools;
 
 impl PersonaTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         persona_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        persona_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,37 +20,19 @@ impl PersonaTools {
 mod persona_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "set_persona",
-                description: "Define a category of agent",
-                input_schema: schema_for::<SetPersona>,
-            },
-            ToolDef {
-                name: "get_persona",
-                description: "Look up an agent category",
-                input_schema: schema_for::<GetPersona>,
-            },
-            ToolDef {
-                name: "list_personas",
-                description: "See all agent categories",
-                input_schema: schema_for::<ListPersonas>,
-            },
-            ToolDef {
-                name: "remove_persona",
-                description: "Remove an agent category",
-                input_schema: schema_for::<RemovePersona>,
-            },
-        ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &[
-            "set_persona",
-            "get_persona",
-            "list_personas",
-            "remove_persona",
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<SetPersona>::new(PersonaRequestType::SetPersona, "Define a category of agent")
+                .def(),
+            Tool::<GetPersona>::new(PersonaRequestType::GetPersona, "Look up an agent category")
+                .def(),
+            Tool::<ListPersonas>::new(PersonaRequestType::ListPersonas, "See all agent categories")
+                .def(),
+            Tool::<RemovePersona>::new(
+                PersonaRequestType::RemovePersona,
+                "Remove an agent category",
+            )
+            .def(),
         ]
     }
 
@@ -63,14 +41,23 @@ mod persona_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "set_persona" => PersonaService::set(context, &serde_json::from_str(params)?).await,
-            "get_persona" => PersonaService::get(context, &serde_json::from_str(params)?).await,
-            "list_personas" => PersonaService::list(context, &serde_json::from_str(params)?).await,
-            "remove_persona" => {
+        let request_type: PersonaRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            PersonaRequestType::SetPersona => {
+                PersonaService::set(context, &serde_json::from_str(params)?).await
+            }
+            PersonaRequestType::GetPersona => {
+                PersonaService::get(context, &serde_json::from_str(params)?).await
+            }
+            PersonaRequestType::ListPersonas => {
+                PersonaService::list(context, &serde_json::from_str(params)?).await
+            }
+            PersonaRequestType::RemovePersona => {
                 PersonaService::remove(context, &serde_json::from_str(params)?).await
             }
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/persona/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/persona/protocol/events.rs
@@ -1,12 +1,30 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = PersonaEventsType, display = "kebab-case")]
 pub enum PersonaEvents {
     PersonaSet(Persona),
     PersonaRemoved(PersonaRemoved),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        let cases = [
+            (PersonaEventsType::PersonaSet, "persona-set"),
+            (PersonaEventsType::PersonaRemoved, "persona-removed"),
+        ];
+        for (event_type, expectation) in cases {
+            assert_eq!(&event_type.to_string(), expectation);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/oneiros-engine/src/domains/persona/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/persona/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = PersonaResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum PersonaResponse {
     PersonaSet(PersonaName),

--- a/crates/oneiros-engine/src/domains/pressure/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/pressure/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct PressureTools;
 
 impl PressureTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         pressure_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        pressure_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,23 +20,19 @@ impl PressureTools {
 mod pressure_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "get_pressure",
-                description: "Check an agent's cognitive pressure",
-                input_schema: schema_for::<GetPressure>,
-            },
-            ToolDef {
-                name: "list_pressures",
-                description: "See all pressure readings",
-                input_schema: schema_for::<serde_json::Value>,
-            },
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<GetPressure>::new(
+                PressureRequestType::GetPressure,
+                "Check an agent's cognitive pressure",
+            )
+            .def(),
+            Tool::<serde_json::Value>::new(
+                PressureRequestType::ListPressures,
+                "See all pressure readings",
+            )
+            .def(),
         ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &["get_pressure", "list_pressures"]
     }
 
     pub async fn dispatch(
@@ -48,10 +40,15 @@ mod pressure_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "get_pressure" => PressureService::get(context, &serde_json::from_str(params)?).await,
-            "list_pressures" => PressureService::list(context).await,
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+        let request_type: PressureRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            PressureRequestType::GetPressure => {
+                PressureService::get(context, &serde_json::from_str(params)?).await
+            }
+            PressureRequestType::ListPressures => PressureService::list(context).await,
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/pressure/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/pressure/protocol/responses.rs
@@ -1,3 +1,4 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
@@ -14,7 +15,8 @@ pub struct ListPressureResult {
     pub pressures: Vec<Pressure>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = PressureResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum PressureResponse {
     Readings(PressureResult),

--- a/crates/oneiros-engine/src/domains/project/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/project/protocol/responses.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
@@ -59,7 +60,8 @@ pub struct InitResult {
     pub token: Token,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = ProjectResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ProjectResponse {
     Initialized(InitResult),

--- a/crates/oneiros-engine/src/domains/search/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/search/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct SearchTools;
 
 impl SearchTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         search_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        search_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,16 +20,14 @@ impl SearchTools {
 mod search_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[ToolDef {
-            name: "search",
-            description: "Search across everything in the brain",
-            input_schema: schema_for::<SearchQuery>,
-        }]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &["search"]
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<SearchQuery>::new(
+                SearchRequestType::SearchQuery,
+                "Search across everything in the brain",
+            )
+            .def(),
+        ]
     }
 
     pub async fn dispatch(
@@ -41,9 +35,14 @@ mod search_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "search" => SearchService::search(context, &serde_json::from_str(params)?).await,
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+        let request_type: SearchRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            SearchRequestType::SearchQuery => {
+                SearchService::search(context, &serde_json::from_str(params)?).await
+            }
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/search/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/search/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = SearchResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum SearchResponse {
     Results(SearchResults),

--- a/crates/oneiros-engine/src/domains/seed/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/seed/protocol/responses.rs
@@ -1,6 +1,8 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = SeedResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum SeedResponse {
     SeedComplete,

--- a/crates/oneiros-engine/src/domains/sensation/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/sensation/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct SensationTools;
 
 impl SensationTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         sensation_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        sensation_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,37 +20,28 @@ impl SensationTools {
 mod sensation_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "set_sensation",
-                description: "Define a quality of connection between thoughts",
-                input_schema: schema_for::<SetSensation>,
-            },
-            ToolDef {
-                name: "get_sensation",
-                description: "Look up an experience category",
-                input_schema: schema_for::<GetSensation>,
-            },
-            ToolDef {
-                name: "list_sensations",
-                description: "See all the ways experiences can feel",
-                input_schema: schema_for::<ListSensations>,
-            },
-            ToolDef {
-                name: "remove_sensation",
-                description: "Remove an experience category",
-                input_schema: schema_for::<RemoveSensation>,
-            },
-        ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &[
-            "set_sensation",
-            "get_sensation",
-            "list_sensations",
-            "remove_sensation",
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<SetSensation>::new(
+                SensationRequestType::SetSensation,
+                "Define a quality of connection between thoughts",
+            )
+            .def(),
+            Tool::<GetSensation>::new(
+                SensationRequestType::GetSensation,
+                "Look up an experience category",
+            )
+            .def(),
+            Tool::<ListSensations>::new(
+                SensationRequestType::ListSensations,
+                "See all the ways experiences can feel",
+            )
+            .def(),
+            Tool::<RemoveSensation>::new(
+                SensationRequestType::RemoveSensation,
+                "Remove an experience category",
+            )
+            .def(),
         ]
     }
 
@@ -63,16 +50,23 @@ mod sensation_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "set_sensation" => SensationService::set(context, &serde_json::from_str(params)?).await,
-            "get_sensation" => SensationService::get(context, &serde_json::from_str(params)?).await,
-            "list_sensations" => {
+        let request_type: SensationRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            SensationRequestType::SetSensation => {
+                SensationService::set(context, &serde_json::from_str(params)?).await
+            }
+            SensationRequestType::GetSensation => {
+                SensationService::get(context, &serde_json::from_str(params)?).await
+            }
+            SensationRequestType::ListSensations => {
                 SensationService::list(context, &serde_json::from_str(params)?).await
             }
-            "remove_sensation" => {
+            SensationRequestType::RemoveSensation => {
                 SensationService::remove(context, &serde_json::from_str(params)?).await
             }
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/sensation/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/sensation/protocol/events.rs
@@ -1,12 +1,30 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = SensationEventsType, display = "kebab-case")]
 pub enum SensationEvents {
     SensationSet(Sensation),
     SensationRemoved(SensationRemoved),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        let cases = [
+            (SensationEventsType::SensationSet, "sensation-set"),
+            (SensationEventsType::SensationRemoved, "sensation-removed"),
+        ];
+        for (event_type, expectation) in cases {
+            assert_eq!(&event_type.to_string(), expectation);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/oneiros-engine/src/domains/sensation/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/sensation/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = SensationResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum SensationResponse {
     SensationSet(SensationName),

--- a/crates/oneiros-engine/src/domains/service/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/service/protocol/responses.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 /// The name under which the service is registered with the OS service manager.
@@ -54,7 +55,8 @@ impl fmt::Display for ServiceReason {
 }
 
 /// All responses the service domain can produce.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = ServiceResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ServiceResponse {
     ServiceInstalled(ServiceName),

--- a/crates/oneiros-engine/src/domains/setup/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/setup/protocol/responses.rs
@@ -1,9 +1,11 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
 /// A single step in the setup flow.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = SetupStepType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum SetupStep {
     SystemInitialized,
@@ -21,7 +23,8 @@ pub enum SetupStep {
 }
 
 /// The result of running setup.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = SetupResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum SetupResponse {
     SetupComplete(Vec<SetupStep>),

--- a/crates/oneiros-engine/src/domains/storage/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/storage/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct StorageTools;
 
 impl StorageTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         storage_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        storage_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,28 +20,17 @@ impl StorageTools {
 mod storage_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "list_storage",
-                description: "Browse your archive",
-                input_schema: schema_for::<ListStorage>,
-            },
-            ToolDef {
-                name: "get_storage",
-                description: "Retrieve a stored artifact",
-                input_schema: schema_for::<GetStorage>,
-            },
-            ToolDef {
-                name: "remove_storage",
-                description: "Remove a stored artifact",
-                input_schema: schema_for::<RemoveStorage>,
-            },
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<ListStorage>::new(StorageRequestType::ListStorage, "Browse your archive").def(),
+            Tool::<GetStorage>::new(StorageRequestType::GetStorage, "Retrieve a stored artifact")
+                .def(),
+            Tool::<RemoveStorage>::new(
+                StorageRequestType::RemoveStorage,
+                "Remove a stored artifact",
+            )
+            .def(),
         ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &["list_storage", "get_storage", "remove_storage"]
     }
 
     pub async fn dispatch(
@@ -53,16 +38,24 @@ mod storage_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "list_storage" => {
+        let request_type: StorageRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            StorageRequestType::ListStorage => {
                 let request: ListStorage = serde_json::from_str(params).unwrap_or_default();
                 StorageService::list(context, &request).await
             }
-            "get_storage" => StorageService::show(context, &serde_json::from_str(params)?).await,
-            "remove_storage" => {
+            StorageRequestType::GetStorage => {
+                StorageService::show(context, &serde_json::from_str(params)?).await
+            }
+            StorageRequestType::RemoveStorage => {
                 StorageService::remove(context, &serde_json::from_str(params)?).await
             }
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+            StorageRequestType::UploadStorage => {
+                return Err(ToolError::UnknownTool(tool_name.to_string()));
+            }
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/storage/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/storage/protocol/events.rs
@@ -1,12 +1,30 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = StorageEventsType, display = "kebab-case")]
 pub enum StorageEvents {
     /// Persistent: projects to storage metadata table (upsert).
     StorageSet(StorageEntry),
     /// Persistent: removes storage metadata by key.
     StorageRemoved(SelectStorageByKey),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        let cases = [
+            (StorageEventsType::StorageSet, "storage-set"),
+            (StorageEventsType::StorageRemoved, "storage-removed"),
+        ];
+        for (event_type, expectation) in cases {
+            assert_eq!(&event_type.to_string(), expectation);
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/storage/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/storage/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = StorageResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum StorageResponse {
     StorageSet(Response<StorageEntry>),

--- a/crates/oneiros-engine/src/domains/system/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/system/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = SystemResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum SystemResponse {
     SystemInitialized(TenantName),

--- a/crates/oneiros-engine/src/domains/tenant/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/tenant/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct TenantTools;
 
 impl TenantTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         tenant_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        tenant_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,28 +20,16 @@ impl TenantTools {
 mod tenant_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "create_tenant",
-                description: "Create a new tenant",
-                input_schema: schema_for::<CreateTenant>,
-            },
-            ToolDef {
-                name: "get_tenant",
-                description: "Look up a specific tenant by ID",
-                input_schema: schema_for::<GetTenant>,
-            },
-            ToolDef {
-                name: "list_tenants",
-                description: "List all tenants",
-                input_schema: schema_for::<ListTenants>,
-            },
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<CreateTenant>::new(TenantRequestType::CreateTenant, "Create a new tenant").def(),
+            Tool::<GetTenant>::new(
+                TenantRequestType::GetTenant,
+                "Look up a specific tenant by ID",
+            )
+            .def(),
+            Tool::<ListTenants>::new(TenantRequestType::ListTenants, "List all tenants").def(),
         ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &["create_tenant", "get_tenant", "list_tenants"]
     }
 
     pub async fn dispatch(
@@ -53,13 +37,22 @@ mod tenant_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
+        let request_type: TenantRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
         let system = SystemContext::new(context.config.clone());
 
-        let value = match tool_name {
-            "create_tenant" => TenantService::create(&system, &serde_json::from_str(params)?).await,
-            "get_tenant" => TenantService::get(&system, &serde_json::from_str(params)?).await,
-            "list_tenants" => TenantService::list(&system, &serde_json::from_str(params)?).await,
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+        let value = match request_type {
+            TenantRequestType::CreateTenant => {
+                TenantService::create(&system, &serde_json::from_str(params)?).await
+            }
+            TenantRequestType::GetTenant => {
+                TenantService::get(&system, &serde_json::from_str(params)?).await
+            }
+            TenantRequestType::ListTenants => {
+                TenantService::list(&system, &serde_json::from_str(params)?).await
+            }
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/tenant/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/tenant/protocol/events.rs
@@ -1,9 +1,24 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = TenantEventsType, display = "kebab-case")]
 pub enum TenantEvents {
     TenantCreated(Tenant),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        assert_eq!(
+            &TenantEventsType::TenantCreated.to_string(),
+            "tenant-created"
+        );
+    }
 }

--- a/crates/oneiros-engine/src/domains/tenant/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/tenant/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = TenantResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum TenantResponse {
     Created(Response<Tenant>),

--- a/crates/oneiros-engine/src/domains/texture/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/texture/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct TextureTools;
 
 impl TextureTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         texture_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        texture_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,37 +20,25 @@ impl TextureTools {
 mod texture_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "set_texture",
-                description: "Define a quality of thought",
-                input_schema: schema_for::<SetTexture>,
-            },
-            ToolDef {
-                name: "get_texture",
-                description: "Look up a thought category",
-                input_schema: schema_for::<GetTexture>,
-            },
-            ToolDef {
-                name: "list_textures",
-                description: "See all the ways thoughts can be textured",
-                input_schema: schema_for::<ListTextures>,
-            },
-            ToolDef {
-                name: "remove_texture",
-                description: "Remove a thought category",
-                input_schema: schema_for::<RemoveTexture>,
-            },
-        ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &[
-            "set_texture",
-            "get_texture",
-            "list_textures",
-            "remove_texture",
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<SetTexture>::new(
+                TextureRequestType::SetTexture,
+                "Define a quality of thought",
+            )
+            .def(),
+            Tool::<GetTexture>::new(TextureRequestType::GetTexture, "Look up a thought category")
+                .def(),
+            Tool::<ListTextures>::new(
+                TextureRequestType::ListTextures,
+                "See all the ways thoughts can be textured",
+            )
+            .def(),
+            Tool::<RemoveTexture>::new(
+                TextureRequestType::RemoveTexture,
+                "Remove a thought category",
+            )
+            .def(),
         ]
     }
 
@@ -63,14 +47,23 @@ mod texture_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "set_texture" => TextureService::set(context, &serde_json::from_str(params)?).await,
-            "get_texture" => TextureService::get(context, &serde_json::from_str(params)?).await,
-            "list_textures" => TextureService::list(context, &serde_json::from_str(params)?).await,
-            "remove_texture" => {
+        let request_type: TextureRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            TextureRequestType::SetTexture => {
+                TextureService::set(context, &serde_json::from_str(params)?).await
+            }
+            TextureRequestType::GetTexture => {
+                TextureService::get(context, &serde_json::from_str(params)?).await
+            }
+            TextureRequestType::ListTextures => {
+                TextureService::list(context, &serde_json::from_str(params)?).await
+            }
+            TextureRequestType::RemoveTexture => {
                 TextureService::remove(context, &serde_json::from_str(params)?).await
             }
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/texture/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/texture/protocol/events.rs
@@ -1,12 +1,30 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = TextureEventsType, display = "kebab-case")]
 pub enum TextureEvents {
     TextureSet(Texture),
     TextureRemoved(TextureRemoved),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        let cases = [
+            (TextureEventsType::TextureSet, "texture-set"),
+            (TextureEventsType::TextureRemoved, "texture-removed"),
+        ];
+        for (event_type, expectation) in cases {
+            assert_eq!(&event_type.to_string(), expectation);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/oneiros-engine/src/domains/texture/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/texture/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = TextureResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum TextureResponse {
     TextureSet(TextureName),

--- a/crates/oneiros-engine/src/domains/ticket/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/ticket/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct TicketTools;
 
 impl TicketTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         ticket_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        ticket_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,37 +20,24 @@ impl TicketTools {
 mod ticket_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "create_ticket",
-                description: "Issue a new ticket for an actor and brain",
-                input_schema: schema_for::<CreateTicket>,
-            },
-            ToolDef {
-                name: "get_ticket",
-                description: "Look up a specific ticket by ID",
-                input_schema: schema_for::<GetTicket>,
-            },
-            ToolDef {
-                name: "list_tickets",
-                description: "List all tickets",
-                input_schema: schema_for::<ListTickets>,
-            },
-            ToolDef {
-                name: "validate_ticket",
-                description: "Validate a ticket token",
-                input_schema: schema_for::<ValidateTicket>,
-            },
-        ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &[
-            "create_ticket",
-            "get_ticket",
-            "list_tickets",
-            "validate_ticket",
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<CreateTicket>::new(
+                TicketRequestType::CreateTicket,
+                "Issue a new ticket for an actor and brain",
+            )
+            .def(),
+            Tool::<GetTicket>::new(
+                TicketRequestType::GetTicket,
+                "Look up a specific ticket by ID",
+            )
+            .def(),
+            Tool::<ListTickets>::new(TicketRequestType::ListTickets, "List all tickets").def(),
+            Tool::<ValidateTicket>::new(
+                TicketRequestType::ValidateTicket,
+                "Validate a ticket token",
+            )
+            .def(),
         ]
     }
 
@@ -63,16 +46,25 @@ mod ticket_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
+        let request_type: TicketRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
         let system = SystemContext::new(context.config.clone());
 
-        let value = match tool_name {
-            "create_ticket" => TicketService::create(&system, &serde_json::from_str(params)?).await,
-            "get_ticket" => TicketService::get(&system, &serde_json::from_str(params)?).await,
-            "list_tickets" => TicketService::list(&system, &serde_json::from_str(params)?).await,
-            "validate_ticket" => {
+        let value = match request_type {
+            TicketRequestType::CreateTicket => {
+                TicketService::create(&system, &serde_json::from_str(params)?).await
+            }
+            TicketRequestType::GetTicket => {
+                TicketService::get(&system, &serde_json::from_str(params)?).await
+            }
+            TicketRequestType::ListTickets => {
+                TicketService::list(&system, &serde_json::from_str(params)?).await
+            }
+            TicketRequestType::ValidateTicket => {
                 TicketService::validate(&system, &serde_json::from_str(params)?).await
             }
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/ticket/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/ticket/protocol/events.rs
@@ -1,9 +1,21 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = TicketEventsType, display = "kebab-case")]
 pub enum TicketEvents {
     TicketIssued(Ticket),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        assert_eq!(&TicketEventsType::TicketIssued.to_string(), "ticket-issued");
+    }
 }

--- a/crates/oneiros-engine/src/domains/ticket/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/ticket/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = TicketResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum TicketResponse {
     Created(Ticket),

--- a/crates/oneiros-engine/src/domains/urge/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/urge/features/mcp.rs
@@ -3,12 +3,8 @@ use crate::*;
 pub struct UrgeTools;
 
 impl UrgeTools {
-    pub const fn defs(&self) -> &'static [ToolDef] {
+    pub fn defs(&self) -> Vec<ToolDef> {
         urge_mcp::tool_defs()
-    }
-
-    pub const fn names(&self) -> &'static [&'static str] {
-        urge_mcp::tool_names()
     }
 
     pub async fn dispatch(
@@ -24,33 +20,13 @@ impl UrgeTools {
 mod urge_mcp {
     use crate::*;
 
-    pub const fn tool_defs() -> &'static [ToolDef] {
-        &[
-            ToolDef {
-                name: "set_urge",
-                description: "Define a cognitive drive",
-                input_schema: schema_for::<SetUrge>,
-            },
-            ToolDef {
-                name: "get_urge",
-                description: "Look up a cognitive drive",
-                input_schema: schema_for::<GetUrge>,
-            },
-            ToolDef {
-                name: "list_urges",
-                description: "See all cognitive drives",
-                input_schema: schema_for::<ListUrges>,
-            },
-            ToolDef {
-                name: "remove_urge",
-                description: "Remove a cognitive drive",
-                input_schema: schema_for::<RemoveUrge>,
-            },
+    pub fn tool_defs() -> Vec<ToolDef> {
+        vec![
+            Tool::<SetUrge>::new(UrgeRequestType::SetUrge, "Define a cognitive drive").def(),
+            Tool::<GetUrge>::new(UrgeRequestType::GetUrge, "Look up a cognitive drive").def(),
+            Tool::<ListUrges>::new(UrgeRequestType::ListUrges, "See all cognitive drives").def(),
+            Tool::<RemoveUrge>::new(UrgeRequestType::RemoveUrge, "Remove a cognitive drive").def(),
         ]
-    }
-
-    pub const fn tool_names() -> &'static [&'static str] {
-        &["set_urge", "get_urge", "list_urges", "remove_urge"]
     }
 
     pub async fn dispatch(
@@ -58,12 +34,23 @@ mod urge_mcp {
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        let value = match tool_name {
-            "set_urge" => UrgeService::set(context, &serde_json::from_str(params)?).await,
-            "get_urge" => UrgeService::get(context, &serde_json::from_str(params)?).await,
-            "list_urges" => UrgeService::list(context, &serde_json::from_str(params)?).await,
-            "remove_urge" => UrgeService::remove(context, &serde_json::from_str(params)?).await,
-            _ => return Err(ToolError::UnknownTool(tool_name.to_string())),
+        let request_type: UrgeRequestType = tool_name
+            .parse()
+            .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
+
+        let value = match request_type {
+            UrgeRequestType::SetUrge => {
+                UrgeService::set(context, &serde_json::from_str(params)?).await
+            }
+            UrgeRequestType::GetUrge => {
+                UrgeService::get(context, &serde_json::from_str(params)?).await
+            }
+            UrgeRequestType::ListUrges => {
+                UrgeService::list(context, &serde_json::from_str(params)?).await
+            }
+            UrgeRequestType::RemoveUrge => {
+                UrgeService::remove(context, &serde_json::from_str(params)?).await
+            }
         }
         .map_err(Error::from)?;
 

--- a/crates/oneiros-engine/src/domains/urge/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/urge/protocol/events.rs
@@ -1,12 +1,30 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = UrgeEventsType, display = "kebab-case")]
 pub enum UrgeEvents {
     UrgeSet(Urge),
     UrgeRemoved(UrgeRemoved),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_types_are_kebab_cased() {
+        let cases = [
+            (UrgeEventsType::UrgeSet, "urge-set"),
+            (UrgeEventsType::UrgeRemoved, "urge-removed"),
+        ];
+        for (event_type, expectation) in cases {
+            assert_eq!(&event_type.to_string(), expectation);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/oneiros-engine/src/domains/urge/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/urge/protocol/responses.rs
@@ -1,8 +1,10 @@
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[kinded(kind = UrgeResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum UrgeResponse {
     UrgeSet(UrgeName),

--- a/crates/oneiros-engine/src/macros/collects_enum.rs
+++ b/crates/oneiros-engine/src/macros/collects_enum.rs
@@ -1,0 +1,13 @@
+macro_rules! collects_enum {
+    ($($root:ident::$variant:ident => $base:ident),* $(,)?) => {
+        $(
+            impl From<$base> for $root {
+                fn from(given_base: $base) -> Self {
+                    $root::$variant(given_base)
+                }
+            }
+        )*
+    };
+}
+
+pub(crate) use collects_enum;

--- a/crates/oneiros-engine/src/macros/mod.rs
+++ b/crates/oneiros-engine/src/macros/mod.rs
@@ -1,5 +1,7 @@
+mod collects_enum;
 mod resource_id;
 mod resource_name;
 
+pub(crate) use collects_enum::collects_enum;
 pub(crate) use resource_id::resource_id;
 pub(crate) use resource_name::resource_name;

--- a/crates/oneiros-engine/src/mcp.rs
+++ b/crates/oneiros-engine/src/mcp.rs
@@ -39,8 +39,8 @@ pub enum ToolError {
 }
 
 /// Collect all tool definitions from every domain's catalog.
-fn all_tools() -> Vec<&'static ToolDef> {
-    let sources: &[&[ToolDef]] = &[
+fn all_tools() -> Vec<ToolDef> {
+    [
         ActorTools.defs(),
         TenantTools.defs(),
         BrainTools.defs(),
@@ -61,9 +61,10 @@ fn all_tools() -> Vec<&'static ToolDef> {
         SearchTools.defs(),
         StorageTools.defs(),
         PressureTools.defs(),
-    ];
-
-    sources.iter().flat_map(|s| s.iter()).collect()
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
 }
 
 /// Domain dispatch table — routes tool names to domain dispatchers.
@@ -77,7 +78,7 @@ async fn dispatch(
     params: &str,
 ) -> Result<serde_json::Value, ToolError> {
     // Bookmark tools — need ServerState for CanonIndex
-    if BookmarkTools.names().contains(&tool_name) {
+    if tool_name.parse::<BookmarkRequestType>().is_ok() {
         return BookmarkTools.dispatch(state, tool_name, params).await;
     }
 
@@ -87,62 +88,62 @@ async fn dispatch(
         .map_err(|e| ToolError::Domain(e.to_string()))?;
 
     // System domains
-    if ActorTools.names().contains(&tool_name) {
+    if tool_name.parse::<ActorRequestType>().is_ok() {
         return ActorTools.dispatch(&context, tool_name, params).await;
     }
-    if TenantTools.names().contains(&tool_name) {
+    if tool_name.parse::<TenantRequestType>().is_ok() {
         return TenantTools.dispatch(&context, tool_name, params).await;
     }
-    if BrainTools.names().contains(&tool_name) {
+    if tool_name.parse::<BrainRequestType>().is_ok() {
         return BrainTools.dispatch(&context, tool_name, params).await;
     }
-    if TicketTools.names().contains(&tool_name) {
+    if tool_name.parse::<TicketRequestType>().is_ok() {
         return TicketTools.dispatch(&context, tool_name, params).await;
     }
     // Project domains
-    if LevelTools.names().contains(&tool_name) {
+    if tool_name.parse::<LevelRequestType>().is_ok() {
         return LevelTools.dispatch(&context, tool_name, params).await;
     }
-    if TextureTools.names().contains(&tool_name) {
+    if tool_name.parse::<TextureRequestType>().is_ok() {
         return TextureTools.dispatch(&context, tool_name, params).await;
     }
-    if SensationTools.names().contains(&tool_name) {
+    if tool_name.parse::<SensationRequestType>().is_ok() {
         return SensationTools.dispatch(&context, tool_name, params).await;
     }
-    if NatureTools.names().contains(&tool_name) {
+    if tool_name.parse::<NatureRequestType>().is_ok() {
         return NatureTools.dispatch(&context, tool_name, params).await;
     }
-    if PersonaTools.names().contains(&tool_name) {
+    if tool_name.parse::<PersonaRequestType>().is_ok() {
         return PersonaTools.dispatch(&context, tool_name, params).await;
     }
-    if UrgeTools.names().contains(&tool_name) {
+    if tool_name.parse::<UrgeRequestType>().is_ok() {
         return UrgeTools.dispatch(&context, tool_name, params).await;
     }
-    if AgentTools.names().contains(&tool_name) {
+    if tool_name.parse::<AgentRequestType>().is_ok() {
         return AgentTools.dispatch(&context, tool_name, params).await;
     }
-    if CognitionTools.names().contains(&tool_name) {
+    if tool_name.parse::<CognitionRequestType>().is_ok() {
         return CognitionTools.dispatch(&context, tool_name, params).await;
     }
-    if MemoryTools.names().contains(&tool_name) {
+    if tool_name.parse::<MemoryRequestType>().is_ok() {
         return MemoryTools.dispatch(&context, tool_name, params).await;
     }
-    if ExperienceTools.names().contains(&tool_name) {
+    if tool_name.parse::<ExperienceRequestType>().is_ok() {
         return ExperienceTools.dispatch(&context, tool_name, params).await;
     }
-    if ConnectionTools.names().contains(&tool_name) {
+    if tool_name.parse::<ConnectionRequestType>().is_ok() {
         return ConnectionTools.dispatch(&context, tool_name, params).await;
     }
-    if ContinuityTools.names().contains(&tool_name) {
+    if tool_name.parse::<ContinuityRequestType>().is_ok() {
         return ContinuityTools.dispatch(&context, tool_name, params).await;
     }
-    if SearchTools.names().contains(&tool_name) {
+    if tool_name.parse::<SearchRequestType>().is_ok() {
         return SearchTools.dispatch(&context, tool_name, params).await;
     }
-    if StorageTools.names().contains(&tool_name) {
+    if tool_name.parse::<StorageRequestType>().is_ok() {
         return StorageTools.dispatch(&context, tool_name, params).await;
     }
-    if PressureTools.names().contains(&tool_name) {
+    if tool_name.parse::<PressureRequestType>().is_ok() {
         return PressureTools.dispatch(&context, tool_name, params).await;
     }
 
@@ -240,10 +241,10 @@ impl ServerHandler for EngineToolBox {
             .into_iter()
             .map(|t| {
                 let mut tool = Tool::default();
-                tool.name = t.name.into();
-                tool.description = Some(t.description.into());
-                tool.input_schema = serde_json::from_value((t.input_schema)())
-                    .expect("schema should be a JSON object");
+                tool.name = t.name.to_string().into();
+                tool.description = Some(t.description.to_string().into());
+                tool.input_schema =
+                    serde_json::from_value(t.input_schema).expect("schema should be a JSON object");
                 tool
             })
             .collect();

--- a/crates/oneiros-engine/src/protocol/events.rs
+++ b/crates/oneiros-engine/src/protocol/events.rs
@@ -4,6 +4,7 @@
 //! a single `Events` type that the store persists. The `Unknown` variant
 //! catches events from newer versions during replay.
 
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
@@ -44,8 +45,9 @@ pub enum Events {
 /// These carry data between brains during export/import but are materialized
 /// directly at the import boundary. They never enter the event log and are
 /// never seen by projections.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Kinded)]
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
+#[kinded(kind = EphemeralEventsType, display = "kebab-case")]
 pub enum EphemeralEvents {
     /// Carries compressed blob binary for export/import portability.
     BlobStored(BlobContent),
@@ -56,203 +58,50 @@ impl Events {
     ///
     /// This is the same string that appears in the JSON representation and
     /// is stored in the `event_type` column for query indexing.
-    pub fn event_type(&self) -> &'static str {
+    pub fn event_type(&self) -> String {
         match self {
-            Events::Level(e) => match e {
-                LevelEvents::LevelSet(_) => "level-set",
-                LevelEvents::LevelRemoved(_) => "level-removed",
-            },
-            Events::Texture(e) => match e {
-                TextureEvents::TextureSet(_) => "texture-set",
-                TextureEvents::TextureRemoved(_) => "texture-removed",
-            },
-            Events::Sensation(e) => match e {
-                SensationEvents::SensationSet(_) => "sensation-set",
-                SensationEvents::SensationRemoved(_) => "sensation-removed",
-            },
-            Events::Nature(e) => match e {
-                NatureEvents::NatureSet(_) => "nature-set",
-                NatureEvents::NatureRemoved(_) => "nature-removed",
-            },
-            Events::Persona(e) => match e {
-                PersonaEvents::PersonaSet(_) => "persona-set",
-                PersonaEvents::PersonaRemoved(_) => "persona-removed",
-            },
-            Events::Urge(e) => match e {
-                UrgeEvents::UrgeSet(_) => "urge-set",
-                UrgeEvents::UrgeRemoved(_) => "urge-removed",
-            },
-            Events::Agent(e) => match e {
-                AgentEvents::AgentCreated(_) => "agent-created",
-                AgentEvents::AgentUpdated(_) => "agent-updated",
-                AgentEvents::AgentRemoved(_) => "agent-removed",
-            },
-            Events::Cognition(e) => match e {
-                CognitionEvents::CognitionAdded(_) => "cognition-added",
-            },
-            Events::Memory(e) => match e {
-                MemoryEvents::MemoryAdded(_) => "memory-added",
-            },
-            Events::Experience(e) => match e {
-                ExperienceEvents::ExperienceCreated(_) => "experience-created",
-                ExperienceEvents::ExperienceDescriptionUpdated(_) => {
-                    "experience-description-updated"
-                }
-                ExperienceEvents::ExperienceSensationUpdated(_) => "experience-sensation-updated",
-            },
-            Events::Connection(e) => match e {
-                ConnectionEvents::ConnectionCreated(_) => "connection-created",
-                ConnectionEvents::ConnectionRemoved(_) => "connection-removed",
-            },
-            Events::Storage(e) => match e {
-                StorageEvents::StorageSet(_) => "storage-set",
-                StorageEvents::StorageRemoved(_) => "storage-removed",
-            },
-            Events::Continuity(e) => match e {
-                ContinuityEvents::Dreamed(_) => "dreamed",
-                ContinuityEvents::Introspected(_) => "introspected",
-                ContinuityEvents::Reflected(_) => "reflected",
-                ContinuityEvents::Sensed(_) => "sensed",
-                ContinuityEvents::Slept(_) => "slept",
-            },
-            Events::Tenant(e) => match e {
-                TenantEvents::TenantCreated(_) => "tenant-created",
-            },
-            Events::Actor(e) => match e {
-                ActorEvents::ActorCreated(_) => "actor-created",
-            },
-            Events::Brain(e) => match e {
-                BrainEvents::BrainCreated(_) => "brain-created",
-            },
-            Events::Ticket(e) => match e {
-                TicketEvents::TicketIssued(_) => "ticket-issued",
-            },
-            Events::Bookmark(e) => match e {
-                BookmarkEvents::BookmarkCreated(_) => "bookmark-created",
-                BookmarkEvents::BookmarkForked(_) => "bookmark-forked",
-                BookmarkEvents::BookmarkSwitched(_) => "bookmark-switched",
-                BookmarkEvents::BookmarkMerged(_) => "bookmark-merged",
-            },
-            Events::Ephemeral(e) => match e {
-                EphemeralEvents::BlobStored(_) => "blob-stored",
-            },
-            Events::Unknown(_) => "unknown",
+            Events::Level(e) => e.kind().to_string(),
+            Events::Texture(e) => e.kind().to_string(),
+            Events::Sensation(e) => e.kind().to_string(),
+            Events::Nature(e) => e.kind().to_string(),
+            Events::Persona(e) => e.kind().to_string(),
+            Events::Urge(e) => e.kind().to_string(),
+            Events::Agent(e) => e.kind().to_string(),
+            Events::Cognition(e) => e.kind().to_string(),
+            Events::Memory(e) => e.kind().to_string(),
+            Events::Experience(e) => e.kind().to_string(),
+            Events::Connection(e) => e.kind().to_string(),
+            Events::Storage(e) => e.kind().to_string(),
+            Events::Continuity(e) => e.kind().to_string(),
+            Events::Tenant(e) => e.kind().to_string(),
+            Events::Actor(e) => e.kind().to_string(),
+            Events::Brain(e) => e.kind().to_string(),
+            Events::Ticket(e) => e.kind().to_string(),
+            Events::Bookmark(e) => e.kind().to_string(),
+            Events::Ephemeral(e) => e.kind().to_string(),
+            Events::Unknown(_) => "unknown".to_string(),
         }
     }
 }
 
-// ── From impls ───────────────────────────────────────────────────
-
-impl From<LevelEvents> for Events {
-    fn from(e: LevelEvents) -> Self {
-        Events::Level(e)
-    }
-}
-
-impl From<TextureEvents> for Events {
-    fn from(e: TextureEvents) -> Self {
-        Events::Texture(e)
-    }
-}
-
-impl From<SensationEvents> for Events {
-    fn from(e: SensationEvents) -> Self {
-        Events::Sensation(e)
-    }
-}
-
-impl From<NatureEvents> for Events {
-    fn from(e: NatureEvents) -> Self {
-        Events::Nature(e)
-    }
-}
-
-impl From<PersonaEvents> for Events {
-    fn from(e: PersonaEvents) -> Self {
-        Events::Persona(e)
-    }
-}
-
-impl From<UrgeEvents> for Events {
-    fn from(e: UrgeEvents) -> Self {
-        Events::Urge(e)
-    }
-}
-
-impl From<AgentEvents> for Events {
-    fn from(e: AgentEvents) -> Self {
-        Events::Agent(e)
-    }
-}
-
-impl From<CognitionEvents> for Events {
-    fn from(e: CognitionEvents) -> Self {
-        Events::Cognition(e)
-    }
-}
-
-impl From<MemoryEvents> for Events {
-    fn from(e: MemoryEvents) -> Self {
-        Events::Memory(e)
-    }
-}
-
-impl From<ExperienceEvents> for Events {
-    fn from(e: ExperienceEvents) -> Self {
-        Events::Experience(e)
-    }
-}
-
-impl From<ConnectionEvents> for Events {
-    fn from(e: ConnectionEvents) -> Self {
-        Events::Connection(e)
-    }
-}
-
-impl From<StorageEvents> for Events {
-    fn from(e: StorageEvents) -> Self {
-        Events::Storage(e)
-    }
-}
-
-impl From<ContinuityEvents> for Events {
-    fn from(e: ContinuityEvents) -> Self {
-        Events::Continuity(e)
-    }
-}
-
-impl From<TenantEvents> for Events {
-    fn from(e: TenantEvents) -> Self {
-        Events::Tenant(e)
-    }
-}
-
-impl From<ActorEvents> for Events {
-    fn from(e: ActorEvents) -> Self {
-        Events::Actor(e)
-    }
-}
-
-impl From<BrainEvents> for Events {
-    fn from(e: BrainEvents) -> Self {
-        Events::Brain(e)
-    }
-}
-
-impl From<TicketEvents> for Events {
-    fn from(e: TicketEvents) -> Self {
-        Events::Ticket(e)
-    }
-}
-
-impl From<BookmarkEvents> for Events {
-    fn from(e: BookmarkEvents) -> Self {
-        Events::Bookmark(e)
-    }
-}
-
-impl From<EphemeralEvents> for Events {
-    fn from(e: EphemeralEvents) -> Self {
-        Events::Ephemeral(e)
-    }
-}
+collects_enum!(
+    Events::Level => LevelEvents,
+    Events::Texture => TextureEvents,
+    Events::Sensation => SensationEvents,
+    Events::Nature => NatureEvents,
+    Events::Persona => PersonaEvents,
+    Events::Urge => UrgeEvents,
+    Events::Agent => AgentEvents,
+    Events::Cognition => CognitionEvents,
+    Events::Memory => MemoryEvents,
+    Events::Experience => ExperienceEvents,
+    Events::Connection => ConnectionEvents,
+    Events::Storage => StorageEvents,
+    Events::Continuity => ContinuityEvents,
+    Events::Tenant => TenantEvents,
+    Events::Actor => ActorEvents,
+    Events::Brain => BrainEvents,
+    Events::Ticket => TicketEvents,
+    Events::Bookmark => BookmarkEvents,
+    Events::Ephemeral => EphemeralEvents,
+);

--- a/crates/oneiros-engine/src/protocol/requests.rs
+++ b/crates/oneiros-engine/src/protocol/requests.rs
@@ -32,100 +32,24 @@ pub enum Requests {
     Ticket(TicketRequest),
 }
 
-// ── From impls ───────────────────────────────────────────────────
-
-impl From<LevelRequest> for Requests {
-    fn from(r: LevelRequest) -> Self {
-        Requests::Level(r)
-    }
-}
-impl From<TextureRequest> for Requests {
-    fn from(r: TextureRequest) -> Self {
-        Requests::Texture(r)
-    }
-}
-impl From<SensationRequest> for Requests {
-    fn from(r: SensationRequest) -> Self {
-        Requests::Sensation(r)
-    }
-}
-impl From<NatureRequest> for Requests {
-    fn from(r: NatureRequest) -> Self {
-        Requests::Nature(r)
-    }
-}
-impl From<PersonaRequest> for Requests {
-    fn from(r: PersonaRequest) -> Self {
-        Requests::Persona(r)
-    }
-}
-impl From<UrgeRequest> for Requests {
-    fn from(r: UrgeRequest) -> Self {
-        Requests::Urge(r)
-    }
-}
-impl From<AgentRequest> for Requests {
-    fn from(r: AgentRequest) -> Self {
-        Requests::Agent(r)
-    }
-}
-impl From<CognitionRequest> for Requests {
-    fn from(r: CognitionRequest) -> Self {
-        Requests::Cognition(r)
-    }
-}
-impl From<MemoryRequest> for Requests {
-    fn from(r: MemoryRequest) -> Self {
-        Requests::Memory(r)
-    }
-}
-impl From<ExperienceRequest> for Requests {
-    fn from(r: ExperienceRequest) -> Self {
-        Requests::Experience(r)
-    }
-}
-impl From<ConnectionRequest> for Requests {
-    fn from(r: ConnectionRequest) -> Self {
-        Requests::Connection(r)
-    }
-}
-impl From<StorageRequest> for Requests {
-    fn from(r: StorageRequest) -> Self {
-        Requests::Storage(r)
-    }
-}
-impl From<ContinuityRequest> for Requests {
-    fn from(r: ContinuityRequest) -> Self {
-        Requests::Continuity(r)
-    }
-}
-impl From<PressureRequest> for Requests {
-    fn from(r: PressureRequest) -> Self {
-        Requests::Pressure(r)
-    }
-}
-impl From<SearchRequest> for Requests {
-    fn from(r: SearchRequest) -> Self {
-        Requests::Search(r)
-    }
-}
-impl From<TenantRequest> for Requests {
-    fn from(r: TenantRequest) -> Self {
-        Requests::Tenant(r)
-    }
-}
-impl From<ActorRequest> for Requests {
-    fn from(r: ActorRequest) -> Self {
-        Requests::Actor(r)
-    }
-}
-impl From<BrainRequest> for Requests {
-    fn from(r: BrainRequest) -> Self {
-        Requests::Brain(r)
-    }
-}
-impl From<TicketRequest> for Requests {
-    fn from(r: TicketRequest) -> Self {
-        Requests::Ticket(r)
-    }
-}
+collects_enum!(
+    Requests::Level => LevelRequest,
+    Requests::Texture => TextureRequest,
+    Requests::Sensation => SensationRequest,
+    Requests::Nature => NatureRequest,
+    Requests::Persona => PersonaRequest,
+    Requests::Urge => UrgeRequest,
+    Requests::Agent => AgentRequest,
+    Requests::Cognition => CognitionRequest,
+    Requests::Memory => MemoryRequest,
+    Requests::Experience => ExperienceRequest,
+    Requests::Connection => ConnectionRequest,
+    Requests::Storage => StorageRequest,
+    Requests::Continuity => ContinuityRequest,
+    Requests::Pressure => PressureRequest,
+    Requests::Search => SearchRequest,
+    Requests::Tenant => TenantRequest,
+    Requests::Actor => ActorRequest,
+    Requests::Brain => BrainRequest,
+    Requests::Ticket => TicketRequest,
+);

--- a/crates/oneiros-engine/src/protocol/responses.rs
+++ b/crates/oneiros-engine/src/protocol/responses.rs
@@ -42,149 +42,34 @@ pub enum Responses {
     Service(ServiceResponse),
     McpConfig(McpConfigResponse),
     Setup(SetupResponse),
-    /// Escape hatch for composite operations that don't map to a single domain response.
-    Json(serde_json::Value),
 }
 
-// ── From impls ───────────────────────────────────────────────────
-
-impl From<LevelResponse> for Responses {
-    fn from(r: LevelResponse) -> Self {
-        Responses::Level(r)
-    }
-}
-impl From<TextureResponse> for Responses {
-    fn from(r: TextureResponse) -> Self {
-        Responses::Texture(r)
-    }
-}
-impl From<SensationResponse> for Responses {
-    fn from(r: SensationResponse) -> Self {
-        Responses::Sensation(r)
-    }
-}
-impl From<NatureResponse> for Responses {
-    fn from(r: NatureResponse) -> Self {
-        Responses::Nature(r)
-    }
-}
-impl From<PersonaResponse> for Responses {
-    fn from(r: PersonaResponse) -> Self {
-        Responses::Persona(r)
-    }
-}
-impl From<UrgeResponse> for Responses {
-    fn from(r: UrgeResponse) -> Self {
-        Responses::Urge(r)
-    }
-}
-impl From<AgentResponse> for Responses {
-    fn from(r: AgentResponse) -> Self {
-        Responses::Agent(r)
-    }
-}
-impl From<CognitionResponse> for Responses {
-    fn from(r: CognitionResponse) -> Self {
-        Responses::Cognition(r)
-    }
-}
-impl From<MemoryResponse> for Responses {
-    fn from(r: MemoryResponse) -> Self {
-        Responses::Memory(r)
-    }
-}
-impl From<ExperienceResponse> for Responses {
-    fn from(r: ExperienceResponse) -> Self {
-        Responses::Experience(r)
-    }
-}
-impl From<ConnectionResponse> for Responses {
-    fn from(r: ConnectionResponse) -> Self {
-        Responses::Connection(r)
-    }
-}
-impl From<StorageResponse> for Responses {
-    fn from(r: StorageResponse) -> Self {
-        Responses::Storage(r)
-    }
-}
-impl From<ContinuityResponse> for Responses {
-    fn from(r: ContinuityResponse) -> Self {
-        Responses::Continuity(r)
-    }
-}
-impl From<PressureResponse> for Responses {
-    fn from(r: PressureResponse) -> Self {
-        Responses::Pressure(r)
-    }
-}
-impl From<SearchResponse> for Responses {
-    fn from(r: SearchResponse) -> Self {
-        Responses::Search(r)
-    }
-}
-impl From<TenantResponse> for Responses {
-    fn from(r: TenantResponse) -> Self {
-        Responses::Tenant(r)
-    }
-}
-impl From<ActorResponse> for Responses {
-    fn from(r: ActorResponse) -> Self {
-        Responses::Actor(r)
-    }
-}
-impl From<BrainResponse> for Responses {
-    fn from(r: BrainResponse) -> Self {
-        Responses::Brain(r)
-    }
-}
-impl From<TicketResponse> for Responses {
-    fn from(r: TicketResponse) -> Self {
-        Responses::Ticket(r)
-    }
-}
-impl From<ProjectResponse> for Responses {
-    fn from(r: ProjectResponse) -> Self {
-        Responses::Project(r)
-    }
-}
-impl From<ServiceResponse> for Responses {
-    fn from(r: ServiceResponse) -> Self {
-        Responses::Service(r)
-    }
-}
-impl From<serde_json::Value> for Responses {
-    fn from(r: serde_json::Value) -> Self {
-        Responses::Json(r)
-    }
-}
-impl From<SeedResponse> for Responses {
-    fn from(r: SeedResponse) -> Self {
-        Responses::Seed(r)
-    }
-}
-impl From<DoctorResponse> for Responses {
-    fn from(r: DoctorResponse) -> Self {
-        Responses::Doctor(r)
-    }
-}
-impl From<SystemResponse> for Responses {
-    fn from(r: SystemResponse) -> Self {
-        Responses::System(r)
-    }
-}
-impl From<McpConfigResponse> for Responses {
-    fn from(r: McpConfigResponse) -> Self {
-        Responses::McpConfig(r)
-    }
-}
-impl From<BookmarkResponse> for Responses {
-    fn from(r: BookmarkResponse) -> Self {
-        Responses::Bookmark(r)
-    }
-}
-impl From<SetupResponse> for Responses {
-    fn from(r: SetupResponse) -> Self {
-        Responses::Setup(r)
-    }
-}
+collects_enum!(
+    Responses::Level => LevelResponse,
+    Responses::Texture => TextureResponse,
+    Responses::Sensation => SensationResponse,
+    Responses::Nature => NatureResponse,
+    Responses::Persona => PersonaResponse,
+    Responses::Urge => UrgeResponse,
+    Responses::Agent => AgentResponse,
+    Responses::Cognition => CognitionResponse,
+    Responses::Memory => MemoryResponse,
+    Responses::Experience => ExperienceResponse,
+    Responses::Connection => ConnectionResponse,
+    Responses::Storage => StorageResponse,
+    Responses::Continuity => ContinuityResponse,
+    Responses::Pressure => PressureResponse,
+    Responses::Search => SearchResponse,
+    Responses::Tenant => TenantResponse,
+    Responses::Actor => ActorResponse,
+    Responses::Brain => BrainResponse,
+    Responses::Ticket => TicketResponse,
+    Responses::Project => ProjectResponse,
+    Responses::Service => ServiceResponse,
+    Responses::Seed => SeedResponse,
+    Responses::Doctor => DoctorResponse,
+    Responses::System => SystemResponse,
+    Responses::McpConfig => McpConfigResponse,
+    Responses::Bookmark => BookmarkResponse,
+    Responses::Setup => SetupResponse,
+);

--- a/crates/oneiros-engine/src/tests/workflows/continuity.rs
+++ b/crates/oneiros-engine/src/tests/workflows/continuity.rs
@@ -590,18 +590,18 @@ async fn activity_stream_observes_events() -> Result<(), Box<dyn core::error::Er
 
     assert!(!events.is_empty(), "SSE stream should have received events");
 
-    let event_types: Vec<&str> = events.iter().map(|e| e.data.event_type()).collect();
+    let event_types: Vec<String> = events.iter().map(|e| e.data.event_type()).collect();
 
     assert!(
-        event_types.contains(&"agent-created"),
+        event_types.iter().any(|t| t == "agent-created"),
         "stream should contain agent-created, got: {event_types:?}"
     );
     assert!(
-        event_types.contains(&"cognition-added"),
+        event_types.iter().any(|t| t == "cognition-added"),
         "stream should contain cognition-added, got: {event_types:?}"
     );
     assert!(
-        event_types.contains(&"memory-added"),
+        event_types.iter().any(|t| t == "memory-added"),
         "stream should contain memory-added, got: {event_types:?}"
     );
 

--- a/crates/oneiros-engine/src/tests/workflows/mcp.rs
+++ b/crates/oneiros-engine/src/tests/workflows/mcp.rs
@@ -156,12 +156,12 @@ async fn mcp_session() -> Result<(), Box<dyn core::error::Error>> {
 
     // Spot-check across domains
     let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
-    assert!(tool_names.contains(&"create_agent"));
-    assert!(tool_names.contains(&"dream"));
-    assert!(tool_names.contains(&"search"));
-    assert!(tool_names.contains(&"add_cognition"));
-    assert!(tool_names.contains(&"set_level"));
-    assert!(tool_names.contains(&"list_storage"));
+    assert!(tool_names.contains(&"create-agent"));
+    assert!(tool_names.contains(&"dream-agent"));
+    assert!(tool_names.contains(&"search-query"));
+    assert!(tool_names.contains(&"add-cognition"));
+    assert!(tool_names.contains(&"set-level"));
+    assert!(tool_names.contains(&"list-storage"));
 
     // Every tool should have a name and inputSchema
     for tool in tools {
@@ -184,7 +184,7 @@ async fn mcp_session() -> Result<(), Box<dyn core::error::Error>> {
         "id": 3,
         "method": "tools/call",
         "params": {
-            "name": "set_persona",
+            "name": "set-persona",
             "arguments": {
                 "name": "mcp-persona",
                 "description": "Created via MCP",
@@ -270,7 +270,7 @@ async fn mcp_session_auth() -> Result<(), Box<dyn core::error::Error>> {
         &url,
         &session_id,
         3,
-        "set_persona",
+        "set-persona",
         serde_json::json!({
             "name": "auth-persona",
             "description": "Created via authenticated MCP",
@@ -353,7 +353,7 @@ async fn mcp_error_paths() -> Result<(), Box<dyn core::error::Error>> {
         "id": 11,
         "method": "tools/call",
         "params": {
-            "name": "get_agent",
+            "name": "get-agent",
             "arguments": { "wrong_field": "not a name" }
         }
     }));
@@ -380,7 +380,7 @@ async fn mcp_error_paths() -> Result<(), Box<dyn core::error::Error>> {
         "id": 12,
         "method": "tools/call",
         "params": {
-            "name": "get_agent",
+            "name": "get-agent",
             "arguments": { "name": "ghost.nobody" }
         }
     }));

--- a/crates/oneiros-engine/src/values/mod.rs
+++ b/crates/oneiros-engine/src/values/mod.rs
@@ -50,6 +50,7 @@ mod timestamp;
 mod token;
 mod token_version;
 mod tool_def;
+mod tool_name;
 mod verbosity;
 
 pub use agent_activity::*;
@@ -102,5 +103,6 @@ pub use system_canon::*;
 pub use table::*;
 pub use timestamp::*;
 pub use token::*;
-pub use tool_def::{ToolDef, schema_for};
+pub use tool_def::*;
+pub use tool_name::*;
 pub use verbosity::*;

--- a/crates/oneiros-engine/src/values/tool_def.rs
+++ b/crates/oneiros-engine/src/values/tool_def.rs
@@ -1,11 +1,44 @@
-/// A tool definition — name, description, and JSON schema for input parameters.
+use core::fmt;
+use std::marker::PhantomData;
+
+use crate::{Description, ToolName};
+
+/// A type-erased tool definition — name, description, and JSON schema.
 ///
-/// Each domain declares its tools as static slices of ToolDef.
-/// The MCP collector gathers them into the tool catalog.
+/// Produced by `Tool<T>::def()`. The MCP collector gathers these into
+/// the tool catalog.
 pub struct ToolDef {
-    pub name: &'static str,
-    pub description: &'static str,
-    pub input_schema: fn() -> serde_json::Value,
+    pub name: ToolName,
+    pub description: Description,
+    pub input_schema: serde_json::Value,
+}
+
+/// A typed tool — binds a request struct to a name and description.
+///
+/// The type parameter `T` provides the JSON schema via `schemars::JsonSchema`.
+/// The name is derived from the request type's `Display` implementation.
+pub struct Tool<T> {
+    name: ToolName,
+    description: Description,
+    _marker: PhantomData<T>,
+}
+
+impl<T: schemars::JsonSchema> Tool<T> {
+    pub fn new(name: impl fmt::Display, description: impl Into<Description>) -> Self {
+        Self {
+            name: ToolName::new(name),
+            description: description.into(),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn def(&self) -> ToolDef {
+        ToolDef {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            input_schema: schema_for::<T>(),
+        }
+    }
 }
 
 /// Generate a JSON Schema value for a type.

--- a/crates/oneiros-engine/src/values/tool_name.rs
+++ b/crates/oneiros-engine/src/values/tool_name.rs
@@ -1,0 +1,21 @@
+use core::fmt;
+
+/// A typed tool name — derived from a request type's `Display` implementation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolName(String);
+
+impl ToolName {
+    pub fn new(name: impl fmt::Display) -> Self {
+        Self(name.to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ToolName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/tests/usage/tests/acceptance/cases/emerge.rs
+++ b/tests/usage/tests/acceptance/cases/emerge.rs
@@ -13,10 +13,6 @@ pub(crate) async fn creates_and_wakes_agent<B: Backend>() -> TestResult {
         Responses::Continuity(ContinuityResponse::Emerged(ctx)) => {
             assert_eq!(ctx.agent.name, AgentName::new("newborn.process"));
         }
-        // Legacy: inline JSON (will be removed when legacy is retired)
-        Responses::Json(v) => {
-            assert_eq!(v.get("type").and_then(|t| t.as_str()), Some("emerged"));
-        }
         other => panic!("expected Continuity(Emerged) or Json(emerged), got {other:#?}"),
     }
 
@@ -83,10 +79,6 @@ pub(crate) async fn recede_retires_agent<B: Backend>() -> TestResult {
         // Engine: typed continuity response
         Responses::Continuity(ContinuityResponse::Receded(name)) => {
             assert_eq!(*name, AgentName::new("retiring.process"));
-        }
-        // Legacy: inline JSON (will be removed when legacy is retired)
-        Responses::Json(v) => {
-            assert_eq!(v.get("type").and_then(|t| t.as_str()), Some("receded"));
         }
         other => panic!("expected Continuity(Receded) or Json(receded), got {other:#?}"),
     }


### PR DESCRIPTION
- Where strings were doing stuff enums could do for us, we switched to letting enums do it.
- New `collects_enum!` macro lets us put a lot more `From` impls into play without being too sassy about file size.