### PR TITLE
Spike: MCP Redesign spike

### DIFF
--- a/crates/oneiros-engine/src/mcp.rs
+++ b/crates/oneiros-engine/src/mcp.rs
@@ -1,8 +1,13 @@
-//! MCP tool server — thin rmcp adapter delegating to per-domain dispatchers.
+//! MCP server — toolset-aware adapter with resources and prompts.
 //!
-//! Each domain owns its tool catalog in `features/mcp.rs`. This module
-//! collects them into an rmcp ServerHandler, routing tool calls to the
-//! appropriate domain dispatcher.
+//! The server exposes a **root** layer (dashboard resources, toolset management
+//! tools, orientation prompts) that is always available. The agent can activate
+//! a **Toolset** to load additional tools for a specific cognitive moment.
+//!
+//! Primitives used:
+//! - **Tools**: root tools (activate/deactivate, pressure, status) + active toolset's tools
+//! - **Resources**: read-only windows into cognitive state (dream, pressure, status)
+//! - **Prompts**: interaction templates that guide toolset selection
 //!
 //! Session authentication: if the MCP client sends an `Authorization:
 //! Bearer <token>` header during the initialize handshake, the session
@@ -11,8 +16,15 @@
 
 use std::sync::OnceLock;
 
-use rmcp::model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo, Tool};
+use rmcp::model::{
+    Annotated, CallToolResult, Content, GetPromptRequestParams, GetPromptResult,
+    Implementation, ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult,
+    PaginatedRequestParams, PromptArgument, PromptMessage, PromptMessageRole,
+    ReadResourceRequestParams, ReadResourceResult, ResourceContents, ServerCapabilities, ServerInfo,
+    Tool,
+};
 use rmcp::{ErrorData, ServerHandler};
+use tokio::sync::RwLock;
 
 use crate::*;
 
@@ -38,34 +50,225 @@ pub enum ToolError {
     Domain(String),
 }
 
