### PR TITLE
Hints use actual command paths.

### DIFF
--- a/crates/oneiros-engine/src/values/hints/cognition_added_hints.rs
+++ b/crates/oneiros-engine/src/values/hints/cognition_added_hints.rs
@@ -16,11 +16,11 @@ impl CognitionAddedHints {
         vec![
             Hint::suggest(format!("reflect {agent}"), "Pause on something significant"),
             Hint::inspect(
-                format!("cognition list {agent}"),
+                format!("cognition list --agent {agent}"),
                 "Browse your full thought stream",
             ),
             Hint::suggest(
-                format!("connection create {ref_token} <target>"),
+                format!("connection create <nature> {ref_token} <target>"),
                 "Draw a line between related things",
             ),
         ]

--- a/crates/oneiros-engine/src/values/hints/listing_hints.rs
+++ b/crates/oneiros-engine/src/values/hints/listing_hints.rs
@@ -20,7 +20,7 @@ impl ListingHints {
 
         if self.has_more {
             hints.push(Hint::inspect(
-                format!("cognition list {agent}"),
+                format!("cognition list --agent {agent}"),
                 "There are more items to explore",
             ));
         }

--- a/crates/oneiros-engine/src/values/hints/mutation_hints.rs
+++ b/crates/oneiros-engine/src/values/hints/mutation_hints.rs
@@ -13,7 +13,7 @@ impl MutationHints {
         let ref_token = &self.ref_token;
         vec![
             Hint::suggest(
-                format!("connection create {ref_token} <target>"),
+                format!("connection create <nature> {ref_token} <target>"),
                 "Draw a line between related things",
             ),
             Hint::suggest(format!("search {ref_token}"), "Find related entities"),

--- a/crates/oneiros-engine/src/values/hints/reflect_hints.rs
+++ b/crates/oneiros-engine/src/values/hints/reflect_hints.rs
@@ -17,11 +17,11 @@ impl ReflectHints {
                 "Consolidate this reflection into memory",
             ),
             Hint::suggest(
-                format!("experience create {agent} \"...\""),
+                format!("experience create {agent} <sensation> \"...\""),
                 "Mark this as a meaningful moment",
             ),
             Hint::inspect(
-                format!("cognition list {agent}"),
+                format!("cognition list --agent {agent}"),
                 "Review the thought stream that led here",
             ),
         ]


### PR DESCRIPTION
We can't actually - frustratingly - use hints in a typesafe way, command-wise. So we're just going to goof up on this from time to time, I guess. Unless we're supremely disciplined and never forget to manually double check, I suppose?

This commit fixes some of our command notation in hints so that it uses actual notation.