### PR TITLE
Streams and subscribers.

### DIFF
--- a/crates/oneiros-engine/src/contexts/project.rs
+++ b/crates/oneiros-engine/src/contexts/project.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use tokio::sync::broadcast;
 
 use crate::*;
@@ -8,46 +10,56 @@ impl aide::operation::OperationInput for ProjectContext {}
 pub struct ProjectContext {
     pub config: Config,
     pub projections: Projections<BrainCanon>,
-    chronicle: Chronicle,
-    broadcast: broadcast::Sender<StoredEvent>,
+    stream: ProjectStream,
 }
 
 impl ProjectContext {
     pub fn new(config: Config) -> Self {
-        let (broadcast, _) = broadcast::channel(256);
-
-        Self {
-            config,
-            projections: Projections::project(),
-            chronicle: Chronicle::new(),
-            broadcast,
-        }
+        let (wake, _) = broadcast::channel(256);
+        let projections = Projections::project();
+        let chronicle = Chronicle::new();
+        Self::assemble(config, wake, projections, chronicle)
     }
 
     /// Create a context that shares an existing broadcast channel.
     ///
     /// Used by the HTTP server so all per-request contexts and SSE
     /// subscribers share the same event stream.
-    pub fn with_broadcast(config: Config, broadcast: broadcast::Sender<StoredEvent>) -> Self {
-        Self {
-            config,
-            projections: Projections::project(),
-            chronicle: Chronicle::new(),
-            broadcast,
-        }
+    pub fn with_broadcast(config: Config, wake: broadcast::Sender<StoredEvent>) -> Self {
+        let projections = Projections::project();
+        let chronicle = Chronicle::new();
+        Self::assemble(config, wake, projections, chronicle)
     }
 
     /// Create a context with shared broadcast and a pre-hydrated bookmark entry.
     pub fn with_entry(
         config: Config,
-        broadcast: broadcast::Sender<StoredEvent>,
+        wake: broadcast::Sender<StoredEvent>,
         entry: BookmarkEntry,
     ) -> Self {
+        let projections = Projections::project_with_pipeline(entry.pipeline);
+        Self::assemble(config, wake, projections, entry.chronicle)
+    }
+
+    /// Shared constructor — wires up the stream with its subscribers.
+    fn assemble(
+        config: Config,
+        wake: broadcast::Sender<StoredEvent>,
+        projections: Projections<BrainCanon>,
+        chronicle: Chronicle,
+    ) -> Self {
+        let subscribers: Vec<Arc<dyn Subscriber>> = vec![
+            Arc::new(ProjectionSubscriber::new(
+                projections.clone(),
+                config.clone(),
+            )),
+            Arc::new(ChronicleSubscriber::new(chronicle, config.clone())),
+        ];
+        let stream = ProjectStream::new(config.clone(), wake, subscribers);
         Self {
             config,
-            projections: Projections::project_with_pipeline(entry.pipeline),
-            chronicle: entry.chronicle,
-            broadcast,
+            projections,
+            stream,
         }
     }
 
@@ -71,7 +83,7 @@ impl ProjectContext {
 
     /// Subscribe to the event broadcast stream.
     pub fn subscribe(&self) -> broadcast::Receiver<StoredEvent> {
-        self.broadcast.subscribe()
+        self.stream.subscribe()
     }
 
     /// Open the bookmark DB with the events DB ATTACHed.
@@ -97,25 +109,14 @@ impl ProjectContext {
 
     /// Emit an event to the brain's event log and apply projections.
     pub async fn emit(&self, event: impl Into<Events>) -> Result<(), EventError> {
-        let db = self.db()?;
-        let new_event = NewEvent::builder().data(event).build();
-        let stored = EventLog::attached(&db).append(&new_event)?;
-
-        self.projections.apply_brain(&db, &stored)?;
-
-        // Chronicle the event in the system DB (shared across bookmarks).
-        let system_db = self.system_db()?;
-        let chronicle_store = ChronicleStore::new(&system_db);
-        chronicle_store.migrate()?;
-        self.chronicle.record(
-            &stored,
-            &chronicle_store.resolver(),
-            &chronicle_store.writer(),
-        )?;
-
-        // We broadcast the new event after projecting it.
-        let _ = self.broadcast.send(stored);
-
+        self.stream.publish(event)?;
         Ok(())
+    }
+
+    /// Ceremony barrier — wait until subscribers (projections, chronicle)
+    /// have caught up to the current log head. Call before reading back
+    /// projected state in multi-emit workflows.
+    pub async fn wait_for_head(&self) -> Result<(), EventError> {
+        self.stream.wait_for_head().await
     }
 }

--- a/crates/oneiros-engine/src/contexts/system.rs
+++ b/crates/oneiros-engine/src/contexts/system.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::*;
 
 impl aide::operation::OperationInput for SystemContext {}
@@ -6,13 +8,20 @@ impl aide::operation::OperationInput for SystemContext {}
 pub struct SystemContext {
     pub config: Config,
     pub projections: Projections<SystemCanon>,
+    stream: SystemStream,
 }
 
 impl SystemContext {
     pub fn new(config: Config) -> Self {
+        let projections = Projections::system();
+        let subscribers: Vec<Arc<dyn Subscriber>> = vec![Arc::new(
+            SystemProjectionSubscriber::new(projections.clone(), config.clone()),
+        )];
+        let stream = SystemStream::new(config.clone(), subscribers);
         Self {
             config,
-            projections: Projections::system(),
+            projections,
+            stream,
         }
     }
 
@@ -28,12 +37,14 @@ impl SystemContext {
 
     /// Emit an event to the system event log and apply projections.
     pub async fn emit(&self, event: impl Into<Events>) -> Result<(), EventError> {
-        let db = self.db()?;
-        let new_event = NewEvent::builder().data(event).build();
-        let stored = EventLog::new(&db).append(&new_event)?;
-
-        self.projections.apply(&db, &stored)?;
-
+        self.stream.publish(event)?;
         Ok(())
+    }
+
+    /// Ceremony barrier — wait until subscribers have caught up to the
+    /// current log head. Call before reading projected state after a
+    /// multi-emit workflow.
+    pub async fn wait_for_head(&self) -> Result<(), EventError> {
+        self.stream.wait_for_head().await
     }
 }

--- a/crates/oneiros-engine/src/domains/continuity/service.rs
+++ b/crates/oneiros-engine/src/domains/continuity/service.rs
@@ -55,6 +55,12 @@ impl ContinuityService {
             overrides,
         )
         .await?;
+
+        // Barrier: wait for subscribers to process AgentCreated + Dreamed
+        // before reading back projected state. No-op while fan-out is
+        // synchronous, load-bearing once subscribers become tasks.
+        context.wait_for_head().await?;
+
         let dream = Self::gather_context(context, &agent_name, overrides)?;
         Ok(ContinuityResponse::Emerged(dream))
     }

--- a/crates/oneiros-engine/src/lib.rs
+++ b/crates/oneiros-engine/src/lib.rs
@@ -14,6 +14,7 @@ mod projections;
 mod protocol;
 mod reducers;
 mod skill;
+mod streams;
 mod support;
 #[cfg(test)]
 mod tests;
@@ -34,6 +35,7 @@ pub use projections::*;
 pub use protocol::*;
 pub use reducers::*;
 pub use skill::*;
+pub use streams::*;
 pub use support::*;
 pub use values::*;
 

--- a/crates/oneiros-engine/src/streams.rs
+++ b/crates/oneiros-engine/src/streams.rs
@@ -1,0 +1,203 @@
+//! Streams — the surrogate `emit` delegates to.
+//!
+//! A `ProjectStream` owns the pieces that used to be inlined in
+//! `ProjectContext::emit`: the wake channel (broadcast), the synchronous
+//! subscribers (projections, chronicle), and enough config to open the
+//! connections each needs.
+//!
+//! Publishing an event is:
+//! 1. Append to the event log (truth).
+//! 2. Synchronously fan out to each subscriber in order.
+//! 3. Fire the wake (best-effort).
+//!
+//! Subscribers are sync callees for this spike — the whole publish call
+//! completes before returning, matching today's emit semantics exactly.
+
+use tokio::sync::broadcast;
+
+use crate::*;
+
+/// Something that reacts to an appended event.
+///
+/// Synchronous for this spike — iteration in `publish` waits for each
+/// subscriber before moving to the next. Same behavior as today's
+/// inline emit.
+pub trait Subscriber: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn on_event(&self, stored: &StoredEvent) -> Result<(), EventError>;
+}
+
+/// A project-scoped stream — per (brain, bookmark) for this spike.
+///
+/// Holds the pieces `emit` used to touch inline.
+#[derive(Clone)]
+pub struct ProjectStream {
+    config: Config,
+    wake: broadcast::Sender<StoredEvent>,
+    subscribers: Vec<std::sync::Arc<dyn Subscriber>>,
+}
+
+impl ProjectStream {
+    pub fn new(
+        config: Config,
+        wake: broadcast::Sender<StoredEvent>,
+        subscribers: Vec<std::sync::Arc<dyn Subscriber>>,
+    ) -> Self {
+        Self {
+            config,
+            wake,
+            subscribers,
+        }
+    }
+
+    /// Subscribe to the wake channel — external listeners (e.g. SSE).
+    pub fn subscribe(&self) -> broadcast::Receiver<StoredEvent> {
+        self.wake.subscribe()
+    }
+
+    /// Wait until all subscribers have caught up to the current log head.
+    ///
+    /// While subscribers fan out synchronously inside `publish`, this is
+    /// a no-op — cursors are always at head when control returns to the
+    /// caller. Ceremonies that need read-your-own-writes call this
+    /// before querying projected state, so the code reads correctly and
+    /// the call site survives the eventual flip to async subscribers.
+    pub async fn wait_for_head(&self) -> Result<(), EventError> {
+        Ok(())
+    }
+
+    /// Append an event, fan out to subscribers, fire the wake.
+    pub fn publish(&self, event: impl Into<Events>) -> Result<StoredEvent, EventError> {
+        let db = self.config.bookmark_conn()?;
+        let new_event = NewEvent::builder().data(event).build();
+        let stored = EventLog::attached(&db).append(&new_event)?;
+
+        for subscriber in &self.subscribers {
+            subscriber.on_event(&stored)?;
+        }
+
+        let _ = self.wake.send(stored.clone());
+        Ok(stored)
+    }
+}
+
+/// Subscriber that applies brain projections (tables + reducers +
+/// pressure sync). Wraps today's `Projections::apply_brain`.
+pub struct ProjectionSubscriber {
+    projections: Projections<BrainCanon>,
+    config: Config,
+}
+
+impl ProjectionSubscriber {
+    pub fn new(projections: Projections<BrainCanon>, config: Config) -> Self {
+        Self {
+            projections,
+            config,
+        }
+    }
+}
+
+impl Subscriber for ProjectionSubscriber {
+    fn name(&self) -> &'static str {
+        "projections"
+    }
+
+    fn on_event(&self, stored: &StoredEvent) -> Result<(), EventError> {
+        let db = self.config.bookmark_conn()?;
+        self.projections.apply_brain(&db, stored)
+    }
+}
+
+/// A host-scoped stream — one per running service.
+///
+/// Simpler than `ProjectStream`: no chronicle, no wake (system events
+/// don't broadcast today). One canonical subscriber: the system
+/// projections.
+#[derive(Clone)]
+pub struct SystemStream {
+    config: Config,
+    subscribers: Vec<std::sync::Arc<dyn Subscriber>>,
+}
+
+impl SystemStream {
+    pub fn new(config: Config, subscribers: Vec<std::sync::Arc<dyn Subscriber>>) -> Self {
+        Self {
+            config,
+            subscribers,
+        }
+    }
+
+    /// Wait until subscribers have caught up to the current log head.
+    /// No-op while fan-out is synchronous; earns teeth when subscribers
+    /// move to their own tasks.
+    pub async fn wait_for_head(&self) -> Result<(), EventError> {
+        Ok(())
+    }
+
+    /// Append a system event, fan out to subscribers.
+    pub fn publish(&self, event: impl Into<Events>) -> Result<StoredEvent, EventError> {
+        let db = self.config.system_db()?;
+        let new_event = NewEvent::builder().data(event).build();
+        let stored = EventLog::new(&db).append(&new_event)?;
+
+        for subscriber in &self.subscribers {
+            subscriber.on_event(&stored)?;
+        }
+
+        Ok(stored)
+    }
+}
+
+/// Subscriber that applies system-level projections. Wraps today's
+/// `Projections::<SystemCanon>::apply`.
+pub struct SystemProjectionSubscriber {
+    projections: Projections<SystemCanon>,
+    config: Config,
+}
+
+impl SystemProjectionSubscriber {
+    pub fn new(projections: Projections<SystemCanon>, config: Config) -> Self {
+        Self {
+            projections,
+            config,
+        }
+    }
+}
+
+impl Subscriber for SystemProjectionSubscriber {
+    fn name(&self) -> &'static str {
+        "system-projections"
+    }
+
+    fn on_event(&self, stored: &StoredEvent) -> Result<(), EventError> {
+        let db = self.config.system_db()?;
+        self.projections.apply(&db, stored)
+    }
+}
+
+/// Subscriber that records the event in the brain's chronicle (HAMT
+/// root in the system DB). Wraps today's `Chronicle::record`.
+pub struct ChronicleSubscriber {
+    chronicle: Chronicle,
+    config: Config,
+}
+
+impl ChronicleSubscriber {
+    pub fn new(chronicle: Chronicle, config: Config) -> Self {
+        Self { chronicle, config }
+    }
+}
+
+impl Subscriber for ChronicleSubscriber {
+    fn name(&self) -> &'static str {
+        "chronicle"
+    }
+
+    fn on_event(&self, stored: &StoredEvent) -> Result<(), EventError> {
+        let system_db = self.config.system_db()?;
+        let store = ChronicleStore::new(&system_db);
+        store.migrate()?;
+        self.chronicle
+            .record(stored, &store.resolver(), &store.writer())
+    }
+}


### PR DESCRIPTION
This is just a spike designed to take a look at what a stream and subscriber should look like. This is kind of messy, and isn't meant to be carried forward - but the code should be kept as reference.