-/// Collect all tool definitions from every domain's catalog.
-fn all_tools() -> Vec<ToolDef> {
+// ---------------------------------------------------------------------------
+// Root tools — always available regardless of active toolset
+// ---------------------------------------------------------------------------
+
+/// Tools that are always present: toolset management + dashboard essentials.
+fn root_tools() -> Vec<ToolDef> {
     [
-        ActorTools.defs(),
-        TenantTools.defs(),
-        BrainTools.defs(),
-        TicketTools.defs(),
-        BookmarkTools.defs(),
-        LevelTools.defs(),
-        TextureTools.defs(),
-        SensationTools.defs(),
-        NatureTools.defs(),
-        PersonaTools.defs(),
-        UrgeTools.defs(),
-        AgentTools.defs(),
-        CognitionTools.defs(),
-        MemoryTools.defs(),
-        ExperienceTools.defs(),
-        ConnectionTools.defs(),
-        ContinuityTools.defs(),
-        SearchTools.defs(),
-        StorageTools.defs(),
+        vec![
+            crate::values::Tool::<ActivateToolset>::new(
+                "activate-toolset",
+                "Load a toolset — changes which tools are available. \
+                 Options: lifecycle, capture, garden, admin, distribute",
+            )
+            .def(),
+            crate::values::Tool::<DeactivateToolset>::new(
+                "deactivate-toolset",
+                "Unload the active toolset, returning to root-only tools",
+            )
+            .def(),
+        ],
         PressureTools.defs(),
     ]
     .into_iter()
     .flatten()
     .collect()
 }
+
+// ---------------------------------------------------------------------------
+// Resources — read-only windows, always available
+// ---------------------------------------------------------------------------
+
+/// Resource templates — parameterized read-only data windows.
+fn resource_templates() -> Vec<Annotated<rmcp::model::RawResourceTemplate>> {
+    use rmcp::model::{AnnotateAble, RawResourceTemplate};
+
+    vec![
+        RawResourceTemplate::new("oneiros://agent/{name}/dream", "Dream context")
+            .with_description("Full assembled identity and cognitive context for an agent")
+            .with_mime_type("text/markdown")
+            .no_annotation(),
+        RawResourceTemplate::new("oneiros://agent/{name}/pressure", "Pressure gauge")
+            .with_description("Current cognitive pressure readings and urge levels")
+            .with_mime_type("text/markdown")
+            .no_annotation(),
+        RawResourceTemplate::new("oneiros://agent/{name}/guidebook", "Guidebook")
+            .with_description("How to use cognitive tools — progressive reference")
+            .with_mime_type("text/markdown")
+            .no_annotation(),
+    ]
+}
+
+/// Read a resource by URI.
+async fn read_resource(
+    state: &ServerState,
+    config: &Config,
+    uri: &str,
+) -> Result<Vec<ResourceContents>, ToolError> {
+    // Parse oneiros://agent/{name}/{kind}
+    let path = uri
+        .strip_prefix("oneiros://agent/")
+        .ok_or_else(|| ToolError::Parameter(format!("Unknown resource URI: {uri}")))?;
+
+    let (agent_name, kind) = path
+        .split_once('/')
+        .ok_or_else(|| ToolError::Parameter(format!("Malformed resource URI: {uri}")))?;
+
+    let context = state
+        .project_context(config.clone())
+        .map_err(|e| ToolError::Domain(e.to_string()))?;
+
+    match kind {
+        "dream" => {
+            let request = DreamAgent::builder()
+                .agent(AgentName::new(agent_name))
+                .build();
+            let overrides = DreamOverrides::default();
+            let value = ContinuityService::dream(&context, &request, &overrides)
+                .await
+                .map_err(Error::from)?;
+            let text = serde_json::to_value(&value)
+                .ok()
+                .and_then(|v| v.as_str().map(String::from))
+                .unwrap_or_else(|| serde_json::to_string_pretty(&value).unwrap_or_default());
+            Ok(vec![ResourceContents::text(text, uri)])
+        }
+        "pressure" => {
+            let request = GetPressure::builder()
+                .agent(AgentName::new(agent_name))
+                .build();
+            let value = PressureService::get(&context, &request)
+                .await
+                .map_err(Error::from)?;
+            let text = serde_json::to_string_pretty(&value)
+                .unwrap_or_else(|_| format!("{value:?}"));
+            Ok(vec![ResourceContents::text(text, uri)])
+        }
+        "guidebook" => {
+            let request = GuidebookAgent::builder()
+                .agent(AgentName::new(agent_name))
+                .build();
+            let overrides = DreamOverrides::default();
+            let value = ContinuityService::guidebook(&context, &request, &overrides)
+                .map_err(Error::from)?;
+            let text = serde_json::to_value(&value)
+                .ok()
+                .and_then(|v| v.as_str().map(String::from))
+                .unwrap_or_else(|| serde_json::to_string_pretty(&value).unwrap_or_default());
+            Ok(vec![ResourceContents::text(text, uri)])
+        }
+        other => Err(ToolError::Parameter(format!(
+            "Unknown resource kind: '{other}'. Available: dream, pressure, guidebook"
+        ))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prompts — interaction templates that guide toolset selection
+// ---------------------------------------------------------------------------
+
+/// Available MCP prompts.
+fn prompt_catalog() -> Vec<rmcp::model::Prompt> {
+    vec![
+        rmcp::model::Prompt::new(
+            "orient",
+            Some("Read cognitive state and get toolset suggestions"),
+            Some(vec![
+                PromptArgument::new("agent")
+                    .with_description("Agent name (e.g., governor.process)")
+                    .with_required(true),
+            ]),
+        ),
+        rmcp::model::Prompt::new(
+            "toolsets",
+            Some("List all available toolsets and their descriptions"),
+            None,
+        ),
+    ]
+}
+
+/// Handle a prompt request.
+async fn handle_prompt(
+    state: &ServerState,
+    config: &Config,
+    name: &str,
+    arguments: &Option<serde_json::Map<String, serde_json::Value>>,
+) -> Result<GetPromptResult, ToolError> {
+    match name {
+        "orient" => {
+            let agent_name = arguments
+                .as_ref()
+                .and_then(|a| a.get("agent"))
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| ToolError::Parameter("'agent' argument is required".into()))?;
+
+            let context = state
+                .project_context(config.clone())
+                .map_err(|e| ToolError::Domain(e.to_string()))?;
+
+            let request = GetPressure::builder()
+                .agent(AgentName::new(agent_name))
+                .build();
+            let pressure = PressureService::get(&context, &request)
+                .await
+                .map_err(Error::from)?;
+
+            let pressure_text = serde_json::to_string_pretty(&pressure)
+                .unwrap_or_else(|_| format!("{pressure:?}"));
+
+            let mut lines = vec![
+                format!("## {agent_name} — Orientation\n"),
+                format!("### Pressure\n\n{pressure_text}\n"),
+                "### Available Toolsets\n".to_string(),
+            ];
+
+            for toolset in Toolset::all() {
+                lines.push(format!(
+                    "- **{}** ({} tools) — {}",
+                    toolset,
+                    toolset.tool_count(),
+                    toolset.description(),
+                ));
+            }
+
+            lines.push("\nUse `activate-toolset` to load the tools for your current moment.".into());
+
+            let content = lines.join("\n");
+            Ok(GetPromptResult::new(vec![PromptMessage::new_text(
+                PromptMessageRole::Assistant,
+                content,
+            )]))
+        }
+        "toolsets" => {
+            let mut lines = vec!["## Available Toolsets\n".to_string()];
+            for toolset in Toolset::all() {
+                lines.push(format!(
+                    "### {} ({} tools)\n\n{}\n\nTools: {}\n",
+                    toolset,
+                    toolset.tool_count(),
+                    toolset.description(),
+                    toolset
+                        .defs()
+                        .iter()
+                        .map(|t| t.name.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ));
+            }
+            Ok(GetPromptResult::new(vec![PromptMessage::new_text(
+                PromptMessageRole::Assistant,
+                lines.join("\n"),
+            )]))
+        }
+        other => Err(ToolError::UnknownTool(format!("Unknown prompt: {other}"))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Domain dispatch — routes tool names to domain dispatchers
+// ---------------------------------------------------------------------------
 
 /// Domain dispatch table — routes tool names to domain dispatchers.
 ///
@@ -150,6 +353,10 @@ async fn dispatch(
     Err(ToolError::UnknownTool(tool_name.to_string()))
 }
 
+// ---------------------------------------------------------------------------
+// Token resolution
+// ---------------------------------------------------------------------------
+
 /// Resolve a brain-specific config from a Bearer token.
 ///
 /// Follows the same validation as the HTTP auth layer: decode the
@@ -174,18 +381,28 @@ async fn resolve_config_from_token(state: &ServerState, token_str: &str) -> Opti
     Some(config)
 }
 
-/// MCP tool server wrapping the server state.
+// ---------------------------------------------------------------------------
+// EngineToolBox — per-session MCP handler
+// ---------------------------------------------------------------------------
+
+/// MCP server wrapping the server state.
 ///
 /// Each MCP session gets its own `EngineToolBox`. During the initialize
 /// handshake, if a Bearer token is present, the session resolves to
 /// the brain associated with that token. Otherwise it uses the server's
 /// default brain config.
+///
+/// The active toolset controls which tools appear in `list_tools`.
+/// Activating a toolset notifies the client to re-fetch the tool list.
 #[derive(Clone)]
 pub struct EngineToolBox {
     state: ServerState,
     /// Session-resolved config, set during initialize from Bearer token.
     /// Falls back to state.config() if not set.
     session_config: OnceLock<Config>,
+    /// The currently active toolset for this session.
+    /// None means root-only (dashboard + toolset management).
+    active_toolset: std::sync::Arc<RwLock<Option<Toolset>>>,
 }
 
 impl EngineToolBox {
@@ -193,6 +410,7 @@ impl EngineToolBox {
         Self {
             state,
             session_config: OnceLock::new(),
+            active_toolset: std::sync::Arc::new(RwLock::new(None)),
         }
     }
 
@@ -201,13 +419,39 @@ impl EngineToolBox {
     fn config(&self) -> &Config {
         self.session_config.get().unwrap_or(self.state.config())
     }
+
+    /// Collect tool definitions for the current session state.
+    async fn current_tools(&self) -> Vec<ToolDef> {
+        let mut tools = root_tools();
+
+        if let Some(toolset) = self.active_toolset.read().await.as_ref() {
+            tools.extend(toolset.defs());
+        }
+
+        tools
+    }
+}
+
+/// Convert a ToolDef into an rmcp Tool.
+fn to_rmcp_tool(t: ToolDef) -> Tool {
+    let mut tool = Tool::default();
+    tool.name = t.name.to_string().into();
+    tool.description = Some(t.description.to_string().into());
+    tool.input_schema =
+        serde_json::from_value(t.input_schema).expect("schema should be a JSON object");
+    tool
 }
 
 impl ServerHandler for EngineToolBox {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_server_info(
-            Implementation::new("oneiros-engine", env!("CARGO_PKG_VERSION")),
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .enable_prompts()
+                .build(),
         )
+        .with_server_info(Implementation::new("oneiros-engine", env!("CARGO_PKG_VERSION")))
     }
 
     async fn initialize(
@@ -234,20 +478,10 @@ impl ServerHandler for EngineToolBox {
 
     async fn list_tools(
         &self,
-        _request: Option<rmcp::model::PaginatedRequestParams>,
+        _request: Option<PaginatedRequestParams>,
         _context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<rmcp::model::ListToolsResult, ErrorData> {
-        let tools = all_tools()
-            .into_iter()
-            .map(|t| {
-                let mut tool = Tool::default();
-                tool.name = t.name.to_string().into();
-                tool.description = Some(t.description.to_string().into());
-                tool.input_schema =
-                    serde_json::from_value(t.input_schema).expect("schema should be a JSON object");
-                tool
-            })
-            .collect();
+        let tools = self.current_tools().await.into_iter().map(to_rmcp_tool).collect();
 
         Ok(rmcp::model::ListToolsResult {
             tools,
@@ -259,17 +493,122 @@ impl ServerHandler for EngineToolBox {
     async fn call_tool(
         &self,
         request: rmcp::model::CallToolRequestParams,
-        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let tool_name = request.name.as_ref();
         let params = serde_json::to_string(&request.arguments.unwrap_or_default())
             .unwrap_or_else(|_| "{}".to_string());
 
+        // Handle toolset management tools
+        match tool_name {
+            "activate-toolset" => {
+                let req: ActivateToolset = serde_json::from_str(&params)
+                    .map_err(|e| ErrorData::invalid_params(e.to_string(), None))?;
+
+                let toolset: Toolset = req.toolset.parse()
+                    .map_err(|e: String| ErrorData::invalid_params(e, None))?;
+
+                let description = toolset.description().to_string();
+                let count = toolset.tool_count();
+                let name = toolset.to_string();
+
+                *self.active_toolset.write().await = Some(toolset);
+
+                // Notify the client to re-fetch the tool list
+                let _ = context.peer.notify_tool_list_changed().await;
+
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Loaded {name} toolset ({count} tools). {description}"
+                ))]));
+            }
+            "deactivate-toolset" => {
+                let had_toolset = self.active_toolset.read().await.is_some();
+                *self.active_toolset.write().await = None;
+
+                if had_toolset {
+                    let _ = context.peer.notify_tool_list_changed().await;
+                }
+
+                return Ok(CallToolResult::success(vec![Content::text(
+                    "Toolset deactivated. Root tools only.",
+                )]));
+            }
+            _ => {}
+        }
+
+        // Dispatch to domain handlers
         match dispatch(&self.state, self.config(), tool_name, &params).await {
             Ok(value) => Ok(CallToolResult::success(vec![
                 Content::json(value).expect("content"),
             ])),
             Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Resources
+    // -----------------------------------------------------------------------
+
+    async fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, ErrorData> {
+        Ok(ListResourceTemplatesResult {
+            resource_templates: resource_templates(),
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<ListResourcesResult, ErrorData> {
+        // No concrete (non-template) resources — all are parameterized
+        Ok(ListResourcesResult {
+            resources: vec![],
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<ReadResourceResult, ErrorData> {
+        let contents = read_resource(&self.state, self.config(), &request.uri)
+            .await
+            .map_err(|e| ErrorData::resource_not_found(e.to_string(), None))?;
+
+        Ok(ReadResourceResult::new(contents))
+    }
+
+    // -----------------------------------------------------------------------
+    // Prompts
+    // -----------------------------------------------------------------------
+
+    async fn list_prompts(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<ListPromptsResult, ErrorData> {
+        Ok(ListPromptsResult {
+            prompts: prompt_catalog(),
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    async fn get_prompt(
+        &self,
+        request: GetPromptRequestParams,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<GetPromptResult, ErrorData> {
+        handle_prompt(&self.state, self.config(), &request.name, &request.arguments)
+            .await
+            .map_err(|e| ErrorData::invalid_params(e.to_string(), None))
     }
 }

--- a/crates/oneiros-engine/src/tests/workflows/mcp.rs
+++ b/crates/oneiros-engine/src/tests/workflows/mcp.rs
@@ -1,8 +1,9 @@
-//! MCP workflow — tool discovery and execution via the Model Context Protocol.
+//! MCP workflow — toolset-aware tool discovery and execution via the Model Context Protocol.
 //!
 //! MCP clients connect over streamable HTTP, initialize a session, discover
-//! available tools, and call them. Data created through MCP is visible
-//! through all other layers (HTTP REST, CLI).
+//! available tools, and call them. The server exposes a small root tool set
+//! with toolset management. Activating a toolset expands the available tools.
+//! Data created through MCP is visible through all other layers (HTTP REST, CLI).
 
 use crate::tests::harness::TestApp;
 use crate::*;
@@ -64,7 +65,7 @@ async fn mcp_initialize_with_token(
         "jsonrpc": "2.0",
         "method": "notifications/initialized"
     }));
-    if let Some(ref sid) = session_id {
+    if let Some(sid) = &session_id {
         notif = notif.header("mcp-session-id", sid);
     }
     notif.send().await.unwrap();
@@ -104,7 +105,7 @@ async fn mcp_initialize(http: &reqwest::Client, url: &str) -> Option<String> {
         "jsonrpc": "2.0",
         "method": "notifications/initialized"
     }));
-    if let Some(ref sid) = session_id {
+    if let Some(sid) = &session_id {
         notif = notif.header("mcp-session-id", sid);
     }
     notif.send().await.unwrap();
@@ -112,111 +113,31 @@ async fn mcp_initialize(http: &reqwest::Client, url: &str) -> Option<String> {
     session_id
 }
 
-#[tokio::test]
-async fn mcp_session() -> Result<(), Box<dyn core::error::Error>> {
-    let app = TestApp::new()
-        .await?
-        .init_system()
-        .await?
-        .init_project()
-        .await?
-        .seed_core()
-        .await?;
-
-    let http = reqwest::Client::new();
-    let url = app.mcp_url();
-
-    // Initialize a session
-    let session_id = mcp_initialize(&http, &url).await;
-
-    // Discover tools
-    let mut tools_req = mcp_post(&http, &url).json(&serde_json::json!({
+/// Helper: list tools for a session.
+async fn mcp_list_tools(
+    http: &reqwest::Client,
+    url: &str,
+    session_id: &Option<String>,
+) -> Vec<String> {
+    let mut req = mcp_post(http, url).json(&serde_json::json!({
         "jsonrpc": "2.0",
-        "id": 2,
+        "id": 100,
         "method": "tools/list"
     }));
-    if let Some(ref sid) = session_id {
-        tools_req = tools_req.header("mcp-session-id", sid);
+    if let Some(sid) = &session_id {
+        req = req.header("mcp-session-id", sid);
     }
-    let tools_resp = tools_req.send().await?;
-    assert!(tools_resp.status().is_success());
+    let resp = req.send().await.unwrap();
+    assert!(resp.status().is_success());
 
-    let body = tools_resp.text().await?;
+    let body = resp.text().await.unwrap();
     let json = extract_sse_json(&body);
-    let tools = json["result"]["tools"]
+    json["result"]["tools"]
         .as_array()
-        .expect("tools should be an array");
-
-    // All 68 tools should be listed
-    assert!(
-        tools.len() >= 60,
-        "expected at least 60 tools, got {}",
-        tools.len()
-    );
-
-    // Spot-check across domains
-    let tool_names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
-    assert!(tool_names.contains(&"create-agent"));
-    assert!(tool_names.contains(&"dream-agent"));
-    assert!(tool_names.contains(&"search-query"));
-    assert!(tool_names.contains(&"add-cognition"));
-    assert!(tool_names.contains(&"set-level"));
-    assert!(tool_names.contains(&"list-storage"));
-
-    // Every tool should have a name and inputSchema
-    for tool in tools {
-        assert!(tool["name"].is_string(), "tool should have a name");
-        assert!(
-            tool["inputSchema"].is_object(),
-            "tool should have an inputSchema"
-        );
-    }
-
-    // Tool names should be unique
-    let mut seen = std::collections::HashSet::new();
-    for name in &tool_names {
-        assert!(seen.insert(name), "duplicate tool name: {name}");
-    }
-
-    // Call a tool — create a persona through MCP
-    let mut call_req = mcp_post(&http, &url).json(&serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": 3,
-        "method": "tools/call",
-        "params": {
-            "name": "set-persona",
-            "arguments": {
-                "name": "mcp-persona",
-                "description": "Created via MCP",
-                "prompt": "You were born from a tool call"
-            }
-        }
-    }));
-    if let Some(ref sid) = session_id {
-        call_req = call_req.header("mcp-session-id", sid);
-    }
-    let call_resp = call_req.send().await?;
-    assert!(call_resp.status().is_success());
-
-    // Data created through MCP is visible through the HTTP REST API
-    match app
-        .client()
-        .persona()
-        .get(&PersonaName::new("mcp-persona"))
-        .await?
-    {
-        PersonaResponse::PersonaDetails(p) => {
-            assert_eq!(p.data.description.to_string(), "Created via MCP");
-        }
-        other => panic!("expected PersonaDetails, got {other:?}"),
-    }
-
-    // And through the CLI
-    let cmd_result = app.command("persona show mcp-persona").await?;
-    let cmd_json = serde_json::to_value(cmd_result.response())?;
-    assert_eq!(cmd_json["data"]["name"], "mcp-persona");
-
-    Ok(())
+        .expect("tools should be an array")
+        .iter()
+        .filter_map(|t| t["name"].as_str().map(String::from))
+        .collect()
 }
 
 /// Helper: call an MCP tool and return the result JSON.
@@ -246,6 +167,199 @@ async fn mcp_call_tool(
     extract_sse_json(&body)
 }
 
+/// Helper: send an MCP JSON-RPC request and return the result JSON.
+async fn mcp_request(
+    http: &reqwest::Client,
+    url: &str,
+    session_id: &Option<String>,
+    id: u64,
+    method: &str,
+    params: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+    });
+    if let Some(p) = params {
+        body["params"] = p;
+    }
+    let mut req = mcp_post(http, url).json(&body);
+    if let Some(sid) = session_id {
+        req = req.header("mcp-session-id", sid);
+    }
+    let resp = req.send().await.unwrap();
+    assert!(resp.status().is_success());
+    let body = resp.text().await.unwrap();
+    extract_sse_json(&body)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn mcp_session() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_system()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let http = reqwest::Client::new();
+    let url = app.mcp_url();
+
+    // Initialize a session
+    let session_id = mcp_initialize(&http, &url).await;
+
+    // ── Root tools are small ───────────────────────────────────────
+    let root_tools = mcp_list_tools(&http, &url, &session_id).await;
+    assert!(
+        root_tools.len() <= 10,
+        "root should have few tools, got {}",
+        root_tools.len()
+    );
+    assert!(root_tools.contains(&"activate-toolset".to_string()));
+    assert!(root_tools.contains(&"deactivate-toolset".to_string()));
+    assert!(root_tools.contains(&"get-pressure".to_string()));
+
+    // Domain tools should NOT be in root
+    assert!(!root_tools.contains(&"create-agent".to_string()));
+    assert!(!root_tools.contains(&"add-cognition".to_string()));
+
+    // ── Activate admin toolset ─────────────────────────────────────
+    let result = mcp_call_tool(
+        &http,
+        &url,
+        &session_id,
+        2,
+        "activate-toolset",
+        serde_json::json!({ "toolset": "admin" }),
+    )
+    .await;
+    let is_error = result["result"]["isError"].as_bool().unwrap_or(false);
+    assert!(!is_error, "activate-toolset should succeed: {result}");
+
+    // ── Tools list now includes admin tools ─────────────────────────
+    let admin_tools = mcp_list_tools(&http, &url, &session_id).await;
+    assert!(
+        admin_tools.len() > root_tools.len(),
+        "admin toolset should add tools (root: {}, admin: {})",
+        root_tools.len(),
+        admin_tools.len()
+    );
+    assert!(admin_tools.contains(&"create-agent".to_string()));
+    assert!(admin_tools.contains(&"set-level".to_string()));
+    assert!(admin_tools.contains(&"set-persona".to_string()));
+    // Root tools are still present
+    assert!(admin_tools.contains(&"activate-toolset".to_string()));
+
+    // Tool names should be unique
+    let mut seen = std::collections::HashSet::new();
+    for name in &admin_tools {
+        assert!(seen.insert(name), "duplicate tool name: {name}");
+    }
+
+    // Every tool should have a name and inputSchema (spot check via raw request)
+    let mut tools_req = mcp_post(&http, &url).json(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 20,
+        "method": "tools/list"
+    }));
+    if let Some(sid) = &session_id {
+        tools_req = tools_req.header("mcp-session-id", sid);
+    }
+    let tools_resp = tools_req.send().await?;
+    let body = tools_resp.text().await?;
+    let json = extract_sse_json(&body);
+    for tool in json["result"]["tools"].as_array().unwrap() {
+        assert!(tool["name"].is_string(), "tool should have a name");
+        assert!(
+            tool["inputSchema"].is_object(),
+            "tool should have an inputSchema"
+        );
+    }
+
+    // ── Call a tool through the toolset ─────────────────────────────
+    let result = mcp_call_tool(
+        &http,
+        &url,
+        &session_id,
+        3,
+        "set-persona",
+        serde_json::json!({
+            "name": "mcp-persona",
+            "description": "Created via MCP",
+            "prompt": "You were born from a tool call"
+        }),
+    )
+    .await;
+    let is_error = result["result"]["isError"].as_bool().unwrap_or(false);
+    assert!(!is_error, "set-persona should succeed: {result}");
+
+    // Data created through MCP is visible through the HTTP REST API
+    match app
+        .client()
+        .persona()
+        .get(&PersonaName::new("mcp-persona"))
+        .await?
+    {
+        PersonaResponse::PersonaDetails(p) => {
+            assert_eq!(p.data.description.to_string(), "Created via MCP");
+        }
+        other => panic!("expected PersonaDetails, got {other:?}"),
+    }
+
+    // And through the CLI
+    let cmd_result = app.command("persona show mcp-persona").await?;
+    let cmd_json = serde_json::to_value(cmd_result.response())?;
+    assert_eq!(cmd_json["data"]["name"], "mcp-persona");
+
+    // ── Deactivate returns to root ──────────────────────────────────
+    let result = mcp_call_tool(
+        &http,
+        &url,
+        &session_id,
+        4,
+        "deactivate-toolset",
+        serde_json::json!({}),
+    )
+    .await;
+    let is_error = result["result"]["isError"].as_bool().unwrap_or(false);
+    assert!(!is_error, "deactivate-toolset should succeed: {result}");
+
+    let deactivated_tools = mcp_list_tools(&http, &url, &session_id).await;
+    assert_eq!(
+        deactivated_tools.len(),
+        root_tools.len(),
+        "should return to root tool count"
+    );
+
+    // ── Switch to capture toolset ───────────────────────────────────
+    let result = mcp_call_tool(
+        &http,
+        &url,
+        &session_id,
+        5,
+        "activate-toolset",
+        serde_json::json!({ "toolset": "capture" }),
+    )
+    .await;
+    let is_error = result["result"]["isError"].as_bool().unwrap_or(false);
+    assert!(!is_error, "activate capture should succeed: {result}");
+
+    let capture_tools = mcp_list_tools(&http, &url, &session_id).await;
+    assert!(capture_tools.contains(&"add-cognition".to_string()));
+    assert!(capture_tools.contains(&"search-query".to_string()));
+    // Admin tools should be gone
+    assert!(!capture_tools.contains(&"create-agent".to_string()));
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn mcp_session_auth() -> Result<(), Box<dyn core::error::Error>> {
     let app = TestApp::new()
@@ -263,6 +377,19 @@ async fn mcp_session_auth() -> Result<(), Box<dyn core::error::Error>> {
 
     // Initialize with Bearer token
     let session_id = mcp_initialize_with_token(&http, &url, &token).await;
+
+    // Activate admin toolset to access persona tools
+    let result = mcp_call_tool(
+        &http,
+        &url,
+        &session_id,
+        2,
+        "activate-toolset",
+        serde_json::json!({ "toolset": "admin" }),
+    )
+    .await;
+    let is_error = result["result"]["isError"].as_bool().unwrap_or(false);
+    assert!(!is_error, "activate-toolset should succeed: {result}");
 
     // Create a persona through the authenticated session
     let result = mcp_call_tool(
@@ -329,7 +456,7 @@ async fn mcp_error_paths() -> Result<(), Box<dyn core::error::Error>> {
             "arguments": {}
         }
     }));
-    if let Some(ref sid) = session_id {
+    if let Some(sid) = &session_id {
         req = req.header("mcp-session-id", sid);
     }
     let resp = req.send().await?;
@@ -346,56 +473,378 @@ async fn mcp_error_paths() -> Result<(), Box<dyn core::error::Error>> {
         "unknown tool should return isError=true, got: {json}"
     );
 
-    // ── Bad parameters ──────────────────────────────────────────
+    // ── Invalid toolset name ───────────────────────────────────────
 
+    let result = mcp_call_tool(
+        &http,
+        &url,
+        &session_id,
+        11,
+        "activate-toolset",
+        serde_json::json!({ "toolset": "nonexistent" }),
+    )
+    .await;
+    // activate-toolset with bad name returns a JSON-RPC error (invalid params)
+    let has_error = result.get("error").is_some();
+    assert!(
+        has_error,
+        "bad toolset name should return error, got: {result}"
+    );
+
+    // ── Activate admin, then test domain errors ────────────────────
+
+    mcp_call_tool(
+        &http,
+        &url,
+        &session_id,
+        12,
+        "activate-toolset",
+        serde_json::json!({ "toolset": "admin" }),
+    )
+    .await;
+
+    // Bad parameters
     let mut req = mcp_post(&http, &url).json(&serde_json::json!({
         "jsonrpc": "2.0",
-        "id": 11,
+        "id": 13,
         "method": "tools/call",
         "params": {
             "name": "get-agent",
             "arguments": { "wrong_field": "not a name" }
         }
     }));
-    if let Some(ref sid) = session_id {
+    if let Some(sid) = &session_id {
         req = req.header("mcp-session-id", sid);
     }
     let resp = req.send().await?;
     assert!(resp.status().is_success());
     let body = resp.text().await?;
     let json = extract_sse_json(&body);
-
-    // Should also indicate an error — deserialization failure or domain error
     let is_error = json["result"]["isError"].as_bool().unwrap_or(false);
     assert!(
         is_error,
         "bad params should return isError=true, got: {json}"
     );
 
-    // ── Domain error through MCP ────────────────────────────────
-
-    // Try to get a nonexistent agent — should be a domain-level error
+    // Domain error — nonexistent agent
     let mut req = mcp_post(&http, &url).json(&serde_json::json!({
         "jsonrpc": "2.0",
-        "id": 12,
+        "id": 14,
         "method": "tools/call",
         "params": {
             "name": "get-agent",
             "arguments": { "name": "ghost.nobody" }
         }
     }));
-    if let Some(ref sid) = session_id {
+    if let Some(sid) = &session_id {
         req = req.header("mcp-session-id", sid);
     }
     let resp = req.send().await?;
     assert!(resp.status().is_success());
     let body = resp.text().await?;
     let json = extract_sse_json(&body);
-
     let is_error = json["result"]["isError"].as_bool().unwrap_or(false);
     assert!(
         is_error,
         "nonexistent agent via MCP should return isError=true, got: {json}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_resource_templates() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_system()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let http = reqwest::Client::new();
+    let url = app.mcp_url();
+    let session_id = mcp_initialize(&http, &url).await;
+
+    // ── List resource templates ────────────────────────────────────
+
+    let json = mcp_request(&http, &url, &session_id, 2, "resources/templates/list", None).await;
+    let templates = json["result"]["resourceTemplates"]
+        .as_array()
+        .expect("resourceTemplates should be an array");
+
+    assert!(
+        templates.len() >= 3,
+        "should have at least 3 resource templates, got {}",
+        templates.len()
+    );
+
+    let template_uris: Vec<&str> = templates
+        .iter()
+        .filter_map(|t| t["uriTemplate"].as_str())
+        .collect();
+    assert!(template_uris.contains(&"oneiros://agent/{name}/dream"));
+    assert!(template_uris.contains(&"oneiros://agent/{name}/pressure"));
+    assert!(template_uris.contains(&"oneiros://agent/{name}/guidebook"));
+
+    // Every template should have a name and description
+    for template in templates {
+        assert!(template["name"].is_string(), "template should have a name");
+        assert!(
+            template["description"].is_string(),
+            "template should have a description"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_read_resource() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_system()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let http = reqwest::Client::new();
+    let url = app.mcp_url();
+    let session_id = mcp_initialize(&http, &url).await;
+
+    // seed_core creates vocabulary but not agents — seed agents too
+    let _ = app.command("seed agents").await?;
+
+    // ── Read pressure resource ──────────────────────────────────────
+
+    let json = mcp_request(
+        &http,
+        &url,
+        &session_id,
+        10,
+        "resources/read",
+        Some(serde_json::json!({ "uri": "oneiros://agent/governor.process/pressure" })),
+    )
+    .await;
+
+    // Pressure may error if agent not found — check either way
+    if let Some(err) = json.get("error") {
+        panic!("pressure resource returned error: {err}");
+    }
+    let contents = json["result"]["contents"]
+        .as_array()
+        .unwrap_or_else(|| panic!("pressure contents should be an array, got: {json}"));
+    assert!(!contents.is_empty(), "pressure resource should return content");
+    assert!(
+        contents[0]["text"].is_string(),
+        "resource content should have text"
+    );
+
+    // ── Read dream resource ─────────────────────────────────────────
+
+    let json = mcp_request(
+        &http,
+        &url,
+        &session_id,
+        11,
+        "resources/read",
+        Some(serde_json::json!({ "uri": "oneiros://agent/governor.process/dream" })),
+    )
+    .await;
+
+    let contents = json["result"]["contents"]
+        .as_array()
+        .unwrap_or_else(|| panic!("dream contents should be an array, got: {json}"));
+    assert!(!contents.is_empty(), "dream resource should return content");
+    let text = contents[0]["text"].as_str().unwrap_or("");
+    assert!(
+        text.contains("governor.process"),
+        "dream should mention the agent name, got: {text}"
+    );
+
+    // ── Read guidebook resource ─────────────────────────────────────
+
+    let json = mcp_request(
+        &http,
+        &url,
+        &session_id,
+        12,
+        "resources/read",
+        Some(serde_json::json!({ "uri": "oneiros://agent/governor.process/guidebook" })),
+    )
+    .await;
+
+    let contents = json["result"]["contents"]
+        .as_array()
+        .unwrap_or_else(|| panic!("guidebook contents should be an array, got: {json}"));
+    assert!(
+        !contents.is_empty(),
+        "guidebook resource should return content"
+    );
+
+    // ── Unknown resource kind returns error ──────────────────────────
+
+    let json = mcp_request(
+        &http,
+        &url,
+        &session_id,
+        13,
+        "resources/read",
+        Some(serde_json::json!({ "uri": "oneiros://agent/governor.process/bogus" })),
+    )
+    .await;
+    assert!(
+        json.get("error").is_some(),
+        "unknown resource kind should return error, got: {json}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_prompts() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_system()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let http = reqwest::Client::new();
+    let url = app.mcp_url();
+    let session_id = mcp_initialize(&http, &url).await;
+
+    // ── List prompts ────────────────────────────────────────────────
+
+    let json = mcp_request(&http, &url, &session_id, 2, "prompts/list", None).await;
+    let prompts = json["result"]["prompts"]
+        .as_array()
+        .expect("prompts should be an array");
+
+    let prompt_names: Vec<&str> = prompts
+        .iter()
+        .filter_map(|p| p["name"].as_str())
+        .collect();
+    assert!(prompt_names.contains(&"orient"), "should have orient prompt");
+    assert!(
+        prompt_names.contains(&"toolsets"),
+        "should have toolsets prompt"
+    );
+
+    // Every prompt should have a description
+    for prompt in prompts {
+        assert!(
+            prompt["description"].is_string(),
+            "prompt should have a description"
+        );
+    }
+
+    // Orient prompt should declare an agent argument
+    let orient = prompts
+        .iter()
+        .find(|p| p["name"] == "orient")
+        .expect("orient prompt should exist");
+    let args = orient["arguments"]
+        .as_array()
+        .expect("orient should have arguments");
+    assert_eq!(args[0]["name"], "agent");
+    assert_eq!(args[0]["required"], true);
+
+    // ── Get toolsets prompt ──────────────────────────────────────────
+
+    let json = mcp_request(
+        &http,
+        &url,
+        &session_id,
+        3,
+        "prompts/get",
+        Some(serde_json::json!({ "name": "toolsets" })),
+    )
+    .await;
+
+    let messages = json["result"]["messages"]
+        .as_array()
+        .expect("messages should be an array");
+    assert!(!messages.is_empty(), "toolsets prompt should return messages");
+
+    let text = messages[0]["content"]["text"].as_str().unwrap_or("");
+    assert!(text.contains("lifecycle"), "toolsets should list lifecycle");
+    assert!(text.contains("capture"), "toolsets should list capture");
+    assert!(text.contains("garden"), "toolsets should list garden");
+    assert!(text.contains("admin"), "toolsets should list admin");
+    assert!(text.contains("distribute"), "toolsets should list distribute");
+
+    // ── Get orient prompt with agent ────────────────────────────────
+
+    // Create agent through MCP
+    mcp_call_tool(
+        &http, &url, &session_id, 10,
+        "activate-toolset",
+        serde_json::json!({ "toolset": "admin" }),
+    ).await;
+    mcp_call_tool(
+        &http, &url, &session_id, 11,
+        "create-agent",
+        serde_json::json!({
+            "name": "test.agent",
+            "persona": "process",
+            "description": "Test agent for orient prompt",
+            "prompt": ""
+        }),
+    ).await;
+    mcp_call_tool(
+        &http, &url, &session_id, 12,
+        "deactivate-toolset",
+        serde_json::json!({}),
+    ).await;
+
+    let json = mcp_request(
+        &http,
+        &url,
+        &session_id,
+        4,
+        "prompts/get",
+        Some(serde_json::json!({
+            "name": "orient",
+            "arguments": { "agent": "test.agent" }
+        })),
+    )
+    .await;
+
+    let messages = json["result"]["messages"]
+        .as_array()
+        .expect("messages should be an array");
+    assert!(!messages.is_empty(), "orient prompt should return messages");
+
+    let text = messages[0]["content"]["text"].as_str().unwrap_or("");
+    assert!(
+        text.contains("test.agent"),
+        "orient should reference the agent, got: {text}"
+    );
+    assert!(
+        text.contains("activate-toolset"),
+        "orient should suggest activating a toolset, got: {text}"
+    );
+
+    // ── Orient without agent argument returns error ──────────────────
+
+    let json = mcp_request(
+        &http,
+        &url,
+        &session_id,
+        5,
+        "prompts/get",
+        Some(serde_json::json!({ "name": "orient" })),
+    )
+    .await;
+    assert!(
+        json.get("error").is_some(),
+        "orient without agent should return error, got: {json}"
     );
 
     Ok(())

--- a/crates/oneiros-engine/src/values/mod.rs
+++ b/crates/oneiros-engine/src/values/mod.rs
@@ -51,6 +51,7 @@ mod token;
 mod token_version;
 mod tool_def;
 mod tool_name;
+mod toolset;
 mod verbosity;
 
 pub use agent_activity::*;
@@ -105,4 +106,5 @@ pub use timestamp::*;
 pub use token::*;
 pub use tool_def::*;
 pub use tool_name::*;
+pub use toolset::*;
 pub use verbosity::*;

--- a/crates/oneiros-engine/src/values/toolset.rs
+++ b/crates/oneiros-engine/src/values/toolset.rs
@@ -1,0 +1,189 @@
+use core::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::*;
+
+/// A named slice of the MCP tool surface.
+///
+/// The server always exposes its root layer (dashboard resources,
+/// toolset management tools). The active Toolset controls which
+/// additional tools appear alongside the root at any given moment.
+///
+/// Toolsets are organized by cognitive moment, not by domain. A single
+/// toolset may draw tools from multiple domains. A single domain's
+/// tools may appear in multiple toolsets.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Toolset {
+    /// Session lifecycle — wake, dream, introspect, sleep, emerge, recede
+    Lifecycle,
+    /// Mid-work capture — add cognition, reflect, sense, connect
+    Capture,
+    /// Consolidation — memory add, experience create, connection create, search
+    Garden,
+    /// Setup and evolution — system init, project init, seed, agent CRUD, vocabulary
+    Admin,
+    /// Sharing — bookmark share/follow/collect/merge, export, import
+    Distribute,
+}
+
+impl Toolset {
+    /// All available toolsets.
+    pub fn all() -> &'static [Toolset] {
+        &[
+            Toolset::Lifecycle,
+            Toolset::Capture,
+            Toolset::Garden,
+            Toolset::Admin,
+            Toolset::Distribute,
+        ]
+    }
+
+    /// Tool definitions for this toolset.
+    ///
+    /// Each toolset composes from existing domain tool catalogs.
+    /// Tools may appear in multiple toolsets — overlap is intentional.
+    pub fn defs(&self) -> Vec<ToolDef> {
+        match self {
+            Toolset::Lifecycle => [
+                ContinuityTools.defs(),
+                BookmarkTools.defs(),
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+
+            Toolset::Capture => [
+                CognitionTools.defs(),
+                ConnectionTools.defs(),
+                SearchTools.defs(),
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+
+            Toolset::Garden => [
+                MemoryTools.defs(),
+                ExperienceTools.defs(),
+                ConnectionTools.defs(),
+                SearchTools.defs(),
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+
+            Toolset::Admin => [
+                BrainTools.defs(),
+                AgentTools.defs(),
+                PersonaTools.defs(),
+                TextureTools.defs(),
+                SensationTools.defs(),
+                NatureTools.defs(),
+                LevelTools.defs(),
+                UrgeTools.defs(),
+                ActorTools.defs(),
+                TenantTools.defs(),
+                TicketTools.defs(),
+                StorageTools.defs(),
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+
+            Toolset::Distribute => [
+                BookmarkTools.defs(),
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+        }
+    }
+
+    /// Short description of this toolset for agent-facing prompts.
+    pub fn description(&self) -> &'static str {
+        match self {
+            Toolset::Lifecycle => "Session lifecycle — wake, dream, introspect, sleep, emerge, recede",
+            Toolset::Capture => "Mid-work capture — record thoughts, draw connections, search",
+            Toolset::Garden => "Consolidation — promote memories, name experiences, connect, search",
+            Toolset::Admin => "Setup and evolution — brains, agents, vocabulary, storage",
+            Toolset::Distribute => "Sharing — bookmarks, export, import",
+        }
+    }
+
+    /// Number of tools in this toolset.
+    pub fn tool_count(&self) -> usize {
+        self.defs().len()
+    }
+}
+
+impl fmt::Display for Toolset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Toolset::Lifecycle => write!(f, "lifecycle"),
+            Toolset::Capture => write!(f, "capture"),
+            Toolset::Garden => write!(f, "garden"),
+            Toolset::Admin => write!(f, "admin"),
+            Toolset::Distribute => write!(f, "distribute"),
+        }
+    }
+}
+
+impl FromStr for Toolset {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "lifecycle" => Ok(Toolset::Lifecycle),
+            "capture" => Ok(Toolset::Capture),
+            "garden" => Ok(Toolset::Garden),
+            "admin" => Ok(Toolset::Admin),
+            "distribute" => Ok(Toolset::Distribute),
+            other => Err(format!(
+                "Unknown toolset: '{other}'. Available: lifecycle, capture, garden, admin, distribute"
+            )),
+        }
+    }
+}
+
+/// Request to activate a toolset — changes which tools are available.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ActivateToolset {
+    /// The toolset to load. Options: lifecycle, capture, garden, admin, distribute.
+    pub toolset: String,
+}
+
+/// Request to deactivate the current toolset — returns to root only.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DeactivateToolset {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toolset_round_trips_through_string() {
+        for toolset in Toolset::all() {
+            let s = toolset.to_string();
+            let parsed: Toolset = s.parse().unwrap();
+            assert_eq!(&parsed, toolset);
+        }
+    }
+
+    #[test]
+    fn unknown_toolset_gives_helpful_error() {
+        let err = "bogus".parse::<Toolset>().unwrap_err();
+        assert!(err.contains("Unknown toolset"));
+        assert!(err.contains("lifecycle"));
+    }
+
+    #[test]
+    fn toolset_serde_round_trip() {
+        for toolset in Toolset::all() {
+            let json = serde_json::to_string(toolset).unwrap();
+            let parsed: Toolset = serde_json::from_str(&json).unwrap();
+            assert_eq!(&parsed, toolset);
+        }
+    }
+}


### PR DESCRIPTION
This redesigns our MCP layer so that we can let models navigate it fluidly. This is mostly just a research spike, though - we are following up with a distinct implementation that uses less stringly typed approaches, and is consistent with recent updates we've made to the overall structure.