### PR TITLE
Explicit errors. Generate keypair in system init.

### DIFF
--- a/crates/oneiros-engine/src/client.rs
+++ b/crates/oneiros-engine/src/client.rs
@@ -48,23 +48,21 @@ impl Client {
         }
     }
 
-    pub fn with_token(base_url: impl Into<String>, token: Token) -> Self {
-        let http = reqwest::Client::builder()
-            .default_headers({
-                let mut headers = reqwest::header::HeaderMap::new();
-                headers.insert(
-                    reqwest::header::AUTHORIZATION,
-                    format!("Bearer {token}").parse().expect("valid header"),
-                );
-                headers
-            })
-            .build()
-            .expect("build client");
+    pub fn with_token(base_url: impl Into<String>, token: Token) -> Result<Self, ClientError> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        let value = format!("Bearer {token}").parse().map_err(|_| {
+            ClientError::InvalidRequest("token contains invalid header characters".into())
+        })?;
+        headers.insert(reqwest::header::AUTHORIZATION, value);
 
-        Self {
+        let http = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()?;
+
+        Ok(Self {
             http,
             base_url: base_url.into(),
-        }
+        })
     }
 
     pub(crate) fn url(&self, path: &str) -> String {

--- a/crates/oneiros-engine/src/contexts/project.rs
+++ b/crates/oneiros-engine/src/contexts/project.rs
@@ -61,7 +61,8 @@ impl ProjectContext {
     /// project init).
     pub fn client(&self) -> Client {
         match self.config.token() {
-            Some(token) => Client::with_token(self.config.base_url(), token),
+            Some(token) => Client::with_token(self.config.base_url(), token)
+                .unwrap_or_else(|_| Client::new(self.config.base_url())),
             None => Client::new(self.config.base_url()),
         }
     }

--- a/crates/oneiros-engine/src/domains/doctor/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/doctor/protocol/responses.rs
@@ -52,6 +52,8 @@ pub enum DoctorCheck {
     VocabularyMissing,
     AgentsSeeded,
     AgentsMissing,
+    HostKeyOk,
+    HostKeyMissing,
     McpConfigured,
     McpMissing,
     ServiceRunning,

--- a/crates/oneiros-engine/src/domains/doctor/service.rs
+++ b/crates/oneiros-engine/src/domains/doctor/service.rs
@@ -35,6 +35,13 @@ impl DoctorService {
         checks.push(DoctorCheck::Initialized);
         checks.push(DoctorCheck::DatabaseOk(DatabaseLabel::new("system.db")));
 
+        // Host keypair check — identity for distribution
+        if config.host_key_path().exists() {
+            checks.push(DoctorCheck::HostKeyOk);
+        } else {
+            checks.push(DoctorCheck::HostKeyMissing);
+        }
+
         let event_count = db
             .query_row("select count(*) from events", [], |row| {
                 row.get::<_, i64>(0)

--- a/crates/oneiros-engine/src/domains/doctor/view.rs
+++ b/crates/oneiros-engine/src/domains/doctor/view.rs
@@ -57,6 +57,16 @@ impl DoctorView {
                         "—".muted()
                     )
                 }
+                DoctorCheck::HostKeyOk => {
+                    format!("  {} Host keypair present", "✓".success())
+                }
+                DoctorCheck::HostKeyMissing => {
+                    format!(
+                        "  {} Host keypair missing {} run `oneiros system init`",
+                        "!".warning(),
+                        "—".muted()
+                    )
+                }
                 DoctorCheck::McpConfigured => {
                     format!("  {} MCP config present", "✓".success())
                 }

--- a/crates/oneiros-engine/src/domains/system/features/skills/init.md
+++ b/crates/oneiros-engine/src/domains/system/features/skills/init.md
@@ -3,6 +3,6 @@ description: Set up the oneiros host for the first time
 argument-hint: "[--name <name>] [--yes]"
 ---
 
-Run `oneiros system init` to set up the local oneiros host. This creates the system database and default tenant. Use `--name` to specify a host name, or `--yes` to accept defaults without prompting.
+Run `oneiros system init` to set up the local oneiros host. This creates the system database, default tenant, and host keypair. Use `--name` to specify a host name, or `--yes` to accept defaults without prompting.
 
 This is a one-time setup step. Running it again is safe — initialization is idempotent.

--- a/crates/oneiros-engine/src/domains/system/service.rs
+++ b/crates/oneiros-engine/src/domains/system/service.rs
@@ -7,8 +7,11 @@ impl SystemService {
         context: &SystemContext,
         request: &InitSystem,
     ) -> Result<SystemResponse, SystemError> {
-        // system init is the bootstrapper — ensure data dir and schema exist.
+        // system init is the bootstrapper — ensure data dir, schema, and
+        // host keypair all exist. The keypair establishes host identity
+        // before the server ever starts.
         std::fs::create_dir_all(&context.config.data_dir)?;
+        context.config.ensure_host_secret_key()?;
         let db = context.db()?;
         EventLog::new(&db).migrate()?;
         context.projections.migrate(&db)?;

--- a/crates/oneiros-engine/src/engine.rs
+++ b/crates/oneiros-engine/src/engine.rs
@@ -60,7 +60,9 @@ impl Engine {
 
         let server = Server::new(self.config.clone());
         let handle = tokio::spawn(async move {
-            server.serve(listener).await.expect("server failed");
+            if let Err(err) = server.serve(listener).await {
+                eprintln!("server exited with error: {err}");
+            }
         });
 
         Ok(ServerHandle { address, handle })

--- a/crates/oneiros-engine/src/http/state.rs
+++ b/crates/oneiros-engine/src/http/state.rs
@@ -121,14 +121,21 @@ impl FromRequestParts<ServerState> for ProjectContext {
         parts: &mut Parts,
         state: &ServerState,
     ) -> Result<Self, Self::Rejection> {
-        // Extract Bearer token
+        // Extract Bearer token from header, falling back to ?token= query
+        // param. The query fallback exists because browser EventSource
+        // (SSE) cannot set custom headers.
         let token_str = parts
             .headers
             .get("authorization")
             .and_then(|value| value.to_str().ok())
-            .ok_or(AuthError::NoAuthHeader)?
-            .strip_prefix("Bearer ")
-            .ok_or(AuthError::InvalidAuthHeader)?;
+            .and_then(|value| value.strip_prefix("Bearer "))
+            .or_else(|| {
+                parts
+                    .uri
+                    .query()
+                    .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("token=")))
+            })
+            .ok_or(AuthError::NoAuthHeader)?;
 
         // Decode claims from the self-describing token
         let token = Token::from(token_str)

--- a/crates/oneiros-engine/src/mcp.rs
+++ b/crates/oneiros-engine/src/mcp.rs
@@ -239,17 +239,18 @@ impl ServerHandler for EngineToolBox {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         _context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<rmcp::model::ListToolsResult, ErrorData> {
-        let tools = all_tools()
+        let tools: Vec<Tool> = all_tools()
             .into_iter()
             .map(|t| {
                 let mut tool = Tool::default();
                 tool.name = t.name.to_string().into();
                 tool.description = Some(t.description.to_string().into());
-                tool.input_schema =
-                    serde_json::from_value(t.input_schema).expect("schema should be a JSON object");
-                tool
+                tool.input_schema = serde_json::from_value(t.input_schema).map_err(|err| {
+                    ErrorData::internal_error(format!("invalid schema for {}: {err}", t.name), None)
+                })?;
+                Ok(tool)
             })
-            .collect();
+            .collect::<Result<_, ErrorData>>()?;
 
         Ok(rmcp::model::ListToolsResult {
             tools,

--- a/crates/oneiros-engine/src/tests/harness.rs
+++ b/crates/oneiros-engine/src/tests/harness.rs
@@ -123,7 +123,7 @@ impl TestApp {
     pub fn client(&self) -> TestClient {
         let config = self.engine.config();
         let client = match config.token() {
-            Some(token) => Client::with_token(config.base_url(), token),
+            Some(token) => Client::with_token(config.base_url(), token).expect("test token"),
             None => Client::new(config.base_url()),
         };
 
@@ -143,6 +143,56 @@ impl TestApp {
     /// The project token, if one exists (written during `init_project`).
     pub fn token(&self) -> Option<Token> {
         self.engine.config().token()
+    }
+}
+
+/// Retry policy for async convergence in tests.
+///
+/// Repeatedly evaluates a predicate until it succeeds or the timeout
+/// expires. The predicate returns `Ok(())` on success or `Err(message)`
+/// describing why it hasn't converged yet.
+///
+/// ```rust,ignore
+/// Retryable::default()
+///     .wait_for(|| {
+///         if ready() { Ok(()) } else { Err("not ready".into()) }
+///     }, "thing to be ready")
+///     .await;
+/// ```
+pub struct Retryable {
+    interval: std::time::Duration,
+    timeout: std::time::Duration,
+}
+
+impl Default for Retryable {
+    fn default() -> Self {
+        Self {
+            interval: std::time::Duration::from_millis(16),
+            timeout: std::time::Duration::from_secs(2),
+        }
+    }
+}
+
+impl Retryable {
+    /// Block until the predicate returns `Ok(())`, polling at `interval`.
+    /// Panics with a descriptive message if `timeout` expires first.
+    pub async fn wait_for(&self, mut predicate: impl FnMut() -> Result<(), String>, label: &str) {
+        let deadline = std::time::Instant::now() + self.timeout;
+
+        loop {
+            match predicate() {
+                Ok(()) => return,
+                Err(msg) => {
+                    if std::time::Instant::now() >= deadline {
+                        panic!(
+                            "{label}: not met within {:?}.\nLast failure: {msg}",
+                            self.timeout,
+                        );
+                    }
+                    tokio::time::sleep(self.interval).await;
+                }
+            }
+        }
     }
 }
 

--- a/crates/oneiros-engine/src/tests/workflows/continuity.rs
+++ b/crates/oneiros-engine/src/tests/workflows/continuity.rs
@@ -6,7 +6,7 @@
 
 use futures::StreamExt;
 
-use crate::tests::harness::TestApp;
+use crate::tests::harness::{Retryable, TestApp};
 use crate::*;
 
 #[tokio::test]
@@ -568,9 +568,6 @@ async fn activity_stream_observes_events() -> Result<(), Box<dyn core::error::Er
         }
     });
 
-    // Give the SSE connection a moment to establish
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
     // Perform operations that should emit events
     app.command("agent create thinker process").await?;
     app.command(r#"cognition add thinker.process observation "A thought""#)
@@ -578,32 +575,27 @@ async fn activity_stream_observes_events() -> Result<(), Box<dyn core::error::Er
     app.command(r#"memory add thinker.process session "A memory""#)
         .await?;
 
-    // Give events time to propagate through SSE
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    sse_handle.abort();
-
-    // Collect received events
+    let expected = ["agent-created", "cognition-added", "memory-added"];
     let mut events = Vec::new();
-    while let Ok(event) = event_rx.try_recv() {
-        events.push(event);
-    }
 
-    assert!(!events.is_empty(), "SSE stream should have received events");
+    Retryable::default()
+        .wait_for(
+            || {
+                while let Ok(event) = event_rx.try_recv() {
+                    events.push(event);
+                }
+                let types: Vec<String> = events.iter().map(|e| e.data.event_type()).collect();
+                if expected.iter().all(|e| types.iter().any(|t| t == e)) {
+                    Ok(())
+                } else {
+                    Err(format!("got: {types:?}"))
+                }
+            },
+            "all expected SSE event types to arrive",
+        )
+        .await;
 
-    let event_types: Vec<String> = events.iter().map(|e| e.data.event_type()).collect();
-
-    assert!(
-        event_types.iter().any(|t| t == "agent-created"),
-        "stream should contain agent-created, got: {event_types:?}"
-    );
-    assert!(
-        event_types.iter().any(|t| t == "cognition-added"),
-        "stream should contain cognition-added, got: {event_types:?}"
-    );
-    assert!(
-        event_types.iter().any(|t| t == "memory-added"),
-        "stream should contain memory-added, got: {event_types:?}"
-    );
+    sse_handle.abort();
 
     // Events should be in sequence order
     for window in events.windows(2) {
@@ -612,6 +604,99 @@ async fn activity_stream_observes_events() -> Result<(), Box<dyn core::error::Er
             "events should be in sequence order"
         );
     }
+
+    Ok(())
+}
+
+/// Auth via query param — the path browsers must use for SSE since
+/// EventSource cannot set custom headers.
+#[tokio::test]
+async fn activity_stream_authenticates_via_query_param() -> Result<(), Box<dyn core::error::Error>>
+{
+    let app = TestApp::new()
+        .await?
+        .init_system()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let token = app.token().expect("should have a token after init");
+    let sse_url = format!("{}/activity?token={token}", app.base_url());
+
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<StoredEvent>(64);
+
+    let sse_handle = tokio::spawn(async move {
+        let http = reqwest::Client::new();
+        // No Authorization header — token is in the query string
+        let resp = http
+            .get(&sse_url)
+            .header("Accept", "text/event-stream")
+            .send()
+            .await
+            .unwrap();
+
+        assert!(
+            resp.status().is_success(),
+            "query param auth should succeed"
+        );
+
+        let mut stream = resp.bytes_stream();
+        let mut buffer = String::new();
+
+        while let Some(chunk) = stream.next().await {
+            let bytes = chunk.unwrap();
+            let text = String::from_utf8_lossy(&bytes);
+            buffer.push_str(&text);
+
+            while let Some(pos) = buffer.find("\n\n") {
+                let event_block = buffer[..pos].to_string();
+                buffer = buffer[pos + 2..].to_string();
+
+                let data_line = event_block
+                    .lines()
+                    .find(|l| l.starts_with("data:"))
+                    .and_then(|l| {
+                        let trimmed = l.strip_prefix("data:").unwrap().trim();
+                        if trimmed.is_empty() {
+                            None
+                        } else {
+                            Some(trimmed.to_string())
+                        }
+                    });
+
+                if let Some(event) =
+                    data_line.and_then(|d| serde_json::from_str::<StoredEvent>(&d).ok())
+                    && event_tx.send(event).await.is_err()
+                {
+                    return;
+                }
+            }
+        }
+    });
+
+    app.command("agent create thinker process").await?;
+
+    let mut events = Vec::<StoredEvent>::new();
+
+    Retryable::default()
+        .wait_for(
+            || {
+                while let Ok(event) = event_rx.try_recv() {
+                    events.push(event);
+                }
+                if events.is_empty() {
+                    Err("no events received yet".into())
+                } else {
+                    Ok(())
+                }
+            },
+            "SSE events to arrive via query param auth",
+        )
+        .await;
+
+    sse_handle.abort();
 
     Ok(())
 }

--- a/crates/oneiros-engine/src/tests/workflows/errors.rs
+++ b/crates/oneiros-engine/src/tests/workflows/errors.rs
@@ -32,7 +32,7 @@ async fn auth_boundaries() -> Result<(), Box<dyn core::error::Error>> {
     );
 
     // ── Invalid token → rejected ─────────────────────────────────
-    let bad_token = Client::with_token(base_url.clone(), Token::from("not-a-real-token"));
+    let bad_token = Client::with_token(base_url.clone(), Token::from("not-a-real-token"))?;
     let agent_client = AgentClient::new(&bad_token);
     assert!(
         agent_client

--- a/crates/oneiros-engine/src/tests/workflows/system.rs
+++ b/crates/oneiros-engine/src/tests/workflows/system.rs
@@ -186,3 +186,36 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
 
     Ok(())
 }
+
+/// System init must generate the host keypair so that the host
+/// identity exists before the server is ever started.
+#[tokio::test]
+async fn system_init_creates_host_keypair() -> Result<(), Box<dyn core::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let config = Config::builder()
+        .data_dir(dir.path().to_path_buf())
+        .brain(BrainName::new("test"))
+        .build();
+
+    let context = SystemContext::new(config.clone());
+
+    // Before init, no host key exists
+    assert!(
+        !config.host_key_path().exists(),
+        "host key should not exist before system init"
+    );
+
+    SystemService::init(&context, &InitSystem::builder().build()).await?;
+
+    // After init, the host key should exist
+    assert!(
+        config.host_key_path().exists(),
+        "system init should create the host keypair"
+    );
+
+    // The key should be loadable
+    let secret = config.load_host_secret_key()?;
+    assert!(secret.is_some(), "host key should be loadable after init");
+
+    Ok(())
+}

--- a/crates/oneiros-engine/src/values/ledger.rs
+++ b/crates/oneiros-engine/src/values/ledger.rs
@@ -106,13 +106,12 @@ impl Ledger {
             LedgerNode::Interior { mut children } => {
                 let nibble = nibble_at(key, depth);
                 let child = children.get(&nibble).cloned();
-                let new_child = Self::record(
-                    child.as_ref(),
-                    &key.parse().unwrap_or_default(),
-                    value,
-                    resolve,
-                    store,
-                );
+                let new_child = match child {
+                    Some(ref hash) => Self::record_at(hash, key, value, depth + 1, resolve, store),
+                    None => store(&LedgerNode::Leaf {
+                        entries: BTreeMap::from([(key.to_string(), value)]),
+                    }),
+                };
                 children.insert(nibble, new_child);
                 store(&LedgerNode::Interior { children })
             }

--- a/crates/oneiros-engine/templates/dashboard/index.html
+++ b/crates/oneiros-engine/templates/dashboard/index.html
@@ -336,9 +336,8 @@ a{color:inherit;text-decoration:none}
     if (!window._sse) {
       var feed = document.getElementById('activity');
       var opts = {};
-      // EventSource doesn't support custom headers, so we skip auth for SSE
-      // (this may need a cookie or query param approach later)
-      window._sse = new EventSource('/activity');
+      var sseUrl = TOKEN ? '/activity?token=' + encodeURIComponent(TOKEN) : '/activity';
+      window._sse = new EventSource(sseUrl);
       window._sse.onmessage = function(e) {
         try {
           var ev = JSON.parse(e.data);

--- a/tests/usage/tests/acceptance/cases/doctor.rs
+++ b/tests/usage/tests/acceptance/cases/doctor.rs
@@ -34,6 +34,10 @@ pub(crate) async fn reports_initialized_system<B: Backend>() -> TestResult {
                     .any(|r| matches!(r, DoctorCheck::EventLogReady(_))),
                 "expected EventLogReady check in {checks:?}"
             );
+            assert!(
+                checks.iter().any(|r| matches!(r, DoctorCheck::HostKeyOk)),
+                "expected HostKeyOk check in {checks:?}"
+            );
         }
         other => panic!("expected Doctor(CheckupStatus(..)), got {other:#?}"),
     }


### PR DESCRIPTION
This fixes a few things we noticed while combing through the codebase on a fresh insteall.

Explicit errors
---

At a bunch of spots, we were panicking with unwraps or expects. Not something we want to propagate, in general. So we zapped a few of these, putting actual named errors in their place.

No keypair?
---

Our keypair gets generated the very first time the service started, which isn't correct - instead, we want system init to do that. This commit establishes the correct location for keypair generation, adds a doctor check with hint.

SSE Auth
---

Exhaustingly, SSE precludes headers (either that or my robot pal who's fun to be with is confused about it, and I don't want to invest any time in maintaining an API I don't want around long-term) so we have to add token support to the query string.