### PR TITLE
Create a `main` bookmark on project init.

### DIFF
--- a/crates/oneiros-engine/src/domains/project/service.rs
+++ b/crates/oneiros-engine/src/domains/project/service.rs
@@ -29,6 +29,13 @@ impl ProjectService {
         )
         .await?;
 
+        context
+            .emit(BookmarkEvents::BookmarkCreated(BookmarkCreated {
+                brain: brain_name.clone(),
+                name: BookmarkName::main(),
+            }))
+            .await?;
+
         // Ensure brain directory and DB schema exist (mirrors legacy create_brain_db).
         let brain_dir = context.config.data_dir.join(brain_name.as_str());
         std::fs::create_dir_all(&brain_dir)?;

--- a/crates/oneiros-engine/src/tests/harness.rs
+++ b/crates/oneiros-engine/src/tests/harness.rs
@@ -230,4 +230,8 @@ impl TestClient {
     pub fn ticket(&self) -> TicketClient<'_> {
         TicketClient::new(&self.client)
     }
+
+    pub fn bookmark(&self) -> BookmarkClient<'_> {
+        BookmarkClient::new(&self.client)
+    }
 }

--- a/crates/oneiros-engine/src/tests/workflows/bootstrap.rs
+++ b/crates/oneiros-engine/src/tests/workflows/bootstrap.rs
@@ -82,3 +82,38 @@ async fn from_nothing_to_a_dreaming_agent() -> Result<(), Box<dyn core::error::E
 
     Ok(())
 }
+
+/// Project init should produce a "main" bookmark in the system DB.
+///
+/// Nothing implicit: if a resource exists, an event brought it into being
+/// and a projection row reflects it. The default bookmark is no exception.
+#[tokio::test]
+async fn project_init_creates_main_bookmark() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_system()
+        .await?
+        .init_project()
+        .await?;
+
+    let client = app.client();
+    let brain = BrainName::new("test");
+
+    match client
+        .bookmark()
+        .list(&brain, &ListBookmarks::default())
+        .await?
+    {
+        BookmarkResponse::Bookmarks(bookmarks) => {
+            assert_eq!(bookmarks.len(), 1, "exactly one bookmark after init");
+            assert_eq!(
+                bookmarks.items[0].name,
+                BookmarkName::main(),
+                "the bookmark should be named main"
+            );
+        }
+        other => panic!("expected Bookmarks, got {other:?}"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
We needed to do this when we introduced bookmarks, but we made it implicit instead. I ran into the problem when running bookmarks for the first time but treated it as a me problem, since I work with a legacy oneiroi. But then I ran into it with a new system and realized where I'd goofed. This commit resolves the issue so that we've got an actual setup going for bookmarks on the first run experience.