### PR TITLE
Arc the API.

### DIFF
--- a/crates/oneiros-engine/src/http/server.rs
+++ b/crates/oneiros-engine/src/http/server.rs
@@ -5,7 +5,7 @@ use aide::{
     openapi::OpenApi,
     scalar::Scalar,
 };
-use axum::{Extension, Json, Router, extract::State, response::Html, routing};
+use axum::{Json, Router, extract::State, response::Html, routing};
 use rmcp::transport::streamable_http_server::{
     session::local::LocalSessionManager, tower::StreamableHttpService,
 };
@@ -71,9 +71,11 @@ impl Server {
             Json(serde_json::json!({ "token": token, "brain": brain }))
         }
 
-        /// Serves the OpenAPI spec as JSON.
-        async fn serve_api(Extension(api): Extension<OpenApi>) -> Json<OpenApi> {
-            Json(api)
+        /// Serves the OpenAPI spec as JSON. Pulled from state — populated
+        /// once after router assembly to avoid a global `.layer(Extension)`
+        /// walk over every route on each server build.
+        async fn serve_api(State(state): State<ServerState>) -> Json<OpenApi> {
+            Json(state.api().cloned().unwrap_or_default())
         }
 
         let root = Router::new()
@@ -95,7 +97,7 @@ impl Server {
         let mut api = OpenApi::default();
         let app_docs = AppDocs;
 
-        ApiRouter::new()
+        let router = ApiRouter::new()
             .merge(root)
             .nest_service("/mcp", Router::new().route_service("/", mcp_service))
             .merge(ActorRouter.routes())
@@ -148,8 +150,9 @@ impl Server {
                 }
 
                 api
-            })
-            .layer(Extension(api))
-            .with_state(state)
+            });
+
+        state.set_api(api);
+        router.with_state(state)
     }
 }

--- a/crates/oneiros-engine/src/http/state.rs
+++ b/crates/oneiros-engine/src/http/state.rs
@@ -1,3 +1,6 @@
+use std::sync::{Arc, OnceLock};
+
+use aide::openapi::OpenApi;
 use axum::{extract::FromRequestParts, http::request::Parts};
 use tokio::sync::broadcast;
 
@@ -14,6 +17,7 @@ pub struct ServerState {
     broadcast: broadcast::Sender<StoredEvent>,
     canons: CanonIndex,
     bridge: Bridge,
+    api: Arc<OnceLock<OpenApi>>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -38,7 +42,18 @@ impl ServerState {
             broadcast,
             canons,
             bridge,
+            api: Arc::new(OnceLock::new()),
         })
+    }
+
+    /// Install the OpenAPI spec. Called once after the router is assembled.
+    pub fn set_api(&self, api: OpenApi) {
+        let _ = self.api.set(api);
+    }
+
+    /// The installed OpenAPI spec, if set.
+    pub fn api(&self) -> Option<&OpenApi> {
+        self.api.get()
     }
 
     /// The bound bridge.


### PR DESCRIPTION
We goofed up and didn't put the API in an arc, meaning that every single time we cloned the server state, it was recrawling our API routes to reassemble what it needed for its API docs. Putting it behind a reference counter evades that rebuild behavior completely.

How did we notice this? Well, our CI doubled in how long it took, and it turned out to be mostly around the constant rebuilding of routes.