### PR TITLE
Bookmarks as lenses.

### DIFF
--- a/crates/oneiros-engine/src/config.rs
+++ b/crates/oneiros-engine/src/config.rs
@@ -35,6 +35,10 @@ pub struct Config {
     #[arg(long, short, global = true, default_value_t = detect_brain_name())]
     #[builder(into, default = detect_brain_name())]
     pub brain: BrainName,
+    /// The bookmark (lens) to operate through. Defaults to main.
+    #[arg(long, global = true, default_value_t = BookmarkName::main())]
+    #[builder(into, default = BookmarkName::main())]
+    pub bookmark: BookmarkName,
     /// Service management configuration.
     #[command(flatten)]
     #[builder(default)]
@@ -62,6 +66,7 @@ impl Default for Config {
         Self {
             data_dir: default_data_dir(),
             brain: detect_brain_name(),
+            bookmark: BookmarkName::main(),
             service: ServiceConfig::default(),
             dream: DreamConfig::default(),
             output: OutputMode::default(),
@@ -99,10 +104,44 @@ impl Config {
         Ok(conn)
     }
 
-    /// Open the brain (project) database.
-    pub fn brain_db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        let conn = rusqlite::Connection::open(self.brain_dir().join("brain.db"))?;
+    /// Path to the brain's event log database.
+    pub fn events_db_path(&self) -> PathBuf {
+        self.brain_dir().join("events.db")
+    }
+
+    /// Path to the bookmark's projection database.
+    pub fn bookmark_db_path(&self) -> PathBuf {
+        self.brain_dir()
+            .join("bookmarks")
+            .join(format!("{}.db", self.bookmark))
+    }
+
+    /// Directory containing all bookmark databases for this brain.
+    pub fn bookmarks_dir(&self) -> PathBuf {
+        self.brain_dir().join("bookmarks")
+    }
+
+    /// Open the bookmark DB as base with the events DB ATTACHed.
+    ///
+    /// Unqualified table names resolve to the bookmark DB (projections).
+    /// Event log operations use the `events` schema qualifier.
+    /// Both share one connection and transaction for atomicity.
+    pub fn bookmark_conn(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
+        let bookmark_path = self.bookmark_db_path();
+        if let Some(parent) = bookmark_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+
+        let conn = rusqlite::Connection::open(&bookmark_path)?;
         conn.pragma_update(None, "journal_mode", "wal")?;
+        conn.pragma_update(None, "limit_attached", "125")?;
+
+        let events_path = self.events_db_path();
+        conn.execute_batch(&format!(
+            "ATTACH DATABASE '{}' AS events",
+            events_path.display(),
+        ))?;
+
         Ok(conn)
     }
 
@@ -229,6 +268,9 @@ impl Config {
         }
         if self.brain == defaults.brain {
             self.brain = file_config.brain;
+        }
+        if self.bookmark == defaults.bookmark {
+            self.bookmark = file_config.bookmark;
         }
         if self.output == defaults.output {
             self.output = file_config.output;

--- a/crates/oneiros-engine/src/contexts/project.rs
+++ b/crates/oneiros-engine/src/contexts/project.rs
@@ -74,9 +74,13 @@ impl ProjectContext {
         self.broadcast.subscribe()
     }
 
-    /// Open the brain (project) database.
+    /// Open the bookmark DB with the events DB ATTACHed.
+    ///
+    /// Unqualified table names resolve to the bookmark DB (projections).
+    /// Event log operations use the `events` schema qualifier via
+    /// `EventLog::attached`.
     pub fn db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        self.config.brain_db()
+        self.config.bookmark_conn()
     }
 
     /// Open the system database.
@@ -86,19 +90,22 @@ impl ProjectContext {
 
     /// Replay all events through projections, rebuilding read models.
     pub fn replay(&self) -> Result<usize, EventError> {
-        self.projections.replay_brain(&self.db()?)
+        let db = self.db()?;
+        let log = EventLog::attached(&db);
+        self.projections.replay_brain(&db, &log)
     }
 
     /// Emit an event to the brain's event log and apply projections.
     pub async fn emit(&self, event: impl Into<Events>) -> Result<(), EventError> {
         let db = self.db()?;
         let new_event = NewEvent::builder().data(event).build();
-        let stored = EventLog::new(&db).append(&new_event)?;
+        let stored = EventLog::attached(&db).append(&new_event)?;
 
         self.projections.apply_brain(&db, &stored)?;
 
-        // Chronicle the event — record it in the active bookmark's ledger.
-        let chronicle_store = ChronicleStore::new(&db);
+        // Chronicle the event in the system DB (shared across bookmarks).
+        let system_db = self.system_db()?;
+        let chronicle_store = ChronicleStore::new(&system_db);
         chronicle_store.migrate()?;
         self.chronicle.record(
             &stored,

--- a/crates/oneiros-engine/src/domains/bookmark/service.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/service.rs
@@ -11,6 +11,9 @@ impl BookmarkService {
         let from = state.canons().active_bookmark(brain)?;
         state.canons().fork_brain(brain, name)?;
 
+        // Create the new bookmark's DB and replay the source events into it.
+        Self::create_bookmark_db(state.config(), brain, name)?;
+
         let forked = BookmarkForked {
             brain: brain.clone(),
             name: name.clone(),
@@ -30,11 +33,9 @@ impl BookmarkService {
         brain: &BrainName,
         SwitchBookmark { name }: &SwitchBookmark,
     ) -> Result<BookmarkResponse, BookmarkError> {
-        let old_chronicle = state.canons().chronicle(brain)?;
+        // With per-bookmark DBs, switch just updates the default.
+        // Both bookmark DBs already exist with current projections.
         state.canons().switch_brain(brain, name)?;
-        let new_chronicle = state.canons().chronicle(brain)?;
-
-        Self::rebuild_projections(state.config(), brain, &old_chronicle, &new_chronicle)?;
 
         let switched = BookmarkSwitched {
             brain: brain.clone(),
@@ -57,7 +58,7 @@ impl BookmarkService {
         let target = state.canons().active_bookmark(brain)?;
         state.canons().merge_brain(brain, source, &target)?;
 
-        Self::replay_brain_projections(state.config(), brain)?;
+        Self::replay_bookmark(state.config(), brain, &target)?;
 
         let merged = BookmarkMerged {
             brain: brain.clone(),
@@ -175,6 +176,9 @@ impl BookmarkService {
             .await?;
         state.canons().fork_brain(brain, name)?;
 
+        // Create the new bookmark's DB (empty — collect will populate it).
+        Self::create_bookmark_db(state.config(), brain, name)?;
+
         let follow = FollowService::create(&system, brain.clone(), name.clone(), source).await?;
         Ok(BookmarkResponse::Followed(follow))
     }
@@ -220,19 +224,19 @@ impl BookmarkService {
         let chronicle = state.canons().bookmark_chronicle(brain, &follow.bookmark)?;
         let local_root = chronicle.root()?;
 
-        // Build a local resolver from the brain's ChronicleStore.
+        // Build a local resolver from the system DB's ChronicleStore.
         // Opens its own connection per resolve call — Send-safe across
         // the async diff, and fast with WAL mode (~20 resolves per tree walk).
         let mut brain_config = state.config().clone();
         brain_config.brain = brain.clone();
         {
-            let db = brain_config.brain_db()?;
+            let db = state.config().system_db()?;
             ChronicleStore::new(&db).migrate()?;
         }
         let local_resolve = {
-            let config = brain_config.clone();
+            let config = state.config().clone();
             move |hash: &ContentHash| -> Option<LedgerNode> {
-                let db = config.brain_db().ok()?;
+                let db = config.system_db().ok()?;
                 ChronicleStore::new(&db).get(hash)
             }
         };
@@ -269,9 +273,15 @@ impl BookmarkService {
                 .await
                 .map_err(|e: BridgeError| BookmarkError::InvalidUri(e.to_string()))?;
 
-            let db = brain_config.brain_db()?;
-            let log = EventLog::new(&db);
-            let chronicle_store = ChronicleStore::new(&db);
+            // Import events to the event log (standalone events.db).
+            let events_path = brain_config.events_db_path();
+            let events_db = rusqlite::Connection::open(&events_path)?;
+            events_db.pragma_update(None, "journal_mode", "wal")?;
+            let log = EventLog::new(&events_db);
+
+            // Chronicle objects live in the system DB.
+            let system_db = state.config().system_db()?;
+            let chronicle_store = ChronicleStore::new(&system_db);
             chronicle_store.migrate()?;
 
             for event in &events {
@@ -286,8 +296,8 @@ impl BookmarkService {
             }
         }
 
-        // Phase 3: Replay projections from the updated event log.
-        Self::replay_brain_projections(state.config(), brain)?;
+        // Phase 3: Replay projections into the follow's bookmark DB.
+        Self::replay_bookmark(state.config(), brain, &follow.bookmark)?;
 
         // Store the server's root hash in the checkpoint so we can
         // detect "already up to date" on the next collect.
@@ -328,47 +338,44 @@ impl BookmarkService {
         }))
     }
 
-    fn replay_brain_projections(config: &Config, brain: &BrainName) -> Result<(), BookmarkError> {
-        let mut brain_config = config.clone();
-        brain_config.brain = brain.clone();
-        let db = brain_config.brain_db()?;
-        Projections::<BrainCanon>::project().replay_brain(&db)?;
-        Ok(())
-    }
-
-    fn rebuild_projections(
+    /// Replay the event log into a specific bookmark's projection DB.
+    fn replay_bookmark(
         config: &Config,
         brain: &BrainName,
-        old_chronicle: &Chronicle,
-        new_chronicle: &Chronicle,
+        bookmark: &BookmarkName,
     ) -> Result<(), BookmarkError> {
         let mut brain_config = config.clone();
         brain_config.brain = brain.clone();
-        let db = brain_config.brain_db()?;
+        brain_config.bookmark = bookmark.clone();
+        let db = brain_config.bookmark_conn()?;
+        let log = EventLog::attached(&db);
+        Projections::<BrainCanon>::project().replay_brain(&db, &log)?;
+        Ok(())
+    }
 
-        let chronicle_store = ChronicleStore::new(&db);
-        chronicle_store.migrate()?;
+    /// Create a new bookmark DB and replay events into it.
+    ///
+    /// Migrates the schema, then replays the event log through
+    /// projections so the new bookmark starts with the source's state.
+    fn create_bookmark_db(
+        config: &Config,
+        brain: &BrainName,
+        bookmark: &BookmarkName,
+    ) -> Result<(), BookmarkError> {
+        let mut brain_config = config.clone();
+        brain_config.brain = brain.clone();
+        brain_config.bookmark = bookmark.clone();
 
-        let changes = old_chronicle.diff(new_chronicle, &chronicle_store.resolver())?;
-        if changes.is_empty() {
-            return Ok(());
-        }
+        let bookmarks_dir = brain_config.bookmarks_dir();
+        std::fs::create_dir_all(&bookmarks_dir)
+            .map_err(|e| BookmarkError::InvalidUri(e.to_string()))?;
 
-        let new_root = new_chronicle.root()?;
-        let new_event_ids: std::collections::HashSet<String> =
-            Ledger::collect_all_ids(new_root.as_ref(), &chronicle_store.resolver());
-
+        // Open the new bookmark DB with events ATTACHed and replay.
+        let db = brain_config.bookmark_conn()?;
         let projections = Projections::<BrainCanon>::project();
-        let all_events = EventLog::new(&db).load_all()?;
-
         projections.migrate(&db)?;
-        projections.reset(&db)?;
-
-        for event in &all_events {
-            if new_event_ids.contains(&event.id.to_string()) {
-                projections.apply_frames(&db, event)?;
-            }
-        }
+        let log = EventLog::attached(&db);
+        projections.replay_brain(&db, &log)?;
 
         Ok(())
     }

--- a/crates/oneiros-engine/src/domains/bridge/service.rs
+++ b/crates/oneiros-engine/src/domains/bridge/service.rs
@@ -36,10 +36,13 @@ impl SyncHandler {
         Ok(ticket)
     }
 
-    fn brain_db(&self, brain: &BrainName) -> Result<rusqlite::Connection, BridgeError> {
-        let mut brain_config = self.config.clone();
-        brain_config.brain = brain.clone();
-        Ok(brain_config.brain_db()?)
+    fn events_db(&self, brain: &BrainName) -> Result<rusqlite::Connection, BridgeError> {
+        let mut config = self.config.clone();
+        config.brain = brain.clone();
+        let path = config.events_db_path();
+        let conn = rusqlite::Connection::open(path)?;
+        conn.pragma_update(None, "journal_mode", "wal")?;
+        Ok(conn)
     }
 
     async fn handle_diff(&self, diff: &BridgeDiff) -> Result<BridgeResponse, BridgeError> {
@@ -57,8 +60,9 @@ impl SyncHandler {
             return Ok(BridgeResponse::BridgeCurrent);
         };
 
-        let db = self.brain_db(&ticket.brain_name)?;
-        let store = ChronicleStore::new(&db);
+        // Chronicle objects live in the system DB.
+        let system_db = self.config.system_db()?;
+        let store = ChronicleStore::new(&system_db);
         let resolve = store.resolver();
 
         let node = resolve(&root_hash).ok_or_else(|| {
@@ -75,9 +79,11 @@ impl SyncHandler {
         &self,
         resolve_req: &BridgeResolve,
     ) -> Result<BridgeResponse, BridgeError> {
-        let ticket = self.validate_ticket(&resolve_req.link).await?;
-        let db = self.brain_db(&ticket.brain_name)?;
-        let store = ChronicleStore::new(&db);
+        let _ticket = self.validate_ticket(&resolve_req.link).await?;
+
+        // Chronicle objects live in the system DB.
+        let system_db = self.config.system_db()?;
+        let store = ChronicleStore::new(&system_db);
         let resolve = store.resolver();
 
         let nodes: Vec<(ContentHash, LedgerNode)> = resolve_req
@@ -94,7 +100,9 @@ impl SyncHandler {
         fetch: &BridgeFetchEvents,
     ) -> Result<BridgeResponse, BridgeError> {
         let ticket = self.validate_ticket(&fetch.link).await?;
-        let db = self.brain_db(&ticket.brain_name)?;
+
+        // Event log lives in events.db (standalone, no ATTACH).
+        let db = self.events_db(&ticket.brain_name)?;
 
         let ids: Vec<EventId> = fetch
             .event_ids

--- a/crates/oneiros-engine/src/domains/doctor/service.rs
+++ b/crates/oneiros-engine/src/domains/doctor/service.rs
@@ -53,17 +53,17 @@ impl DoctorService {
         // Brain check
         let brain_name = config.brain.clone();
 
-        match config.brain_db() {
+        match config.bookmark_conn() {
             Ok(brain_db) => {
                 let brain_events = brain_db
-                    .query_row("select count(*) from events", [], |row| {
+                    .query_row("select count(*) from events.events", [], |row| {
                         row.get::<_, i64>(0)
                     })
                     .unwrap_or(-1);
 
                 if brain_events >= 0 {
                     checks.push(DoctorCheck::BrainExists(brain_name.clone()));
-                    checks.push(DoctorCheck::DatabaseOk(DatabaseLabel::new("brain.db")));
+                    checks.push(DoctorCheck::DatabaseOk(DatabaseLabel::new("events.db")));
 
                     // Vocabulary check — look for any levels
                     let has_levels = brain_db

--- a/crates/oneiros-engine/src/domains/project/service.rs
+++ b/crates/oneiros-engine/src/domains/project/service.rs
@@ -36,14 +36,24 @@ impl ProjectService {
             }))
             .await?;
 
-        // Ensure brain directory and DB schema exist (mirrors legacy create_brain_db).
+        // Create the brain's database layout:
+        //   {brain_dir}/events.db         — event log (append-only)
+        //   {brain_dir}/bookmarks/main.db — projection tables for the default bookmark
         let brain_dir = context.config.data_dir.join(brain_name.as_str());
-        std::fs::create_dir_all(&brain_dir)?;
-        let brain_db = rusqlite::Connection::open(brain_dir.join("brain.db"))?;
-        brain_db.pragma_update(None, "journal_mode", "wal")?;
-        EventLog::new(&brain_db).migrate()?;
-        Projections::project().migrate(&brain_db)?;
-        drop(brain_db);
+        let bookmarks_dir = brain_dir.join("bookmarks");
+        std::fs::create_dir_all(&bookmarks_dir)?;
+
+        // Event log — standalone, no ATTACH needed during init.
+        let events_db = rusqlite::Connection::open(brain_dir.join("events.db"))?;
+        events_db.pragma_update(None, "journal_mode", "wal")?;
+        EventLog::new(&events_db).migrate()?;
+        drop(events_db);
+
+        // Default bookmark projections — standalone during init.
+        let bookmark_db = rusqlite::Connection::open(bookmarks_dir.join("main.db"))?;
+        bookmark_db.pragma_update(None, "journal_mode", "wal")?;
+        Projections::project().migrate(&bookmark_db)?;
+        drop(bookmark_db);
 
         let all_filters = SearchFilters {
             limit: Limit(usize::MAX),
@@ -94,8 +104,8 @@ impl ProjectService {
     ) -> Result<ProjectResponse, ProjectError> {
         let target_dir = &request.target;
         let project_name = context.brain_name();
-        let events = EventLog::new(&context.db()?).load_all()?;
         let db = context.db()?;
+        let events = EventLog::attached(&db).load_all()?;
         let storage = StorageStore::new(&db);
 
         let mut buffer = String::new();
@@ -146,7 +156,7 @@ impl ProjectService {
         let mut imported = 0usize;
 
         let db = context.db()?;
-        let log = EventLog::new(&db);
+        let log = EventLog::attached(&db);
 
         // Batch all inserts in a single transaction — without this,
         // each INSERT is an implicit transaction with an fsync.
@@ -184,7 +194,8 @@ impl ProjectService {
             }
         }
 
-        let replayed = context.projections.replay_brain(&db)?;
+        let log = EventLog::attached(&db);
+        let replayed = context.projections.replay_brain(&db, &log)?;
 
         Ok(ProjectResponse::Imported(ImportResult {
             imported: EventCount::new(imported as i64),
@@ -194,7 +205,9 @@ impl ProjectService {
 
     /// Replay all events through projections, rebuilding read models.
     pub fn replay(context: &ProjectContext) -> Result<ProjectResponse, ProjectError> {
-        let replayed = context.projections.replay_brain(&context.db()?)?;
+        let db = context.db()?;
+        let log = EventLog::attached(&db);
+        let replayed = context.projections.replay_brain(&db, &log)?;
 
         Ok(ProjectResponse::Replayed(ReplayResult {
             replayed: EventCount::new(replayed as i64),

--- a/crates/oneiros-engine/src/events/event_log.rs
+++ b/crates/oneiros-engine/src/events/event_log.rs
@@ -13,28 +13,47 @@ use crate::*;
 /// Pure persistence: append events, load them back, import from
 /// external sources, delete transient entries. No projections,
 /// no broadcasting — those are the bus's concern.
+///
+/// Two construction modes:
+/// - `new(conn)` — standalone, events DB is the base connection.
+///   Table references are unqualified (`events`).
+/// - `attached(conn)` — the bookmark DB is the base connection and
+///   the events DB is ATTACHed as `events`. Table references use
+///   the `events.` schema qualifier.
 pub struct EventLog<'a> {
     conn: &'a rusqlite::Connection,
+    table: &'static str,
 }
 
 impl<'a> EventLog<'a> {
+    /// Standalone mode — events DB is the base connection.
     pub fn new(conn: &'a rusqlite::Connection) -> Self {
-        Self { conn }
+        Self {
+            conn,
+            table: "events",
+        }
+    }
+
+    /// ATTACH mode — bookmark DB is the base, events DB ATTACHed as `events`.
+    pub fn attached(conn: &'a rusqlite::Connection) -> Self {
+        Self {
+            conn,
+            table: "events.events",
+        }
     }
 
     /// Create the events table.
     pub fn migrate(&self) -> Result<(), EventError> {
-        self.conn.execute_batch(
-            "
-            create table if not exists events (
-                id text primary key,
-                event_type text not null,
-                data text not null,
-                source text not null default '',
-                created_at text not null
-            );
-            ",
-        )?;
+        self.conn.execute_batch(&format!(
+            "CREATE TABLE IF NOT EXISTS {} (
+                id TEXT PRIMARY KEY,
+                event_type TEXT NOT NULL,
+                data TEXT NOT NULL,
+                source TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL
+            )",
+            self.table,
+        ))?;
 
         Ok(())
     }
@@ -48,7 +67,10 @@ impl<'a> EventLog<'a> {
         let now = Timestamp::now();
 
         self.conn.execute(
-            "INSERT INTO events (id, event_type, data, source, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+            &format!(
+                "INSERT INTO {} (id, event_type, data, source, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+                self.table,
+            ),
             params![id.to_string(), event_type, data_json, source_json, now.as_string()],
         )?;
 
@@ -65,9 +87,10 @@ impl<'a> EventLog<'a> {
 
     /// Load all events in sequence order.
     pub fn load_all(&self) -> Result<Vec<StoredEvent>, EventError> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT id, rowid, data, source, created_at FROM events ORDER BY rowid")?;
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT id, rowid, data, source, created_at FROM {} ORDER BY rowid",
+            self.table,
+        ))?;
 
         let events = stmt
             .query_map([], |row| {
@@ -105,8 +128,9 @@ impl<'a> EventLog<'a> {
 
         let placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("?{i}")).collect();
         let query = format!(
-            "SELECT id, rowid, data, source, created_at FROM events WHERE id IN ({}) ORDER BY rowid",
-            placeholders.join(",")
+            "SELECT id, rowid, data, source, created_at FROM {} WHERE id IN ({}) ORDER BY rowid",
+            self.table,
+            placeholders.join(","),
         );
 
         let mut stmt = self.conn.prepare(&query)?;
@@ -145,7 +169,10 @@ impl<'a> EventLog<'a> {
         let source_json = serde_json::to_string(&event.source)?;
 
         self.conn.execute(
-            "INSERT OR IGNORE INTO events (id, event_type, data, source, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+            &format!(
+                "INSERT OR IGNORE INTO {} (id, event_type, data, source, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+                self.table,
+            ),
             params![
                 event.id.to_string(),
                 event_type,
@@ -163,8 +190,10 @@ impl<'a> EventLog<'a> {
     /// Rarely needed — the event log is append-only by design.
     /// Exists for administrative operations, not domain logic.
     pub fn delete(&self, event_id: &str) -> Result<(), EventError> {
-        self.conn
-            .execute("DELETE FROM events WHERE id = ?1", params![event_id])?;
+        self.conn.execute(
+            &format!("DELETE FROM {} WHERE id = ?1", self.table),
+            params![event_id],
+        )?;
         Ok(())
     }
 }

--- a/crates/oneiros-engine/src/http/state.rs
+++ b/crates/oneiros-engine/src/http/state.rs
@@ -97,7 +97,10 @@ impl ServerState {
         &self.broadcast
     }
 
-    /// Build a project context with shared broadcast, canon, and pipeline.
+    /// Build a project context with shared broadcast and pipeline.
+    ///
+    /// Resolves the active bookmark for the brain unless the config
+    /// already has an explicit bookmark override.
     pub fn project_context(&self, config: Config) -> Result<ProjectContext, EventError> {
         let entry = self.canons.brain_entry(&config.brain)?;
         Ok(ProjectContext::with_entry(
@@ -171,7 +174,28 @@ impl FromRequestParts<ServerState> for ProjectContext {
 
         // Assemble ProjectContext with shared broadcast channel
         let mut config = state.config.clone();
-        config.brain = ticket.brain_name;
+        config.brain = ticket.brain_name.clone();
+
+        // Default to the active bookmark for this brain.
+        config.bookmark = state
+            .canons()
+            .active_bookmark(&ticket.brain_name)
+            .unwrap_or_else(|_| BookmarkName::main());
+
+        // Override with explicit X-Bookmark header or ?bookmark= query param.
+        if let Some(bookmark) = parts
+            .headers
+            .get("x-bookmark")
+            .and_then(|v| v.to_str().ok())
+            .or_else(|| {
+                parts
+                    .uri
+                    .query()
+                    .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("bookmark=")))
+            })
+        {
+            config.bookmark = BookmarkName::new(bookmark);
+        }
 
         state
             .project_context(config)

--- a/crates/oneiros-engine/src/projections.rs
+++ b/crates/oneiros-engine/src/projections.rs
@@ -76,8 +76,8 @@ impl<T: Clone + Default> Projections<T> {
     }
 
     /// Replay all events through frames and reducers.
-    pub fn replay(&self, db: &rusqlite::Connection) -> Result<usize, EventError> {
-        let events = EventLog::new(db).load_all()?;
+    pub fn replay(&self, db: &rusqlite::Connection, log: &EventLog) -> Result<usize, EventError> {
+        let events = log.load_all()?;
 
         self.reset(db)?;
 
@@ -134,8 +134,12 @@ impl Projections<BrainCanon> {
     }
 
     /// Replay for brain projections — includes pressure sync at the end.
-    pub fn replay_brain(&self, db: &rusqlite::Connection) -> Result<usize, EventError> {
-        let count = self.replay(db)?;
+    pub fn replay_brain(
+        &self,
+        db: &rusqlite::Connection,
+        log: &EventLog,
+    ) -> Result<usize, EventError> {
+        let count = self.replay(db, log)?;
         self.sync_pressures(db)?;
         Ok(count)
     }

--- a/crates/oneiros-engine/src/values/canon_index.rs
+++ b/crates/oneiros-engine/src/values/canon_index.rs
@@ -175,12 +175,13 @@ impl CanonIndex {
             && let (Some(source_entry), Some(target_entry)) =
                 (shelf.branches.get(source), shelf.branches.get(target))
         {
-            let brain_config = Config {
+            // Chronicle objects live in the system DB.
+            let config = Config {
                 brain: brain.clone(),
                 ..Default::default()
             };
 
-            if let Ok(db) = brain_config.brain_db() {
+            if let Ok(db) = config.system_db() {
                 let store = ChronicleStore::new(&db);
                 let _ = store.migrate();
                 let _ = target_entry.chronicle.merge(
@@ -194,18 +195,28 @@ impl CanonIndex {
         Ok(())
     }
 
-    /// Hydrate a brain's reducer pipeline from its event log.
+    /// Hydrate a brain's reducer pipeline and chronicle from its event log.
     ///
-    /// Runs migrations first to ensure the schema is current.
+    /// Opens events.db standalone for the event log, then the bookmark
+    /// connection for projection migrations.
     pub fn hydrate_brain(&self, config: &Config, name: &BrainName) -> Result<(), EventError> {
         let mut brain_config = config.clone();
         brain_config.brain = name.clone();
 
-        let db = brain_config.brain_db()?;
+        // Events DB — standalone (no ATTACH).
+        let events_path = brain_config.events_db_path();
+        if !events_path.exists() {
+            return Ok(());
+        }
+        let events_db = rusqlite::Connection::open(&events_path)?;
+        events_db.pragma_update(None, "journal_mode", "wal")?;
+        let log = EventLog::new(&events_db);
 
-        Projections::<BrainCanon>::project().migrate(&db)?;
+        // Ensure projection schema exists in the bookmark DB.
+        let bookmark_db = brain_config.bookmark_conn()?;
+        Projections::<BrainCanon>::project().migrate(&bookmark_db)?;
 
-        let events = EventLog::new(&db).load_all()?;
+        let events = log.load_all()?;
 
         let entry = self.brain_entry(name)?;
 
@@ -213,8 +224,9 @@ impl CanonIndex {
             entry.pipeline.apply(&event.data)?;
         }
 
-        // Rebuild the chronicle from the event log.
-        let store = ChronicleStore::new(&db);
+        // Rebuild the chronicle in the system DB.
+        let system_db = config.system_db()?;
+        let store = ChronicleStore::new(&system_db);
         store.migrate()?;
         for event in &events {
             entry


### PR DESCRIPTION
This commit introduces some bookmark-based updates that change the bookmark fundamentals dramatically. They still operate in the same way, but the semantics of what they're doing are fundamentally different, hopefully in a way that expands what you can do with them.

Bookmarks
---

Some background on bookmarks: these are analogous to a "branch" of your agent's continuity. Whenever you name a bookmark, all of the events you incur while that bookmark is active land only on that bookmark. So, switching the bookmark would switch continuity within a single brain, allowing you to do a bit of selective awareness and context manipulation with your oneiroi.

Bookmarks exposed some operational valves under the `bookmark` command:

- `create` adds a new bookmark at your current point, creating a fork of your current continuity
- `switch` switches over to a new bookmark
- `merge` combines two bookmarks

And so on. Bookmarks also offered some operational distribution tools:

- `share` creates a link you can share with other people on other machines, on other projects
- `follow` takes a link and connects you with another person's bookmark
- `collect` pulls any pending events from the other bookmark

Sharing / following works locally or across the internet. The oneiroi know how to find each other with a share link.

The update
---

All in all, this is pretty powerful, but it had a pretty major limitation, which was this: your whole project db coexisted with your event log, and there was just one of them. That had some downstream effects, mainly that even though your oneiroi were able to distribute across networks, you couldn't do that locally. Because you share one db per project, all local oneiroi have the same bookmark active no matter what. The last bookmark would always claim the database, and always win. Not great.

The change
---

In order to get things in better shape, a few things change:

- Bookmarks now all have a distinct database, and those are split from the main project event log. These are lazily updated, but they stick around! So now switches are free.
- Right now this is still last agent wins, because it works by changing the active config, _but_ individual agents can issue per-request bookmarks, to make sure commands land in the right spot at all times.