### PR TITLE
Lists are searches.

### DIFF
--- a/crates/oneiros-engine/src/domains/agent/client.rs
+++ b/crates/oneiros-engine/src/domains/agent/client.rs
@@ -15,10 +15,20 @@ impl<'a> AgentClient<'a> {
 
     pub async fn list(&self, listing: &ListAgents) -> Result<AgentResponse, ClientError> {
         let ListAgents::V1(listing) = listing;
-        let query = format!(
-            "limit={}&offset={}",
-            listing.filters.limit, listing.filters.offset
-        );
+        let mut params: Vec<(&str, String)> = Vec::new();
+
+        if let Some(query) = &listing.query {
+            params.push(("query", query.clone()));
+        }
+
+        params.push(("limit", listing.filters.limit.to_string()));
+        params.push(("offset", listing.filters.offset.to_string()));
+
+        let query = params
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect::<Vec<_>>()
+            .join("&");
         self.client.get(&format!("/agents?{query}")).await
     }
 

--- a/crates/oneiros-engine/src/domains/agent/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/agent/protocol/requests.rs
@@ -36,6 +36,12 @@ versioned! {
     pub enum ListAgents {
         #[derive(clap::Args)]
         V1 => {
+            /// Full-text query against agent name + description. When present,
+            /// hits are FTS5-ranked; absent, the listing browses by filters
+            /// alone.
+            #[arg(long)]
+            #[builder(into)]
+            pub query: Option<String>,
             #[command(flatten)]
             #[serde(flatten)]
             #[builder(default)]

--- a/crates/oneiros-engine/src/domains/agent/repo.rs
+++ b/crates/oneiros-engine/src/domains/agent/repo.rs
@@ -1,4 +1,6 @@
-use rusqlite::params;
+use std::collections::HashMap;
+
+use rusqlite::{params, params_from_iter};
 
 use crate::*;
 
@@ -76,44 +78,47 @@ impl<'a> AgentRepo<'a> {
         }
     }
 
-    pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Agent>, EventError> {
+    /// Hydrate many agents by id, preserving the input order. Used by list
+    /// endpoints to bulk-fetch search hits in a single round trip.
+    pub async fn get_many(&self, ids: &[AgentId]) -> Result<Vec<Agent>, EventError> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
         let db = self.context.db()?;
-
-        let total: usize = db.query_row("SELECT COUNT(*) FROM agents", [], |row| row.get(0))?;
-
-        let mut stmt = db.prepare(
-            "SELECT id, name, persona, description, prompt
-             FROM agents ORDER BY name
-             LIMIT ?1 OFFSET ?2",
-        )?;
-
-        let raw: Vec<(String, String, String, String, String)> = stmt
-            .query_map(params![filters.limit, filters.offset], |row| {
+        let placeholders = (1..=ids.len())
+            .map(|i| format!("?{i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "select id, name, persona, description, prompt
+             from agents where id in ({placeholders})"
+        );
+        let id_strs: Vec<String> = ids.iter().map(ToString::to_string).collect();
+        let mut stmt = db.prepare(&sql)?;
+        let rows = stmt
+            .query_map(params_from_iter(id_strs.iter()), |row| {
                 Ok((
-                    row.get(0)?,
-                    row.get(1)?,
-                    row.get(2)?,
-                    row.get(3)?,
-                    row.get(4)?,
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
                 ))
             })?
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut agents = vec![];
-
-        for (id, name, persona, description, prompt) in raw {
-            agents.push(
-                Agent::builder()
-                    .id(id.parse()?)
-                    .name(name)
-                    .persona(persona)
-                    .description(description)
-                    .prompt(prompt)
-                    .build(),
-            );
+        let mut by_id: HashMap<AgentId, Agent> = HashMap::with_capacity(rows.len());
+        for (id, name, persona, description, prompt) in rows {
+            let agent = Agent::builder()
+                .id(id.parse()?)
+                .name(name)
+                .persona(persona)
+                .description(description)
+                .prompt(prompt)
+                .build();
+            by_id.insert(agent.id, agent);
         }
-
-        Ok(Listed::new(agents, total))
+        Ok(ids.iter().filter_map(|id| by_id.remove(id)).collect())
     }
 
     pub async fn name_exists(&self, name: &AgentName) -> Result<bool, EventError> {

--- a/crates/oneiros-engine/src/domains/agent/service.rs
+++ b/crates/oneiros-engine/src/domains/agent/service.rs
@@ -93,19 +93,35 @@ impl AgentService {
         request: &ListAgents,
     ) -> Result<AgentResponse, AgentError> {
         let ListAgents::V1(listing) = request;
-        let listed = AgentRepo::new(context).list(&listing.filters).await?;
+        let search_query = SearchQuery::builder_v1()
+            .kind(SearchKind::Agent)
+            .maybe_query(listing.query.clone())
+            .filters(listing.filters)
+            .build();
 
-        if listed.total == 0 {
-            Ok(AgentResponse::NoAgents)
-        } else {
-            Ok(AgentResponse::Agents(
-                AgentsResponse::builder_v1()
-                    .items(listed.items)
-                    .total(listed.total)
-                    .build()
-                    .into(),
-            ))
+        let results = SearchRepo::new(context).search(&search_query, None).await?;
+
+        if results.total == 0 {
+            return Ok(AgentResponse::NoAgents);
         }
+
+        let mut ids: Vec<AgentId> = vec![];
+
+        for hit in results.hits {
+            if let Ref::V0(Resource::Agent(id)) = hit.resource_ref {
+                ids.push(id);
+            }
+        }
+
+        let items = AgentRepo::new(context).get_many(&ids).await?;
+
+        Ok(AgentResponse::Agents(
+            AgentsResponse::builder_v1()
+                .items(items)
+                .total(results.total)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn update(

--- a/crates/oneiros-engine/src/domains/agent/store.rs
+++ b/crates/oneiros-engine/src/domains/agent/store.rs
@@ -15,9 +15,28 @@ impl<'a> AgentStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Agent(agent_event)) = &event.data {
             match agent_event {
-                AgentEvents::AgentCreated(agent_created) => self.create(agent_created)?,
-                AgentEvents::AgentUpdated(agent_updated) => self.update(agent_updated)?,
-                AgentEvents::AgentRemoved(agent_removed) => self.remove(agent_removed)?,
+                AgentEvents::AgentCreated(created) => {
+                    let agent = created.current()?.agent;
+                    self.write_agent(&agent)?;
+                    SearchStore::new(self.conn).index_entry(&IndexEntry::agent(&agent))?;
+                }
+                AgentEvents::AgentUpdated(updated) => {
+                    let agent = updated.current()?.agent;
+                    self.write_agent(&agent)?;
+                    let search = SearchStore::new(self.conn);
+                    search.remove_by_ref(&Ref::agent(agent.id))?;
+                    search.index_entry(&IndexEntry::agent(&agent))?;
+                }
+                AgentEvents::AgentRemoved(removal) => {
+                    let name = removal.current()?.name;
+                    if let Some(agent) = self.get(&name)? {
+                        SearchStore::new(self.conn).remove_by_ref(&Ref::agent(agent.id))?;
+                    }
+                    self.conn.execute(
+                        "delete from agents where name = ?1",
+                        params![name.to_string()],
+                    )?;
+                }
             }
         }
 
@@ -130,25 +149,6 @@ impl<'a> AgentStore<'a> {
             |row| row.get(0),
         )?;
         Ok(count > 0)
-    }
-
-    fn create(&self, creation: &AgentCreated) -> Result<(), EventError> {
-        let agent = creation.current()?.agent;
-        self.write_agent(&agent)
-    }
-
-    fn update(&self, update: &AgentUpdated) -> Result<(), EventError> {
-        let agent = update.current()?.agent;
-        self.write_agent(&agent)
-    }
-
-    fn remove(&self, removal: &AgentRemoved) -> Result<(), EventError> {
-        let name = removal.current()?.name;
-        self.conn.execute(
-            "delete from agents where name = ?1",
-            params![name.to_string()],
-        )?;
-        Ok(())
     }
 
     fn write_agent(&self, agent: &Agent) -> Result<(), EventError> {

--- a/crates/oneiros-engine/src/domains/cognition/client.rs
+++ b/crates/oneiros-engine/src/domains/cognition/client.rs
@@ -25,6 +25,10 @@ impl<'a> CognitionClient<'a> {
             params.push(("texture", texture_name.to_string()));
         }
 
+        if let Some(query) = &listing.query {
+            params.push(("query", query.clone()));
+        }
+
         params.push(("limit", listing.filters.limit.to_string()));
         params.push(("offset", listing.filters.offset.to_string()));
 

--- a/crates/oneiros-engine/src/domains/cognition/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/cognition/protocol/requests.rs
@@ -35,6 +35,11 @@ versioned! {
             pub agent: Option<AgentName>,
             #[arg(long)]
             pub texture: Option<TextureName>,
+            /// Full-text query against cognition content. When present, hits
+            /// are FTS5-ranked; absent, the listing browses by filters alone.
+            #[arg(long)]
+            #[builder(into)]
+            pub query: Option<String>,
             #[command(flatten)]
             #[serde(flatten)]
             #[builder(default)]

--- a/crates/oneiros-engine/src/domains/cognition/repo.rs
+++ b/crates/oneiros-engine/src/domains/cognition/repo.rs
@@ -1,4 +1,6 @@
-use rusqlite::params;
+use std::collections::HashMap;
+
+use rusqlite::{params, params_from_iter};
 
 use crate::*;
 
@@ -45,90 +47,47 @@ impl<'a> CognitionRepo<'a> {
         }
     }
 
-    pub async fn list(
-        &self,
-        agent: Option<&AgentId>,
-        texture: Option<&TextureName>,
-        filters: &SearchFilters,
-    ) -> Result<Listed<Cognition>, EventError> {
+    /// Hydrate many cognitions by id, preserving the input order. Used by
+    /// list endpoints to bulk-fetch search hits in a single round trip.
+    pub async fn get_many(&self, ids: &[CognitionId]) -> Result<Vec<Cognition>, EventError> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
         let db = self.context.db()?;
-
-        let mut conditions = Vec::new();
-        let mut bind_values: Vec<String> = Vec::new();
-
-        if let Some(a) = agent {
-            bind_values.push(a.to_string());
-            conditions.push(format!("agent_id = ?{}", bind_values.len()));
-        }
-        if let Some(t) = texture {
-            bind_values.push(t.to_string());
-            conditions.push(format!("texture = ?{}", bind_values.len()));
-        }
-
-        let where_clause = if conditions.is_empty() {
-            String::new()
-        } else {
-            format!(" WHERE {}", conditions.join(" AND "))
-        };
-
-        let count_sql = format!("SELECT COUNT(*) FROM cognitions{where_clause}");
-        let total = {
-            let mut stmt = db.prepare(&count_sql)?;
-            let params: Vec<&dyn rusqlite::ToSql> = bind_values
-                .iter()
-                .map(|v| v as &dyn rusqlite::ToSql)
-                .collect();
-            stmt.query_row(&*params, |row| row.get::<_, usize>(0))?
-        };
-
-        let select_sql = format!(
+        let placeholders = (1..=ids.len())
+            .map(|i| format!("?{i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
             "SELECT id, agent_id, texture, content, created_at
-             FROM cognitions{where_clause}
-             ORDER BY created_at DESC
-             LIMIT ?{} OFFSET ?{}",
-            bind_values.len() + 1,
-            bind_values.len() + 2,
+             FROM cognitions WHERE id IN ({placeholders})"
         );
-
-        let mut stmt = db.prepare(&select_sql)?;
-
-        let map_row = |row: &rusqlite::Row<'_>| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, String>(3)?,
-                row.get::<_, String>(4)?,
-            ))
-        };
-
-        let mut all_params: Vec<Box<dyn rusqlite::ToSql>> = bind_values
-            .into_iter()
-            .map(|v| Box::new(v) as Box<dyn rusqlite::ToSql>)
-            .collect();
-        all_params.push(Box::new(filters.limit));
-        all_params.push(Box::new(filters.offset));
-
-        let param_refs: Vec<&dyn rusqlite::ToSql> = all_params.iter().map(|p| p.as_ref()).collect();
-
-        let raw = stmt
-            .query_map(&*param_refs, map_row)?
+        let id_strs: Vec<String> = ids.iter().map(ToString::to_string).collect();
+        let mut stmt = db.prepare(&sql)?;
+        let rows = stmt
+            .query_map(params_from_iter(id_strs.iter()), |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            })?
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut cognitions = vec![];
-        for (id, agent_id, texture, content, created_at) in raw {
-            cognitions.push(
-                Cognition::builder()
-                    .id(id.parse()?)
-                    .agent_id(agent_id.parse()?)
-                    .texture(texture)
-                    .content(content)
-                    .created_at(Timestamp::parse_str(&created_at)?)
-                    .build(),
-            );
+        let mut by_id: HashMap<CognitionId, Cognition> = HashMap::with_capacity(rows.len());
+        for (id, agent_id, texture, content, created_at) in rows {
+            let cognition = Cognition::builder()
+                .id(id.parse()?)
+                .agent_id(agent_id.parse()?)
+                .texture(texture)
+                .content(content)
+                .created_at(Timestamp::parse_str(&created_at)?)
+                .build();
+            by_id.insert(cognition.id, cognition);
         }
-
-        Ok(Listed::new(cognitions, total))
+        Ok(ids.iter().filter_map(|id| by_id.remove(id)).collect())
     }
 
     /// Most recent cognitions for an agent, ordered newest-first.

--- a/crates/oneiros-engine/src/domains/cognition/service.rs
+++ b/crates/oneiros-engine/src/domains/cognition/service.rs
@@ -70,23 +70,37 @@ impl CognitionService {
             None => None,
         };
 
-        let listed = CognitionRepo::new(context)
-            .list(
-                agent_id.as_ref(),
-                listing.texture.as_ref(),
-                &listing.filters,
-            )
+        let search_query = SearchQuery::builder_v1()
+            .kind(SearchKind::Cognition)
+            .maybe_texture(listing.texture.clone())
+            .maybe_query(listing.query.clone())
+            .filters(listing.filters)
+            .build();
+
+        let results = SearchRepo::new(context)
+            .search(&search_query, agent_id.as_ref())
             .await?;
-        Ok(if listed.total == 0 {
-            CognitionResponse::NoCognitions
-        } else {
-            CognitionResponse::Cognitions(
-                CognitionsResponse::builder_v1()
-                    .items(listed.items)
-                    .total(listed.total)
-                    .build()
-                    .into(),
-            )
-        })
+
+        if results.total == 0 {
+            return Ok(CognitionResponse::NoCognitions);
+        }
+
+        let ids: Vec<CognitionId> = results
+            .hits
+            .iter()
+            .filter_map(|hit| match &hit.resource_ref {
+                Ref::V0(Resource::Cognition(id)) => Some(*id),
+                _ => None,
+            })
+            .collect();
+        let items = CognitionRepo::new(context).get_many(&ids).await?;
+
+        Ok(CognitionResponse::Cognitions(
+            CognitionsResponse::builder_v1()
+                .items(items)
+                .total(results.total)
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/cognition/store.rs
+++ b/crates/oneiros-engine/src/domains/cognition/store.rs
@@ -17,7 +17,8 @@ impl<'a> CognitionStore<'a> {
             match cognition_event {
                 CognitionEvents::CognitionAdded(added) => {
                     let cognition = added.current()?.cognition;
-                    self.write_cognition(&cognition)?
+                    self.write_cognition(&cognition)?;
+                    SearchStore::new(self.conn).index_entry(&IndexEntry::cognition(&cognition))?;
                 }
             }
         }

--- a/crates/oneiros-engine/src/domains/experience/client.rs
+++ b/crates/oneiros-engine/src/domains/experience/client.rs
@@ -24,6 +24,14 @@ impl<'a> ExperienceClient<'a> {
             params.push(("agent", agent_name.to_string()));
         }
 
+        if let Some(sensation_name) = &listing.sensation {
+            params.push(("sensation", sensation_name.to_string()));
+        }
+
+        if let Some(query) = &listing.query {
+            params.push(("query", query.clone()));
+        }
+
         params.push(("limit", listing.filters.limit.to_string()));
         params.push(("offset", listing.filters.offset.to_string()));
 

--- a/crates/oneiros-engine/src/domains/experience/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/experience/protocol/requests.rs
@@ -33,6 +33,14 @@ versioned! {
         V1 => {
             #[arg(long)]
             pub agent: Option<AgentName>,
+            #[arg(long)]
+            pub sensation: Option<SensationName>,
+            /// Full-text query against experience description. When present,
+            /// hits are FTS5-ranked; absent, the listing browses by filters
+            /// alone.
+            #[arg(long)]
+            #[builder(into)]
+            pub query: Option<String>,
             #[command(flatten)]
             #[serde(flatten)]
             #[builder(default)]

--- a/crates/oneiros-engine/src/domains/experience/repo.rs
+++ b/crates/oneiros-engine/src/domains/experience/repo.rs
@@ -1,4 +1,6 @@
-use rusqlite::params;
+use std::collections::HashMap;
+
+use rusqlite::{params, params_from_iter};
 
 use crate::*;
 
@@ -45,85 +47,47 @@ impl<'a> ExperienceRepo<'a> {
         }
     }
 
-    pub async fn list(
-        &self,
-        agent: Option<&str>,
-        filters: &SearchFilters,
-    ) -> Result<Listed<Experience>, EventError> {
-        let db = self.context.db()?;
-
-        let mut conditions = Vec::new();
-        let mut bind_values: Vec<String> = Vec::new();
-
-        if let Some(a) = agent {
-            bind_values.push(a.to_string());
-            conditions.push(format!("agent_id = ?{}", bind_values.len()));
+    /// Hydrate many experiences by id, preserving the input order. Used by
+    /// list endpoints to bulk-fetch search hits in a single round trip.
+    pub async fn get_many(&self, ids: &[ExperienceId]) -> Result<Vec<Experience>, EventError> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
         }
-
-        let where_clause = if conditions.is_empty() {
-            String::new()
-        } else {
-            format!(" WHERE {}", conditions.join(" AND "))
-        };
-
-        let count_sql = format!("SELECT COUNT(*) FROM experiences{where_clause}");
-        let total = {
-            let mut stmt = db.prepare(&count_sql)?;
-            let params: Vec<&dyn rusqlite::ToSql> = bind_values
-                .iter()
-                .map(|v| v as &dyn rusqlite::ToSql)
-                .collect();
-            stmt.query_row(&*params, |row| row.get::<_, usize>(0))?
-        };
-
-        let select_sql = format!(
+        let db = self.context.db()?;
+        let placeholders = (1..=ids.len())
+            .map(|i| format!("?{i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
             "SELECT id, agent_id, sensation, description, created_at
-             FROM experiences{where_clause}
-             ORDER BY created_at DESC
-             LIMIT ?{} OFFSET ?{}",
-            bind_values.len() + 1,
-            bind_values.len() + 2,
+             FROM experiences WHERE id IN ({placeholders})"
         );
-
-        let mut stmt = db.prepare(&select_sql)?;
-
-        let map_row = |row: &rusqlite::Row<'_>| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, String>(3)?,
-                row.get::<_, String>(4)?,
-            ))
-        };
-
-        let mut all_params: Vec<Box<dyn rusqlite::ToSql>> = bind_values
-            .into_iter()
-            .map(|v| Box::new(v) as Box<dyn rusqlite::ToSql>)
-            .collect();
-        all_params.push(Box::new(filters.limit));
-        all_params.push(Box::new(filters.offset));
-
-        let param_refs: Vec<&dyn rusqlite::ToSql> = all_params.iter().map(|p| p.as_ref()).collect();
-
-        let raw = stmt
-            .query_map(&*param_refs, map_row)?
+        let id_strs: Vec<String> = ids.iter().map(ToString::to_string).collect();
+        let mut stmt = db.prepare(&sql)?;
+        let rows = stmt
+            .query_map(params_from_iter(id_strs.iter()), |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            })?
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut experiences = vec![];
-        for (id, agent_id, sensation, description, created_at) in raw {
-            experiences.push(
-                Experience::builder()
-                    .id(id.parse()?)
-                    .agent_id(agent_id.parse()?)
-                    .sensation(sensation)
-                    .description(description)
-                    .created_at(Timestamp::parse_str(&created_at)?)
-                    .build(),
-            );
+        let mut by_id: HashMap<ExperienceId, Experience> = HashMap::with_capacity(rows.len());
+        for (id, agent_id, sensation, description, created_at) in rows {
+            let experience = Experience::builder()
+                .id(id.parse()?)
+                .agent_id(agent_id.parse()?)
+                .sensation(sensation)
+                .description(description)
+                .created_at(Timestamp::parse_str(&created_at)?)
+                .build();
+            by_id.insert(experience.id, experience);
         }
-
-        Ok(Listed::new(experiences, total))
+        Ok(ids.iter().filter_map(|id| by_id.remove(id)).collect())
     }
 
     /// Most recent experiences for an agent, ordered newest-first.

--- a/crates/oneiros-engine/src/domains/experience/service.rs
+++ b/crates/oneiros-engine/src/domains/experience/service.rs
@@ -65,25 +65,43 @@ impl ExperienceService {
                     .get(name)
                     .await?
                     .ok_or_else(|| ExperienceError::AgentNotFound(name.clone()))?;
-                Some(record.id.to_string())
+                Some(record.id)
             }
             None => None,
         };
 
-        let listed = ExperienceRepo::new(context)
-            .list(agent_id.as_deref(), &listing.filters)
+        let search_query = SearchQuery::builder_v1()
+            .kind(SearchKind::Experience)
+            .maybe_sensation(listing.sensation.clone())
+            .maybe_query(listing.query.clone())
+            .filters(listing.filters)
+            .build();
+
+        let results = SearchRepo::new(context)
+            .search(&search_query, agent_id.as_ref())
             .await?;
-        Ok(if listed.total == 0 {
-            ExperienceResponse::NoExperiences
-        } else {
-            ExperienceResponse::Experiences(
-                ExperiencesResponse::builder_v1()
-                    .items(listed.items)
-                    .total(listed.total)
-                    .build()
-                    .into(),
-            )
-        })
+
+        if results.total == 0 {
+            return Ok(ExperienceResponse::NoExperiences);
+        }
+
+        let ids: Vec<ExperienceId> = results
+            .hits
+            .iter()
+            .filter_map(|hit| match &hit.resource_ref {
+                Ref::V0(Resource::Experience(id)) => Some(*id),
+                _ => None,
+            })
+            .collect();
+        let items = ExperienceRepo::new(context).get_many(&ids).await?;
+
+        Ok(ExperienceResponse::Experiences(
+            ExperiencesResponse::builder_v1()
+                .items(items)
+                .total(results.total)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn update_description(

--- a/crates/oneiros-engine/src/domains/experience/store.rs
+++ b/crates/oneiros-engine/src/domains/experience/store.rs
@@ -17,15 +17,27 @@ impl<'a> ExperienceStore<'a> {
             match experience_event {
                 ExperienceEvents::ExperienceCreated(created) => {
                     let experience = created.current()?.experience;
-                    self.write_experience(&experience)?
+                    self.write_experience(&experience)?;
+                    SearchStore::new(self.conn)
+                        .index_entry(&IndexEntry::experience(&experience))?;
                 }
                 ExperienceEvents::ExperienceDescriptionUpdated(updated) => {
                     let current = updated.current()?;
-                    self.update_description(&current.id, &current.description)?
+                    self.update_description(&current.id, &current.description)?;
+                    if let Some(exp) = self.get(&current.id)? {
+                        let search = SearchStore::new(self.conn);
+                        search.remove_by_ref(&Ref::experience(exp.id))?;
+                        search.index_entry(&IndexEntry::experience(&exp))?;
+                    }
                 }
                 ExperienceEvents::ExperienceSensationUpdated(updated) => {
                     let current = updated.current()?;
-                    self.update_sensation(&current.id, &current.sensation)?
+                    self.update_sensation(&current.id, &current.sensation)?;
+                    if let Some(exp) = self.get(&current.id)? {
+                        let search = SearchStore::new(self.conn);
+                        search.remove_by_ref(&Ref::experience(exp.id))?;
+                        search.index_entry(&IndexEntry::experience(&exp))?;
+                    }
                 }
             }
         }

--- a/crates/oneiros-engine/src/domains/memory/client.rs
+++ b/crates/oneiros-engine/src/domains/memory/client.rs
@@ -21,6 +21,14 @@ impl<'a> MemoryClient<'a> {
             params.push(("agent", agent_name.to_string()));
         }
 
+        if let Some(level_name) = &listing.level {
+            params.push(("level", level_name.to_string()));
+        }
+
+        if let Some(query) = &listing.query {
+            params.push(("query", query.clone()));
+        }
+
         params.push(("limit", listing.filters.limit.to_string()));
         params.push(("offset", listing.filters.offset.to_string()));
 

--- a/crates/oneiros-engine/src/domains/memory/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/memory/protocol/requests.rs
@@ -33,6 +33,13 @@ versioned! {
         V1 => {
             #[arg(long)]
             pub agent: Option<AgentName>,
+            #[arg(long)]
+            pub level: Option<LevelName>,
+            /// Full-text query against memory content. When present, hits
+            /// are FTS5-ranked; absent, the listing browses by filters alone.
+            #[arg(long)]
+            #[builder(into)]
+            pub query: Option<String>,
             #[command(flatten)]
             #[serde(flatten)]
             #[builder(default)]

--- a/crates/oneiros-engine/src/domains/memory/repo.rs
+++ b/crates/oneiros-engine/src/domains/memory/repo.rs
@@ -1,4 +1,6 @@
-use rusqlite::params;
+use std::collections::HashMap;
+
+use rusqlite::{params, params_from_iter};
 
 use crate::*;
 
@@ -45,84 +47,46 @@ impl<'a> MemoryRepo<'a> {
         }
     }
 
-    pub async fn list(
-        &self,
-        agent: Option<&str>,
-        filters: &SearchFilters,
-    ) -> Result<Listed<Memory>, EventError> {
-        let db = self.context.db()?;
-
-        let mut conditions = Vec::new();
-        let mut bind_values: Vec<String> = Vec::new();
-
-        if let Some(a) = agent {
-            bind_values.push(a.to_string());
-            conditions.push(format!("agent_id = ?{}", bind_values.len()));
+    /// Hydrate many memories by id, preserving the input order. Used by
+    /// list endpoints to bulk-fetch search hits in a single round trip.
+    pub async fn get_many(&self, ids: &[MemoryId]) -> Result<Vec<Memory>, EventError> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
         }
-
-        let where_clause = if conditions.is_empty() {
-            String::new()
-        } else {
-            format!(" WHERE {}", conditions.join(" AND "))
-        };
-
-        let count_sql = format!("SELECT COUNT(*) FROM memories{where_clause}");
-        let total = {
-            let mut stmt = db.prepare(&count_sql)?;
-            let params: Vec<&dyn rusqlite::ToSql> = bind_values
-                .iter()
-                .map(|v| v as &dyn rusqlite::ToSql)
-                .collect();
-            stmt.query_row(&*params, |row| row.get::<_, usize>(0))?
-        };
-
-        let select_sql = format!(
+        let db = self.context.db()?;
+        let placeholders = (1..=ids.len())
+            .map(|i| format!("?{i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
             "SELECT id, agent_id, level, content, created_at
-             FROM memories{where_clause}
-             ORDER BY created_at DESC
-             LIMIT ?{} OFFSET ?{}",
-            bind_values.len() + 1,
-            bind_values.len() + 2,
+             FROM memories WHERE id IN ({placeholders})"
         );
-
-        let mut stmt = db.prepare(&select_sql)?;
-
-        let map_row = |row: &rusqlite::Row<'_>| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, String>(3)?,
-                row.get::<_, String>(4)?,
-            ))
-        };
-
-        let mut all_params: Vec<Box<dyn rusqlite::ToSql>> = bind_values
-            .into_iter()
-            .map(|v| Box::new(v) as Box<dyn rusqlite::ToSql>)
-            .collect();
-        all_params.push(Box::new(filters.limit));
-        all_params.push(Box::new(filters.offset));
-
-        let param_refs: Vec<&dyn rusqlite::ToSql> = all_params.iter().map(|p| p.as_ref()).collect();
-
-        let raw = stmt
-            .query_map(&*param_refs, map_row)?
+        let id_strs: Vec<String> = ids.iter().map(ToString::to_string).collect();
+        let mut stmt = db.prepare(&sql)?;
+        let rows = stmt
+            .query_map(params_from_iter(id_strs.iter()), |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            })?
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut memories = vec![];
-        for (id, agent_id, level, content, created_at) in raw {
-            memories.push(
-                Memory::builder()
-                    .id(id.parse()?)
-                    .agent_id(agent_id.parse()?)
-                    .level(level)
-                    .content(content)
-                    .created_at(Timestamp::parse_str(&created_at)?)
-                    .build(),
-            );
+        let mut by_id: HashMap<MemoryId, Memory> = HashMap::with_capacity(rows.len());
+        for (id, agent_id, level, content, created_at) in rows {
+            let memory = Memory::builder()
+                .id(id.parse()?)
+                .agent_id(agent_id.parse()?)
+                .level(level)
+                .content(content)
+                .created_at(Timestamp::parse_str(&created_at)?)
+                .build();
+            by_id.insert(memory.id, memory);
         }
-
-        Ok(Listed::new(memories, total))
+        Ok(ids.iter().filter_map(|id| by_id.remove(id)).collect())
     }
 }

--- a/crates/oneiros-engine/src/domains/memory/service.rs
+++ b/crates/oneiros-engine/src/domains/memory/service.rs
@@ -65,24 +65,42 @@ impl MemoryService {
                     .get(name)
                     .await?
                     .ok_or_else(|| MemoryError::AgentNotFound(name.clone()))?;
-                Some(record.id.to_string())
+                Some(record.id)
             }
             None => None,
         };
 
-        let listed = MemoryRepo::new(context)
-            .list(agent_id.as_deref(), &listing.filters)
+        let search_query = SearchQuery::builder_v1()
+            .kind(SearchKind::Memory)
+            .maybe_level(listing.level.clone())
+            .maybe_query(listing.query.clone())
+            .filters(listing.filters)
+            .build();
+
+        let results = SearchRepo::new(context)
+            .search(&search_query, agent_id.as_ref())
             .await?;
-        Ok(if listed.total == 0 {
-            MemoryResponse::NoMemories
-        } else {
-            MemoryResponse::Memories(
-                MemoriesResponse::builder_v1()
-                    .items(listed.items)
-                    .total(listed.total)
-                    .build()
-                    .into(),
-            )
-        })
+
+        if results.total == 0 {
+            return Ok(MemoryResponse::NoMemories);
+        }
+
+        let ids: Vec<MemoryId> = results
+            .hits
+            .iter()
+            .filter_map(|hit| match &hit.resource_ref {
+                Ref::V0(Resource::Memory(id)) => Some(*id),
+                _ => None,
+            })
+            .collect();
+        let items = MemoryRepo::new(context).get_many(&ids).await?;
+
+        Ok(MemoryResponse::Memories(
+            MemoriesResponse::builder_v1()
+                .items(items)
+                .total(results.total)
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/memory/store.rs
+++ b/crates/oneiros-engine/src/domains/memory/store.rs
@@ -17,7 +17,8 @@ impl<'a> MemoryStore<'a> {
             match memory_event {
                 MemoryEvents::MemoryAdded(added) => {
                     let memory = added.current()?.memory;
-                    self.write_memory(&memory)?
+                    self.write_memory(&memory)?;
+                    SearchStore::new(self.conn).index_entry(&IndexEntry::memory(&memory))?;
                 }
             }
         }

--- a/crates/oneiros-engine/src/domains/search/client.rs
+++ b/crates/oneiros-engine/src/domains/search/client.rs
@@ -10,12 +10,30 @@ impl<'a> SearchClient<'a> {
     }
 
     pub async fn search(&self, request: &SearchQuery) -> Result<SearchResponse, ClientError> {
-        let details = request.current()?;
-        let path = match &details.agent {
-            Some(a) => format!("/search?query={}&agent={a}", details.query),
-            None => format!("/search?query={}", details.query),
-        };
+        let query = request.current()?;
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(q) = &query.query {
+            parts.push(format!("query={q}"));
+        }
+        if let Some(a) = &query.agent {
+            parts.push(format!("agent={a}"));
+        }
+        if let Some(k) = query.kind {
+            parts.push(format!("kind={}", k.as_str()));
+        }
+        if let Some(t) = &query.texture {
+            parts.push(format!("texture={t}"));
+        }
+        if let Some(l) = &query.level {
+            parts.push(format!("level={l}"));
+        }
+        if let Some(s) = &query.sensation {
+            parts.push(format!("sensation={s}"));
+        }
+        parts.push(format!("limit={}", query.filters.limit));
+        parts.push(format!("offset={}", query.filters.offset));
 
+        let path = format!("/search?{}", parts.join("&"));
         self.client.get(&path).await
     }
 }

--- a/crates/oneiros-engine/src/domains/search/features/projections.rs
+++ b/crates/oneiros-engine/src/domains/search/features/projections.rs
@@ -8,9 +8,13 @@ impl SearchProjections {
     }
 }
 
+/// The search projection owns the FTS5 substrate (table, reset). Indexing
+/// is driven by content-bearing domains, which call
+/// [`SearchStore::index_entry`] from their own event handlers — so
+/// `apply` here is a deliberate no-op.
 const PROJECTIONS: &[Projection] = &[Projection {
     name: "search",
     migrate: |conn| SearchStore::new(conn).migrate(),
-    apply: |conn, event| SearchStore::new(conn).handle(event),
+    apply: |_conn, _event| Ok(()),
     reset: |conn| SearchStore::new(conn).reset(),
 }];

--- a/crates/oneiros-engine/src/domains/search/presenter.rs
+++ b/crates/oneiros-engine/src/domains/search/presenter.rs
@@ -9,19 +9,42 @@ impl SearchPresenter {
         Self { response }
     }
 
+    /// MCP rendering — kind-grouped sections, one per content type. Agents
+    /// orient by kind first, content second. Facets render as a final
+    /// "palace map" section so the surrounding shape is visible without
+    /// an extra round trip.
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
             SearchResponse::Results(ResultsResponse::V1(results)) => {
                 let mut md = format!(
-                    "# Search: {}\n\n{} results\n\n",
+                    "# Search: {}\n\n{} of {} results\n",
                     results.query,
-                    results.results.len()
+                    results.hits.len(),
+                    results.total,
                 );
-                for result in &results.results {
-                    md.push_str(&format!(
-                        "- **{}** ({}): {}\n",
-                        result.kind, result.resource_ref, result.content
-                    ));
+
+                for (heading, group) in group_by_kind(&results.hits) {
+                    if group.is_empty() {
+                        continue;
+                    }
+                    md.push_str(&format!("\n## {heading}\n\n"));
+                    for hit in &group {
+                        md.push_str(&render_hit_item(hit));
+                    }
+                }
+
+                if !results.facets.is_empty() {
+                    md.push_str("\n## Facets\n\n");
+                    for group in &results.facets.0 {
+                        md.push_str(&format!("- **{:?}**: ", group.facet));
+                        let parts: Vec<String> = group
+                            .buckets
+                            .iter()
+                            .map(|b| format!("{} ({})", b.value, b.count))
+                            .collect();
+                        md.push_str(&parts.join(", "));
+                        md.push('\n');
+                    }
                 }
                 McpResponse::new(md)
             }
@@ -35,30 +58,39 @@ impl SearchPresenter {
         Rendered::new(self.response, prompt, text)
     }
 
+    /// CLI rendering — flat table with a `Kind` column. FTS5 relevance
+    /// order across kinds is preserved row-by-row, since rank means more
+    /// than kind grouping for terminal scanning.
     fn render_prompt(&self) -> String {
         match &self.response {
             SearchResponse::Results(ResultsResponse::V1(results)) => {
-                if results.results.is_empty() {
-                    return format!("No results for '{}'.", results.query);
+                let heading = if results.query.as_str().is_empty() {
+                    "Browse results".to_string()
+                } else {
+                    format!("Search results for '{}'", results.query)
+                };
+                if results.hits.is_empty() {
+                    return format!("{heading}: none.");
                 }
 
-                let mut out = format!("Search results for '{}':\n\n", results.query);
-                for result in &results.results {
-                    let content = result.content.as_str();
-                    let truncated = if content.len() > 80 {
-                        let end = content.floor_char_boundary(80);
-                        format!("{}...", &content[..end])
-                    } else {
-                        content.to_string()
-                    };
-                    out.push_str(&format!(
-                        "  [{}] {}\n    {}\n\n",
-                        result.kind,
-                        truncated,
-                        RefToken::new(result.resource_ref.clone())
-                    ));
+                let mut table = Table::new(vec![
+                    Column::key("kind", "Kind"),
+                    Column::key("content", "Content").max(60),
+                    Column::key("ref_token", "Ref"),
+                ]);
+
+                for hit in &results.hits {
+                    let owned = hit.content();
+                    table.push_row(vec![
+                        hit.kind().to_string(),
+                        owned.to_string(),
+                        RefToken::new(hit.resource_ref()).to_string(),
+                    ]);
                 }
-                out
+
+                let raw = format!("{} of {} total", results.hits.len(), results.total);
+                let summary = raw.muted();
+                format!("{heading}\n\n{summary}\n\n{table}")
             }
         }
     }
@@ -66,17 +98,65 @@ impl SearchPresenter {
     fn render_text(&self) -> String {
         match &self.response {
             SearchResponse::Results(ResultsResponse::V1(results)) => {
-                if results.results.is_empty() {
+                if results.hits.is_empty() {
                     format!("No results for '{}'.", results.query)
                 } else {
                     format!(
                         "{} result{} for '{}'.",
-                        results.results.len(),
-                        if results.results.len() == 1 { "" } else { "s" },
+                        results.hits.len(),
+                        if results.hits.len() == 1 { "" } else { "s" },
                         results.query
                     )
                 }
             }
         }
+    }
+}
+
+/// Bucket hits by kind, preserving FTS5 rank within each bucket. Returns
+/// stable section ordering: cognitions, memories, experiences, agents.
+fn group_by_kind(hits: &[Hit]) -> [(&'static str, Vec<&Hit>); 4] {
+    let mut cognitions = Vec::new();
+    let mut memories = Vec::new();
+    let mut experiences = Vec::new();
+    let mut agents = Vec::new();
+    for hit in hits {
+        match hit {
+            Hit::Cognition(_) => cognitions.push(hit),
+            Hit::Memory(_) => memories.push(hit),
+            Hit::Experience(_) => experiences.push(hit),
+            Hit::Agent(_) => agents.push(hit),
+        }
+    }
+    [
+        ("Cognitions", cognitions),
+        ("Memories", memories),
+        ("Experiences", experiences),
+        ("Agents", agents),
+    ]
+}
+
+/// Render one hit as a kind-shaped MCP item. Each kind shows the facet
+/// that lists already lead with — texture for cognitions, level for
+/// memories, sensation for experiences, persona for agents.
+fn render_hit_item(hit: &Hit) -> String {
+    let ref_token = RefToken::new(hit.resource_ref());
+    match hit {
+        Hit::Cognition(c) => format!(
+            "- **{}** — {}\n  {}\n  {}\n",
+            c.texture, c.created_at, c.content, ref_token
+        ),
+        Hit::Memory(m) => format!(
+            "- **{}** — {}\n  {}\n  {}\n",
+            m.level, m.created_at, m.content, ref_token
+        ),
+        Hit::Experience(e) => format!(
+            "- **{}** — {}\n  {}\n  {}\n",
+            e.sensation, e.created_at, e.description, ref_token
+        ),
+        Hit::Agent(a) => format!(
+            "- **{}** ({})\n  {}\n  {}\n",
+            a.name, a.persona, a.description, ref_token
+        ),
     }
 }

--- a/crates/oneiros-engine/src/domains/search/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/search/protocol/requests.rs
@@ -9,9 +9,35 @@ versioned! {
     pub enum SearchQuery {
         #[derive(clap::Args)]
         V1 => {
-            #[builder(into)] pub query: String,
-            #[arg(long)]
-            pub agent: Option<AgentName>,
+            /// Full-text query. When absent, the search browses by filters alone,
+            /// ordered by creation time.
+            #[builder(into)] pub query: Option<String>,
+            #[arg(long)] pub agent: Option<AgentName>,
+            #[arg(long)] pub kind: Option<SearchKind>,
+            #[arg(long)] pub texture: Option<TextureName>,
+            #[arg(long)] pub level: Option<LevelName>,
+            #[arg(long)] pub sensation: Option<SensationName>,
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+            /// Whether to compute facet aggregations alongside hits. Internal —
+            /// flipped on by [`SearchService`] for explicit search; left off by
+            /// list endpoints that don't render the palace map.
+            #[arg(skip)]
+            #[serde(skip)]
+            #[builder(default)]
+            pub with_facets: bool,
+        }
+    }
+}
+
+impl SearchQueryV1 {
+    /// Return a clone of this query with facet aggregations enabled.
+    pub fn with_facets(&self) -> Self {
+        Self {
+            with_facets: true,
+            ..self.clone()
         }
     }
 }

--- a/crates/oneiros-engine/src/domains/search/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/search/protocol/responses.rs
@@ -14,9 +14,6 @@ pub enum SearchResponse {
 versioned! {
     #[derive(JsonSchema)]
     pub enum ResultsResponse {
-        V1 => {
-            pub query: QueryText,
-            pub results: Vec<Expression>,
-        }
+        V1 => SearchResults,
     }
 }

--- a/crates/oneiros-engine/src/domains/search/repo.rs
+++ b/crates/oneiros-engine/src/domains/search/repo.rs
@@ -1,8 +1,16 @@
-use rusqlite::params;
+use rusqlite::{ToSql, params_from_iter};
 
 use crate::*;
 
 /// Search repo — async read queries over the FTS5 search index.
+///
+/// Returns faceted results: hits (with typed per-kind metadata) plus
+/// aggregations grouped by kind, agent, texture, level, sensation, and
+/// persona. Facet groups with no buckets are omitted.
+///
+/// With a text query, hits are ranked by FTS5 relevance. Without one, the
+/// repo browses by filters alone, ordered by `created_at` descending — the
+/// shape list endpoints consume.
 pub struct SearchRepo<'a> {
     context: &'a ProjectContext,
 }
@@ -12,43 +20,169 @@ impl<'a> SearchRepo<'a> {
         Self { context }
     }
 
-    pub async fn search(
+    /// Execute a search with optional filters. Returns ranked refs plus
+    /// facet aggregations scoped to the filtered result set. Hydration to
+    /// typed [`Hit`]s is the service layer's job — the repo only knows
+    /// what's in the index.
+    ///
+    /// `agent_id` is resolved by the caller (service layer) from an
+    /// optional `AgentName` on the public query shape.
+    pub(crate) async fn search(
         &self,
-        query: &str,
-        agent: Option<&AgentId>,
-    ) -> Result<Vec<Expression>, EventError> {
+        query: &SearchQueryV1,
+        agent_id: Option<&AgentId>,
+    ) -> Result<SearchHits, EventError> {
         let db = self.context.db()?;
-        let base =
-            "select resource_ref, kind, content from search_index where search_index match ?1";
 
-        match agent {
-            Some(agent_filter) => {
-                let sql = format!("{base} and agent = ?2 order by rank");
-                let mut statement = db.prepare(&sql)?;
-                Ok(statement
-                    .query_map(params![query, agent_filter.to_string()], Self::map_row)?
-                    .collect::<Result<Vec<_>, _>>()?)
-            }
-            None => {
-                let sql = format!("{base} order by rank");
-                let mut statement = db.prepare(&sql)?;
-                Ok(statement
-                    .query_map(params![query], Self::map_row)?
-                    .collect::<Result<Vec<_>, _>>()?)
-            }
-        }
+        let has_query = query.query.is_some();
+        let where_clause = query.where_clause(agent_id);
+        let params = where_clause.params();
+
+        let total = {
+            let sql = format!("select count(*) from search_index{}", where_clause.sql);
+            db.prepare(&sql)?
+                .query_row(params_from_iter(&params), |row| row.get::<_, usize>(0))?
+        };
+
+        let hits = {
+            let order = if has_query {
+                "order by rank"
+            } else {
+                "order by created_at desc"
+            };
+            let sql = format!(
+                "select resource_ref from search_index{where_sql}
+                 {order}
+                 limit ?{limit_idx} offset ?{offset_idx}",
+                where_sql = where_clause.sql,
+                limit_idx = where_clause.bindings.len() + 1,
+                offset_idx = where_clause.bindings.len() + 2,
+            );
+            let limit: Box<dyn ToSql> = Box::new(query.filters.limit.0 as i64);
+            let offset: Box<dyn ToSql> = Box::new(query.filters.offset.0 as i64);
+            let mut paged: Vec<&dyn ToSql> = params.clone();
+            paged.push(limit.as_ref());
+            paged.push(offset.as_ref());
+            let mut statement = db.prepare(&sql)?;
+            statement
+                .query_map(params_from_iter(&paged), RankedHit::from_row)?
+                .collect::<Result<Vec<_>, _>>()?
+        };
+
+        let facets = if query.with_facets {
+            self.collect_facets(&db, &where_clause.sql, &params)?
+        } else {
+            Facets::default()
+        };
+
+        Ok(SearchHits {
+            total,
+            hits,
+            facets,
+        })
     }
 
-    fn map_row(row: &rusqlite::Row) -> rusqlite::Result<Expression> {
-        let ref_json: String = row.get(0)?;
-        let resource_ref: Ref = serde_json::from_str(&ref_json).map_err(|e| {
-            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
-        })?;
+    /// Run GROUP BY over each facet column, scoped to the same WHERE clause
+    /// as the hit query. Empty bucket values are excluded so we only surface
+    /// dimensions that actually apply to the result set.
+    fn collect_facets(
+        &self,
+        db: &rusqlite::Connection,
+        where_sql: &str,
+        params: &[&dyn ToSql],
+    ) -> Result<Facets, EventError> {
+        let mut groups = Vec::new();
+        for facet in [
+            FacetName::Kind,
+            FacetName::Agent,
+            FacetName::Texture,
+            FacetName::Level,
+            FacetName::Sensation,
+            FacetName::Persona,
+        ] {
+            let column = facet.column();
+            let joiner = if where_sql.is_empty() { "where" } else { "and" };
+            let sql = format!(
+                "select {column}, count(*) as n
+                 from search_index{where_sql} {joiner} {column} != ''
+                 group by {column}
+                 order by n desc, {column} asc"
+            );
+            let mut stmt = db.prepare(&sql)?;
+            let rows = stmt
+                .query_map(params_from_iter(params), |row| {
+                    Ok(FacetBucket {
+                        value: row.get::<_, String>(0)?,
+                        count: row.get::<_, usize>(1)?,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Expression::builder()
-            .resource_ref(resource_ref)
-            .kind(row.get::<_, String>(1)?)
-            .content(row.get::<_, String>(2)?)
-            .build())
+            if !rows.is_empty() {
+                groups.push(FacetGroup {
+                    facet,
+                    buckets: rows,
+                });
+            }
+        }
+        Ok(Facets(groups))
+    }
+}
+
+/// SQL fragment built from a `SearchQuery`: the `where ...` clause and its
+/// owned parameter bindings. Kept together so the same scope drives both the
+/// hit query and facet aggregations.
+pub(crate) struct WhereClause {
+    pub sql: String,
+    pub bindings: Vec<Box<dyn ToSql>>,
+}
+
+impl WhereClause {
+    pub fn params(&self) -> Vec<&dyn ToSql> {
+        self.bindings
+            .iter()
+            .map(|b| b.as_ref() as &dyn ToSql)
+            .collect()
+    }
+}
+
+impl SearchQueryV1 {
+    /// Translate the query's filters into a WHERE clause + parameter
+    /// bindings. The FTS5 `match` condition is only included when a text
+    /// query is present; otherwise we fall back to column-only filtering.
+    pub(crate) fn where_clause(&self, agent_id: Option<&AgentId>) -> WhereClause {
+        let mut conditions: Vec<String> = Vec::new();
+        let mut bindings: Vec<Box<dyn ToSql>> = Vec::new();
+
+        let mut push = |condition: String, binding: Box<dyn ToSql>| {
+            bindings.push(binding);
+            conditions.push(condition.replace("?N", &format!("?{}", bindings.len())));
+        };
+
+        if let Some(q) = &self.query {
+            push("search_index match ?N".into(), Box::new(q.clone()));
+        }
+        if let Some(kind) = self.kind {
+            push("kind = ?N".into(), Box::new(kind.as_str().to_string()));
+        }
+        if let Some(agent_id) = agent_id {
+            push("agent_id = ?N".into(), Box::new(agent_id.to_string()));
+        }
+        if let Some(texture) = &self.texture {
+            push("texture = ?N".into(), Box::new(texture.to_string()));
+        }
+        if let Some(level) = &self.level {
+            push("level = ?N".into(), Box::new(level.to_string()));
+        }
+        if let Some(sensation) = &self.sensation {
+            push("sensation = ?N".into(), Box::new(sensation.to_string()));
+        }
+
+        let sql = if conditions.is_empty() {
+            String::new()
+        } else {
+            format!(" where {}", conditions.join(" and "))
+        };
+        WhereClause { sql, bindings }
     }
 }

--- a/crates/oneiros-engine/src/domains/search/service.rs
+++ b/crates/oneiros-engine/src/domains/search/service.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::*;
 
 pub struct SearchService;
@@ -7,21 +9,111 @@ impl SearchService {
         context: &ProjectContext,
         request: &SearchQuery,
     ) -> Result<SearchResponse, SearchError> {
-        let SearchQueryV1 { query, agent } = request.current()?;
-        let agent_id = match &agent {
+        let query = request.current()?;
+        let agent_id = match &query.agent {
             Some(name) => AgentRepo::new(context).get(name).await?.map(|a| a.id),
             None => None,
         };
 
-        let results = SearchRepo::new(context)
+        let query = query.with_facets();
+        let SearchHits {
+            total,
+            hits,
+            facets,
+        } = SearchRepo::new(context)
             .search(&query, agent_id.as_ref())
             .await?;
-        Ok(SearchResponse::Results(
-            ResultsResponse::builder_v1()
-                .query(QueryText::new(query))
-                .results(results)
-                .build()
-                .into(),
-        ))
+
+        let hits = hydrate_hits(context, hits).await?;
+
+        let results = SearchResults {
+            query: QueryText::new(query.query.clone().unwrap_or_default()),
+            total,
+            hits,
+            facets,
+        };
+        Ok(SearchResponse::Results(results.into()))
     }
+}
+
+/// Walk the ranked refs once, fan out per-kind `get_many` calls, then
+/// reassemble [`Hit`]s in the original FTS5 order. Drops refs whose
+/// underlying row has been removed since the index was queried — search
+/// shouldn't surface ghosts.
+pub(crate) async fn hydrate_hits(
+    context: &ProjectContext,
+    ranked: Vec<RankedHit>,
+) -> Result<Vec<Hit>, SearchError> {
+    let mut cognition_ids: Vec<CognitionId> = Vec::new();
+    let mut memory_ids: Vec<MemoryId> = Vec::new();
+    let mut experience_ids: Vec<ExperienceId> = Vec::new();
+    let mut agent_ids: Vec<AgentId> = Vec::new();
+
+    for hit in &ranked {
+        let Ref::V0(resource) = &hit.resource_ref;
+        match resource {
+            Resource::Cognition(id) => cognition_ids.push(*id),
+            Resource::Memory(id) => memory_ids.push(*id),
+            Resource::Experience(id) => experience_ids.push(*id),
+            Resource::Agent(id) => agent_ids.push(*id),
+            _ => {}
+        }
+    }
+
+    let cognitions: HashMap<CognitionId, Cognition> = CognitionRepo::new(context)
+        .get_many(&cognition_ids)
+        .await?
+        .into_iter()
+        .map(|c| (c.id, c))
+        .collect();
+    let memories: HashMap<MemoryId, Memory> = MemoryRepo::new(context)
+        .get_many(&memory_ids)
+        .await?
+        .into_iter()
+        .map(|m| (m.id, m))
+        .collect();
+    let experiences: HashMap<ExperienceId, Experience> = ExperienceRepo::new(context)
+        .get_many(&experience_ids)
+        .await?
+        .into_iter()
+        .map(|e| (e.id, e))
+        .collect();
+    let mut agents: HashMap<AgentId, Agent> = AgentRepo::new(context)
+        .get_many(&agent_ids)
+        .await?
+        .into_iter()
+        .map(|a| (a.id, a))
+        .collect();
+
+    let mut hydrated = Vec::with_capacity(ranked.len());
+    let mut cognitions = cognitions;
+    let mut memories = memories;
+    let mut experiences = experiences;
+    for hit in ranked {
+        let Ref::V0(resource) = hit.resource_ref;
+        match resource {
+            Resource::Cognition(id) => {
+                if let Some(c) = cognitions.remove(&id) {
+                    hydrated.push(Hit::Cognition(c));
+                }
+            }
+            Resource::Memory(id) => {
+                if let Some(m) = memories.remove(&id) {
+                    hydrated.push(Hit::Memory(m));
+                }
+            }
+            Resource::Experience(id) => {
+                if let Some(e) = experiences.remove(&id) {
+                    hydrated.push(Hit::Experience(e));
+                }
+            }
+            Resource::Agent(id) => {
+                if let Some(a) = agents.remove(&id) {
+                    hydrated.push(Hit::Agent(a));
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(hydrated)
 }

--- a/crates/oneiros-engine/src/domains/search/store.rs
+++ b/crates/oneiros-engine/src/domains/search/store.rs
@@ -2,7 +2,12 @@ use rusqlite::params;
 
 use crate::*;
 
-/// Search projection store — projection lifecycle, write operations, and index management.
+/// Search projection store — owns the FTS5 index lifecycle and write primitives.
+///
+/// Content-bearing domains (cognition, memory, experience, agent) call
+/// [`SearchStore::index_entry`] and [`SearchStore::remove_by_ref`] from
+/// their own event handlers. The search projection's `apply` is a no-op —
+/// search owns the substrate, domains own the meaning of their events.
 pub struct SearchStore<'a> {
     conn: &'a rusqlite::Connection,
 }
@@ -15,102 +20,68 @@ impl<'a> SearchStore<'a> {
     pub fn migrate(&self) -> Result<(), EventError> {
         self.conn.execute_batch(
             "create virtual table if not exists search_index
-             using fts5(resource_ref, kind, content, agent)",
+             using fts5(
+                 resource_ref unindexed,
+                 kind unindexed,
+                 content,
+                 agent_id unindexed,
+                 texture unindexed,
+                 level unindexed,
+                 sensation unindexed,
+                 persona unindexed,
+                 created_at unindexed
+             )",
         )?;
         Ok(())
     }
 
-    pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
-        match &event.data {
-            Event::Known(Events::Cognition(CognitionEvents::CognitionAdded(
-                CognitionAdded::V1(addition),
-            ))) => {
-                let cognition = &addition.cognition;
-                self.index(
-                    Ref::cognition(cognition.id),
-                    "cognition-content",
-                    &cognition.content,
-                    cognition.agent_id,
-                )?;
-            }
-            Event::Known(Events::Memory(MemoryEvents::MemoryAdded(MemoryAdded::V1(addition)))) => {
-                let memory = &addition.memory;
-                self.index(
-                    Ref::memory(memory.id),
-                    "memory-content",
-                    &memory.content,
-                    memory.agent_id,
-                )?;
-            }
-            Event::Known(Events::Agent(AgentEvents::AgentCreated(AgentCreated::V1(creation)))) => {
-                let agent = &creation.agent;
-                let content = format!("{} {}", agent.name, agent.description);
-                self.index(
-                    Ref::agent(agent.id),
-                    "agent-description",
-                    &content,
-                    &agent.name,
-                )?;
-            }
-            Event::Known(Events::Agent(AgentEvents::AgentUpdated(AgentUpdated::V1(update)))) => {
-                let agent = &update.agent;
-                self.remove_by_ref(&Ref::agent(agent.id))?;
-                let content = format!("{} {}", agent.name, agent.description);
-                self.index(
-                    Ref::agent(agent.id),
-                    "agent-description",
-                    &content,
-                    &agent.name,
-                )?;
-            }
-            Event::Known(Events::Agent(AgentEvents::AgentRemoved(AgentRemoved::V1(v)))) => {
-                self.remove_by_agent(&v.name)?;
-            }
-            Event::Known(Events::Experience(ExperienceEvents::ExperienceCreated(
-                ExperienceCreated::V1(creation),
-            ))) => {
-                let experience = &creation.experience;
-                self.index(
-                    Ref::experience(experience.id),
-                    "experience-description",
-                    &experience.description,
-                    experience.agent_id,
-                )?;
-            }
-            Event::Known(Events::Experience(ExperienceEvents::ExperienceDescriptionUpdated(
-                ExperienceDescriptionUpdated::V1(update),
-            ))) => {
-                self.remove_by_ref(&Ref::experience(update.id))?;
-                if let Ok(Some(exp)) = ExperienceStore::new(self.conn).get(&update.id) {
-                    self.index(
-                        Ref::experience(update.id),
-                        "experience-description",
-                        &update.description,
-                        exp.agent_id,
-                    )?;
-                }
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
     pub fn reset(&self) -> Result<(), EventError> {
-        self.conn.execute("DELETE FROM search_index", [])?;
+        self.conn.execute("delete from search_index", [])?;
         Ok(())
     }
 
-    pub fn index(
-        &self,
-        resource_ref: Ref,
-        kind: &str,
-        content: impl std::fmt::Display,
-        agent: impl std::fmt::Display,
-    ) -> Result<(), EventError> {
-        let ref_json = serde_json::to_string(&resource_ref)?;
+    /// Insert an index row. Called by content-bearing domains from their
+    /// own event handlers — search owns the substrate, domains own the
+    /// meaning of their events.
+    pub(crate) fn index_entry(&self, entry: &IndexEntry) -> Result<(), EventError> {
+        let resource_ref = serde_json::to_string(&entry.resource_ref)?;
+        let texture = entry
+            .texture
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        let level = entry
+            .level
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        let sensation = entry
+            .sensation
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        let persona = entry
+            .persona
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        let created_at = entry.created_at.map(|t| t.as_string()).unwrap_or_default();
         self.conn.execute(
-            "INSERT INTO search_index (resource_ref, kind, content, agent) VALUES (?1, ?2, ?3, ?4)",
-            params![ref_json, kind, content.to_string(), agent.to_string()],
+            "insert into search_index (
+                 resource_ref, kind, content,
+                 agent_id, texture, level, sensation, persona, created_at
+             ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                resource_ref,
+                entry.kind.as_str(),
+                entry.content.to_string(),
+                entry.agent_id.to_string(),
+                texture,
+                level,
+                sensation,
+                persona,
+                created_at,
+            ],
         )?;
         Ok(())
     }
@@ -118,16 +89,16 @@ impl<'a> SearchStore<'a> {
     pub fn remove_by_ref(&self, resource_ref: &Ref) -> Result<(), EventError> {
         let ref_json = serde_json::to_string(resource_ref)?;
         self.conn.execute(
-            "DELETE FROM search_index WHERE resource_ref = ?1",
+            "delete from search_index where resource_ref = ?1",
             params![ref_json],
         )?;
         Ok(())
     }
 
-    pub fn remove_by_agent(&self, agent: &AgentName) -> Result<(), EventError> {
+    pub fn remove_by_agent_id(&self, agent_id: &AgentId) -> Result<(), EventError> {
         self.conn.execute(
-            "DELETE FROM search_index WHERE agent = ?1",
-            params![agent.to_string()],
+            "delete from search_index where agent_id = ?1 and kind = 'agent'",
+            params![agent_id.to_string()],
         )?;
         Ok(())
     }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/cognition.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/cognition.rs
@@ -221,6 +221,40 @@ pub(crate) async fn list_json_items_include_refs<B: Backend>() -> TestResult {
     Ok(())
 }
 
+/// `cognition list --query "<text>"` narrows the listing by FTS5 match
+/// on cognition content. Same query semantics as `search`, scoped to the
+/// cognition kind. Lists ARE searches.
+pub(crate) async fn list_filters_by_query<B: Backend>() -> TestResult {
+    let harness = with_agent::<B>().await?;
+
+    harness
+        .exec_json("cognition add thinker.process observation 'The garden is growing'")
+        .await?;
+    harness
+        .exec_json("cognition add thinker.process observation 'Unrelated content here'")
+        .await?;
+
+    let response = harness.exec_json("cognition list --query garden").await?;
+
+    match response {
+        Responses::Cognition(CognitionResponse::Cognitions(CognitionsResponse::V1(listed))) => {
+            assert_eq!(
+                listed.items.len(),
+                1,
+                "expected 1 cognition matching 'garden'"
+            );
+            assert_eq!(listed.total, 1);
+            assert!(
+                listed.items[0].content.as_str().contains("garden"),
+                "expected matching cognition's content to contain the query"
+            );
+        }
+        other => panic!("expected Cognitions, got {other:#?}"),
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn add_prompt_confirms_creation<B: Backend>() -> TestResult {
     let harness = with_agent::<B>().await?;
 

--- a/crates/oneiros-engine/src/tests/acceptance/cases/import_export.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/import_export.rs
@@ -75,7 +75,7 @@ pub(crate) async fn import_restores_data<B: Backend>() -> TestResult {
     match search_response {
         Responses::Search(SearchResponse::Results(ResultsResponse::V1(results))) => {
             assert!(
-                !results.results.is_empty(),
+                !results.hits.is_empty(),
                 "expected to find the cognition after import"
             );
         }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/memory.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/memory.rs
@@ -93,6 +93,31 @@ pub(crate) async fn list_filters_by_agent<B: Backend>() -> TestResult {
     Ok(())
 }
 
+/// `memory list --query "<text>"` narrows by FTS5 match on memory
+/// content. Same query semantics as `search`, scoped to the memory kind.
+pub(crate) async fn list_filters_by_query<B: Backend>() -> TestResult {
+    let harness = with_agent_and_level::<B>().await?;
+
+    harness
+        .exec_json("memory add learner.process session 'The compaction strategy worked'")
+        .await?;
+    harness
+        .exec_json("memory add learner.process session 'Unrelated note'")
+        .await?;
+
+    let response = harness.exec_json("memory list --query compaction").await?;
+
+    match response {
+        Responses::Memory(MemoryResponse::Memories(MemoriesResponse::V1(memories))) => {
+            assert_eq!(memories.items.len(), 1);
+            assert!(memories.items[0].content.as_str().contains("compaction"));
+        }
+        other => panic!("expected Memories, got {other:#?}"),
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn show_by_id<B: Backend>() -> TestResult {
     let harness = with_agent_and_level::<B>().await?;
 

--- a/crates/oneiros-engine/src/tests/acceptance/cases/search.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/search.rs
@@ -61,10 +61,19 @@ async fn with_searchable<B: Backend>() -> Result<Harness<B>, Box<dyn core::error
 }
 
 /// Helper: extract the results vec from a search response.
-fn extract_results(response: Responses) -> Vec<Expression> {
+fn extract_results(response: Responses) -> Vec<Hit> {
     match response {
         Responses::Search(SearchResponse::Results(ResultsResponse::V1(search_results))) => {
-            search_results.results
+            search_results.hits
+        }
+        other => panic!("expected Search(Results), got {other:#?}"),
+    }
+}
+
+fn extract_full(response: Responses) -> SearchResults {
+    match response {
+        Responses::Search(SearchResponse::Results(ResultsResponse::V1(search_results))) => {
+            search_results
         }
         other => panic!("expected Search(Results), got {other:#?}"),
     }
@@ -205,6 +214,269 @@ pub(crate) async fn finds_updated_agent_description<B: Backend>() -> TestResult 
         1,
         "expected 1 result for updated agent description"
     );
+
+    Ok(())
+}
+
+/// Search response carries faceted aggregations across kind, texture, level,
+/// and sensation — the palace map of what's out there.
+pub(crate) async fn returns_faceted_results<B: Backend>() -> TestResult {
+    let harness = with_searchable::<B>().await?;
+
+    harness
+        .exec_json("cognition add thinker.process observation 'Indexable observation one'")
+        .await?;
+    harness
+        .exec_json("cognition add thinker.process observation 'Indexable observation two'")
+        .await?;
+    harness
+        .exec_json("memory add thinker.process session 'Indexable memory session'")
+        .await?;
+    harness
+        .exec_json("experience create thinker.process caused 'Indexable experience caused'")
+        .await?;
+
+    let response = harness.exec_json("search Indexable").await?;
+    let results = extract_full(response);
+
+    assert_eq!(results.hits.len(), 4, "expected 4 hits across kinds");
+    assert_eq!(results.total, 4);
+
+    let kind_group = results
+        .facets
+        .find(FacetName::Kind)
+        .expect("kind facet present");
+    assert_eq!(kind_group.buckets.len(), 3, "cognition, memory, experience");
+
+    let texture_group = results
+        .facets
+        .find(FacetName::Texture)
+        .expect("texture facet present");
+    assert_eq!(
+        texture_group.buckets.len(),
+        1,
+        "one texture (observation) appears"
+    );
+    assert_eq!(texture_group.buckets[0].value, "observation");
+    assert_eq!(texture_group.buckets[0].count, 2);
+
+    let level_group = results
+        .facets
+        .find(FacetName::Level)
+        .expect("level facet present");
+    assert_eq!(level_group.buckets.len(), 1);
+    assert_eq!(level_group.buckets[0].value, "session");
+
+    let sensation_group = results
+        .facets
+        .find(FacetName::Sensation)
+        .expect("sensation facet present");
+    assert_eq!(sensation_group.buckets.len(), 1);
+    assert_eq!(sensation_group.buckets[0].value, "caused");
+
+    Ok(())
+}
+
+/// Filtering by `--kind` narrows both hits and every facet group to only
+/// rows of that kind.
+pub(crate) async fn narrows_by_kind_filter<B: Backend>() -> TestResult {
+    let harness = with_searchable::<B>().await?;
+
+    harness
+        .exec_json("cognition add thinker.process observation 'Narrowable content here'")
+        .await?;
+    harness
+        .exec_json("memory add thinker.process session 'Narrowable memory content'")
+        .await?;
+
+    let response = harness
+        .exec_json("search Narrowable --kind cognition")
+        .await?;
+    let results = extract_full(response);
+
+    assert_eq!(results.hits.len(), 1);
+    assert_eq!(results.total, 1);
+
+    let kind_group = results
+        .facets
+        .find(FacetName::Kind)
+        .expect("kind facet present");
+    assert_eq!(kind_group.buckets.len(), 1);
+    assert_eq!(kind_group.buckets[0].value, "cognition");
+
+    assert!(
+        results.facets.find(FacetName::Level).is_none(),
+        "level facet should not appear when no memory hits remain"
+    );
+
+    Ok(())
+}
+
+/// Hits carry typed per-kind metadata — the caller can see texture/level/
+/// sensation on each match without a second query.
+pub(crate) async fn hits_carry_typed_metadata<B: Backend>() -> TestResult {
+    let harness = with_searchable::<B>().await?;
+
+    harness
+        .exec_json("cognition add thinker.process observation 'Distinctive cognition text'")
+        .await?;
+
+    let response = harness.exec_json("search Distinctive").await?;
+    let results = extract_full(response);
+
+    let hit = results
+        .hits
+        .first()
+        .expect("one hit for distinctive content");
+    let Hit::Cognition(cognition) = hit else {
+        panic!("expected Hit::Cognition, got {hit:#?}");
+    };
+    assert_eq!(cognition.texture.as_str(), "observation");
+
+    Ok(())
+}
+
+/// Every content-bearing kind reports into the search index — adding a new
+/// kind without wiring `SearchStore::index_expression` will fail this test.
+pub(crate) async fn every_content_kind_indexes<B: Backend>() -> TestResult {
+    let harness = with_searchable::<B>().await?;
+
+    harness
+        .exec_json("agent create gardener process --description 'Probe gardener tends'")
+        .await?;
+    harness
+        .exec_json("cognition add gardener.process observation 'Probe cognition seeded'")
+        .await?;
+    harness
+        .exec_json("memory add gardener.process session 'Probe memory consolidated'")
+        .await?;
+    harness
+        .exec_json("experience create gardener.process caused 'Probe experience marked'")
+        .await?;
+
+    let response = harness.exec_json("search Probe").await?;
+    let results = extract_full(response);
+
+    let kinds: Vec<&str> = results
+        .facets
+        .find(FacetName::Kind)
+        .expect("kind facet present")
+        .buckets
+        .iter()
+        .map(|b| b.value.as_str())
+        .collect();
+
+    for expected in ["cognition", "memory", "experience", "agent"] {
+        assert!(
+            kinds.contains(&expected),
+            "{expected} kind missing from index — wire SearchStore::index_expression in the {expected} domain"
+        );
+    }
+
+    Ok(())
+}
+
+/// CLI rendering shows hits flat with a `Kind` column. FTS5 rank, not
+/// kind, drives the row order — terminal scanning prizes relevance.
+pub(crate) async fn prompt_renders_flat_with_kind_column<B: Backend>() -> TestResult {
+    let harness = with_searchable::<B>().await?;
+
+    harness
+        .exec_json("cognition add thinker.process observation 'Flat cognition'")
+        .await?;
+    harness
+        .exec_json("memory add thinker.process session 'Flat memory'")
+        .await?;
+
+    let prompt = harness.exec_prompt("search Flat").await?;
+
+    assert!(
+        prompt.contains("Kind"),
+        "CLI search prompt should have a Kind column header, got:\n{prompt}"
+    );
+    assert!(
+        prompt.contains("cognition"),
+        "CLI search prompt should label cognition rows by kind, got:\n{prompt}"
+    );
+    assert!(
+        prompt.contains("memory"),
+        "CLI search prompt should label memory rows by kind, got:\n{prompt}"
+    );
+
+    Ok(())
+}
+
+/// Default `--limit` is 10. Without an explicit cap, search returns at
+/// most 10 hits; agents who want more drill in with progressive
+/// commands. Total still reflects the full match count.
+pub(crate) async fn default_limit_caps_at_ten<B: Backend>() -> TestResult {
+    let harness = with_searchable::<B>().await?;
+
+    for i in 0..12 {
+        harness
+            .exec_json(&format!(
+                "cognition add thinker.process observation 'Capped item {i}'"
+            ))
+            .await?;
+    }
+
+    let response = harness.exec_json("search Capped").await?;
+    let results = extract_full(response);
+
+    assert_eq!(
+        results.hits.len(),
+        10,
+        "default limit should cap returned hits at 10"
+    );
+    assert_eq!(
+        results.total, 12,
+        "total should reflect the full match count, not the cap"
+    );
+
+    Ok(())
+}
+
+/// Search hits are kind-discriminated, fully-hydrated typed domain
+/// objects — a `Hit::Cognition` carries the full `Cognition`, a
+/// `Hit::Memory` carries the full `Memory`, etc. The intermediate
+/// `Expression` shape is gone; search renders through the same domain
+/// objects that lists do.
+pub(crate) async fn hits_are_hydrated_typed_objects<B: Backend>() -> TestResult {
+    let harness = with_searchable::<B>().await?;
+
+    harness
+        .exec_json("cognition add thinker.process observation 'Hydration test cognition'")
+        .await?;
+    harness
+        .exec_json("memory add thinker.process session 'Hydration test memory'")
+        .await?;
+
+    let response = harness.exec_json("search Hydration").await?;
+    let results = extract_full(response);
+
+    assert_eq!(results.hits.len(), 2, "expected 2 hits across kinds");
+
+    let cognition_hit = results
+        .hits
+        .iter()
+        .find(|h| matches!(h, Hit::Cognition(_)))
+        .expect("cognition hit present");
+    let Hit::Cognition(cognition) = cognition_hit else {
+        unreachable!()
+    };
+    assert_eq!(cognition.content.as_str(), "Hydration test cognition");
+    assert_eq!(cognition.texture.as_str(), "observation");
+
+    let memory_hit = results
+        .hits
+        .iter()
+        .find(|h| matches!(h, Hit::Memory(_)))
+        .expect("memory hit present");
+    let Hit::Memory(memory) = memory_hit else {
+        unreachable!()
+    };
+    assert_eq!(memory.content.as_str(), "Hydration test memory");
+    assert_eq!(memory.level.as_str(), "session");
 
     Ok(())
 }

--- a/crates/oneiros-engine/src/tests/acceptance/mod.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/mod.rs
@@ -609,6 +609,14 @@ async fn cognition_list_filters_by_agent() -> TestResult {
     cases::cognition::list_filters_by_agent::<EngineBackend>().await
 }
 #[tokio::test]
+async fn cognition_list_filters_by_query() -> TestResult {
+    cases::cognition::list_filters_by_query::<EngineBackend>().await
+}
+#[tokio::test]
+async fn memory_list_filters_by_query() -> TestResult {
+    cases::memory::list_filters_by_query::<EngineBackend>().await
+}
+#[tokio::test]
 async fn cognition_show_by_id() -> TestResult {
     cases::cognition::show_by_id::<EngineBackend>().await
 }
@@ -805,6 +813,36 @@ async fn search_finds_updated_agent_description() -> TestResult {
 #[tokio::test]
 async fn search_finds_updated_experience_description() -> TestResult {
     cases::search::finds_updated_experience_description::<EngineBackend>().await
+}
+
+// Facets
+#[tokio::test]
+async fn search_returns_faceted_results() -> TestResult {
+    cases::search::returns_faceted_results::<EngineBackend>().await
+}
+#[tokio::test]
+async fn search_narrows_by_kind_filter() -> TestResult {
+    cases::search::narrows_by_kind_filter::<EngineBackend>().await
+}
+#[tokio::test]
+async fn search_hits_carry_typed_metadata() -> TestResult {
+    cases::search::hits_carry_typed_metadata::<EngineBackend>().await
+}
+#[tokio::test]
+async fn search_hits_are_hydrated_typed_objects() -> TestResult {
+    cases::search::hits_are_hydrated_typed_objects::<EngineBackend>().await
+}
+#[tokio::test]
+async fn search_default_limit_caps_at_ten() -> TestResult {
+    cases::search::default_limit_caps_at_ten::<EngineBackend>().await
+}
+#[tokio::test]
+async fn search_prompt_renders_flat_with_kind_column() -> TestResult {
+    cases::search::prompt_renders_flat_with_kind_column::<EngineBackend>().await
+}
+#[tokio::test]
+async fn search_every_content_kind_indexes() -> TestResult {
+    cases::search::every_content_kind_indexes::<EngineBackend>().await
 }
 
 // Import/Export depth

--- a/crates/oneiros-engine/src/tests/workflows/search.rs
+++ b/crates/oneiros-engine/src/tests/workflows/search.rs
@@ -40,7 +40,7 @@ async fn search_across_domains() -> Result<(), Box<dyn core::error::Error>> {
         )
         .await?
     {
-        SearchResponse::Results(ResultsResponse::V1(r)) => assert_eq!(r.results.len(), 1),
+        SearchResponse::Results(ResultsResponse::V1(r)) => assert_eq!(r.hits.len(), 1),
     }
 
     // Search finds agent descriptions
@@ -49,7 +49,7 @@ async fn search_across_domains() -> Result<(), Box<dyn core::error::Error>> {
         .search(&SearchQuery::builder_v1().query("Governor").build().into())
         .await?
     {
-        SearchResponse::Results(ResultsResponse::V1(r)) => assert_eq!(r.results.len(), 1),
+        SearchResponse::Results(ResultsResponse::V1(r)) => assert_eq!(r.hits.len(), 1),
     }
 
     // Search with agent filter narrows results
@@ -64,7 +64,7 @@ async fn search_across_domains() -> Result<(), Box<dyn core::error::Error>> {
         )
         .await?
     {
-        SearchResponse::Results(ResultsResponse::V1(r)) => assert_eq!(r.results.len(), 1),
+        SearchResponse::Results(ResultsResponse::V1(r)) => assert_eq!(r.hits.len(), 1),
     }
 
     // Search for something that doesn't exist
@@ -78,7 +78,7 @@ async fn search_across_domains() -> Result<(), Box<dyn core::error::Error>> {
         )
         .await?
     {
-        SearchResponse::Results(ResultsResponse::V1(r)) => assert_eq!(r.results.len(), 0),
+        SearchResponse::Results(ResultsResponse::V1(r)) => assert_eq!(r.hits.len(), 0),
     }
 
     Ok(())

--- a/crates/oneiros-engine/src/values/expression.rs
+++ b/crates/oneiros-engine/src/values/expression.rs
@@ -1,19 +1,151 @@
-use bon::Builder;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-/// A search expression — a normalized text fragment extracted from an entity
-/// and indexed for full-text search. Expressions are projection targets:
-/// events produce them, and the FTS5 index makes them queryable.
-#[derive(Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
-pub struct Expression {
+/// A hydrated search hit — the full domain object behind a `search_index` row.
+///
+/// One variant per content-bearing kind. Search returns these in FTS5
+/// relevance order across kinds; callers that want kind-grouping do so at
+/// presentation time. Lists carry their kind-homogeneous slice through the
+/// usual domain response (e.g. `CognitionsResponse::items`), built by
+/// extracting the matching variant from a search result.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(tag = "kind", content = "data", rename_all = "kebab-case")]
+pub enum Hit {
+    Cognition(Cognition),
+    Memory(Memory),
+    Experience(Experience),
+    Agent(Agent),
+}
+
+impl Hit {
+    pub fn kind(&self) -> SearchKind {
+        match self {
+            Self::Cognition(_) => SearchKind::Cognition,
+            Self::Memory(_) => SearchKind::Memory,
+            Self::Experience(_) => SearchKind::Experience,
+            Self::Agent(_) => SearchKind::Agent,
+        }
+    }
+
+    pub fn resource_ref(&self) -> Ref {
+        match self {
+            Self::Cognition(c) => Ref::cognition(c.id),
+            Self::Memory(m) => Ref::memory(m.id),
+            Self::Experience(e) => Ref::experience(e.id),
+            Self::Agent(a) => Ref::agent(a.id),
+        }
+    }
+
+    pub fn content(&self) -> Content {
+        match self {
+            Self::Cognition(c) => c.content.clone(),
+            Self::Memory(m) => m.content.clone(),
+            Self::Experience(e) => Content::new(e.description.to_string()),
+            Self::Agent(a) => Content::new(format!("{} {}", a.name, a.description)),
+        }
+    }
+}
+
+/// Flat columns for a `search_index` row. Built from a domain object on
+/// the write side, decoded into a [`RankedHit`] on the read side.
+///
+/// Existing `IndexEntry::cognition` etc. constructors normalize the
+/// kind-specific facet (texture/level/sensation/persona) into the right
+/// column; absent dimensions are empty strings.
+pub(crate) struct IndexEntry {
     pub resource_ref: Ref,
-    #[builder(into)]
-    pub kind: Label,
-    #[builder(into)]
+    pub kind: SearchKind,
     pub content: Content,
+    pub agent_id: AgentId,
+    pub texture: Option<TextureName>,
+    pub level: Option<LevelName>,
+    pub sensation: Option<SensationName>,
+    pub persona: Option<PersonaName>,
+    pub created_at: Option<Timestamp>,
+}
+
+impl IndexEntry {
+    pub fn cognition(cognition: &Cognition) -> Self {
+        Self {
+            resource_ref: Ref::cognition(cognition.id),
+            kind: SearchKind::Cognition,
+            content: cognition.content.clone(),
+            agent_id: cognition.agent_id,
+            texture: Some(cognition.texture.clone()),
+            level: None,
+            sensation: None,
+            persona: None,
+            created_at: Some(cognition.created_at),
+        }
+    }
+
+    pub fn memory(memory: &Memory) -> Self {
+        Self {
+            resource_ref: Ref::memory(memory.id),
+            kind: SearchKind::Memory,
+            content: memory.content.clone(),
+            agent_id: memory.agent_id,
+            texture: None,
+            level: Some(memory.level.clone()),
+            sensation: None,
+            persona: None,
+            created_at: Some(memory.created_at),
+        }
+    }
+
+    pub fn experience(experience: &Experience) -> Self {
+        Self {
+            resource_ref: Ref::experience(experience.id),
+            kind: SearchKind::Experience,
+            content: Content::new(experience.description.to_string()),
+            agent_id: experience.agent_id,
+            texture: None,
+            level: None,
+            sensation: Some(experience.sensation.clone()),
+            persona: None,
+            created_at: Some(experience.created_at),
+        }
+    }
+
+    pub fn agent(agent: &Agent) -> Self {
+        Self {
+            resource_ref: Ref::agent(agent.id),
+            kind: SearchKind::Agent,
+            content: Content::new(format!("{} {}", agent.name, agent.description)),
+            agent_id: agent.id,
+            texture: None,
+            level: None,
+            sensation: None,
+            persona: Some(agent.persona.clone()),
+            created_at: None,
+        }
+    }
+}
+
+/// A ranked hit pulled from `search_index` — just enough to drive
+/// kind-aware hydration through per-domain `get_many` calls. The row
+/// preserves FTS5 rank order (or `created_at desc` when no query is
+/// present); hydration must reassemble [`Hit`]s in this order. The
+/// kind is carried by the `Ref::V0(Resource::...)` variant — no
+/// separate discriminator needed.
+#[derive(Debug, Clone)]
+pub(crate) struct RankedHit {
+    pub resource_ref: Ref,
+}
+
+impl RankedHit {
+    pub(crate) fn from_row(row: &rusqlite::Row) -> rusqlite::Result<Self> {
+        let resource_ref = decode_ref(row.get::<_, String>(0)?, 0)?;
+        Ok(Self { resource_ref })
+    }
+}
+
+fn decode_ref(raw: String, col: usize) -> rusqlite::Result<Ref> {
+    serde_json::from_str(&raw).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(col, rusqlite::types::Type::Text, Box::new(e))
+    })
 }
 
 /// The raw text submitted as a search query.
@@ -25,6 +157,10 @@ impl QueryText {
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
     }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl core::fmt::Display for QueryText {
@@ -33,9 +169,135 @@ impl core::fmt::Display for QueryText {
     }
 }
 
-/// Envelope for search results, pairing the original query with matches.
+/// Envelope for search results, pairing the original query with matches
+/// and faceted aggregations.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct SearchResults {
     pub query: QueryText,
-    pub results: Vec<Expression>,
+    pub total: usize,
+    pub hits: Vec<Hit>,
+    #[serde(default, skip_serializing_if = "Facets::is_empty")]
+    pub facets: Facets,
 }
+
+/// Internal repo-layer result — ranked refs awaiting per-domain
+/// hydration. Service layer turns this into [`SearchResults`].
+#[derive(Debug)]
+pub(crate) struct SearchHits {
+    pub total: usize,
+    pub hits: Vec<RankedHit>,
+    pub facets: Facets,
+}
+
+/// Ordered collection of faceted aggregations — the palace map.
+///
+/// Each `FacetGroup` names a dimension (kind, agent, texture, etc.) and
+/// carries one bucket per observed value. Groups with no buckets are
+/// omitted so callers only see wings of the palace that actually have doors.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(transparent)]
+pub struct Facets(pub Vec<FacetGroup>);
+
+impl Facets {
+    pub fn new(groups: Vec<FacetGroup>) -> Self {
+        Self(
+            groups
+                .into_iter()
+                .filter(|g| !g.buckets.is_empty())
+                .collect(),
+        )
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn find(&self, facet: FacetName) -> Option<&FacetGroup> {
+        self.0.iter().find(|g| g.facet == facet)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct FacetGroup {
+    pub facet: FacetName,
+    pub buckets: Vec<FacetBucket>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct FacetBucket {
+    pub value: String,
+    pub count: usize,
+}
+
+/// The named dimensions a search response can aggregate on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum FacetName {
+    Kind,
+    Agent,
+    Texture,
+    Level,
+    Sensation,
+    Persona,
+}
+
+impl FacetName {
+    pub fn column(self) -> &'static str {
+        match self {
+            FacetName::Kind => "kind",
+            FacetName::Agent => "agent_id",
+            FacetName::Texture => "texture",
+            FacetName::Level => "level",
+            FacetName::Sensation => "sensation",
+            FacetName::Persona => "persona",
+        }
+    }
+}
+
+/// The kind of content-bearing entity a search hit refers to.
+///
+/// Mirrors the `kind` column stored in `search_index`. Used both as a filter
+/// on queries and as a label on hits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum SearchKind {
+    Cognition,
+    Memory,
+    Experience,
+    Agent,
+}
+
+impl SearchKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SearchKind::Cognition => "cognition",
+            SearchKind::Memory => "memory",
+            SearchKind::Experience => "experience",
+            SearchKind::Agent => "agent",
+        }
+    }
+}
+
+impl core::fmt::Display for SearchKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl core::str::FromStr for SearchKind {
+    type Err = SearchKindParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "cognition" => Ok(SearchKind::Cognition),
+            "memory" => Ok(SearchKind::Memory),
+            "experience" => Ok(SearchKind::Experience),
+            "agent" => Ok(SearchKind::Agent),
+            other => Err(SearchKindParseError(other.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("unknown search kind: {0}")]
+pub struct SearchKindParseError(pub String);

--- a/crates/oneiros-engine/src/values/search_filters.rs
+++ b/crates/oneiros-engine/src/values/search_filters.rs
@@ -9,7 +9,9 @@ use rusqlite::types::{ToSql, ToSqlOutput};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 
-/// How many items to return. Defaults to 20.
+/// How many items to return. Defaults to 10 — small enough not to flood
+/// CLI output or MCP context; agents who want more drill in with
+/// progressive commands.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 #[serde(transparent)]
 pub struct Limit(pub usize);
@@ -43,7 +45,7 @@ impl Limit {
 
 impl Default for Limit {
     fn default() -> Self {
-        Self(20)
+        Self(10)
     }
 }
 
@@ -127,7 +129,7 @@ impl ToSql for Offset {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Args)]
 pub struct SearchFilters {
     /// Maximum number of items to return
-    #[arg(long, default_value = "20")]
+    #[arg(long, default_value = "10")]
     #[serde(default)]
     pub limit: Limit,
 


### PR DESCRIPTION
This introduces search behavior in list operations for continuity, so that agents can kind of dig around in cognitions, etc., without getting the full firehose of search results. It also results in a filtering function on the search feature directly, so it's somewhat bidirectional - except that continuity resulting from the search gets displayed differently depending on where it's begun.