### PR TITLE
Importable bookmarks.

### DIFF
--- a/crates/oneiros-engine/src/domains/project/service.rs
+++ b/crates/oneiros-engine/src/domains/project/service.rs
@@ -158,6 +158,14 @@ impl ProjectService {
         let db = context.db()?;
         let log = EventLog::attached(&db);
 
+        // Import is self-bootstrapping: a destination brain may have seen
+        // `system init` without `project init`, leaving the events DB and
+        // bookmark DB unmigrated. Running the migrations here is idempotent
+        // (CREATE TABLE IF NOT EXISTS) and makes import the correctness
+        // gate the versioning story relies on.
+        log.migrate()?;
+        context.projections.migrate(&db)?;
+
         // Batch all inserts in a single transaction — without this,
         // each INSERT is an implicit transaction with an fsync.
         db.execute_batch("BEGIN")?;

--- a/crates/oneiros-engine/src/tests/acceptance/cases/import_export.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/import_export.rs
@@ -131,6 +131,63 @@ pub(crate) async fn export_import_preserves_storage<B: Backend>() -> TestResult 
     Ok(())
 }
 
+/// Import should be self-bootstrapping: a brain that has seen `system init`
+/// but never `project init` should still accept an import and materialize
+/// the data. This is the correctness-gate property the versioning design
+/// leans on — "snapshot imported through new code produces same projection
+/// state" presumes import can hydrate a fresh brain without relying on init
+/// to have pre-migrated the on-disk schema.
+pub(crate) async fn import_bootstraps_fresh_brain<B: Backend>() -> TestResult {
+    let source = Harness::<B>::init_project().await?;
+    source
+        .exec_json("persona set process --description 'Process agents'")
+        .await?;
+    source
+        .exec_json("texture set observation --description 'Observations'")
+        .await?;
+    source
+        .exec_json("agent create thinker process --description 'A thinking agent'")
+        .await?;
+    source
+        .exec_json("cognition add thinker.process observation 'Remember this thought'")
+        .await?;
+
+    let export_dir = tempfile::TempDir::new()?;
+    let export_cmd = format!("project export --target {}", export_dir.path().display());
+    let export_response = source.exec_json(&export_cmd).await?;
+
+    let export_path = match export_response {
+        Responses::Project(ProjectResponse::WroteExport(path)) => path,
+        other => panic!("expected WroteExport, got {other:#?}"),
+    };
+
+    // Destination has system init but no project init — import must
+    // bootstrap the brain's schema itself.
+    let destination = Harness::<B>::setup_system().await?.start_service().await?;
+
+    let import_response = destination
+        .exec_json(&format!("project import {}", export_path.display()))
+        .await?;
+
+    match import_response {
+        Responses::Project(ProjectResponse::Imported(result)) => {
+            assert!(
+                result.imported.0 > 0,
+                "expected at least one event imported, got {}",
+                result.imported.0,
+            );
+            assert!(
+                result.replayed.0 > 0,
+                "expected at least one event replayed, got {}",
+                result.replayed.0,
+            );
+        }
+        other => panic!("expected Imported, got {other:#?}"),
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn replay_rebuilds_projections<B: Backend>() -> TestResult {
     let harness = Harness::<B>::init_project().await?;
     harness

--- a/crates/oneiros-engine/src/tests/acceptance/mod.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/mod.rs
@@ -824,6 +824,10 @@ async fn replay_rebuilds_projections() -> TestResult {
 async fn export_import_preserves_storage() -> TestResult {
     cases::import_export::export_import_preserves_storage::<EngineBackend>().await
 }
+#[tokio::test]
+async fn import_bootstraps_fresh_brain() -> TestResult {
+    cases::import_export::import_bootstraps_fresh_brain::<EngineBackend>().await
+}
 
 // Pressure
 #[tokio::test]

--- a/docs/recipes/running-locally.md
+++ b/docs/recipes/running-locally.md
@@ -1,0 +1,94 @@
+# Running Multiple Instances Locally
+
+Debugging oneiros locally can be risky if you're also using an oneiroi. So, if you want to do that, the most direct way is to run it with multiple instances, each pointing at different data directories.
+
+The keys here are:
+
+- Running it on different ports
+- Pointing at different data directories
+- If you're running it off-project, giving it a `--brain` param so it uses that as the project name instead of inferring it
+
+## Why?
+
+You might want to test import / export stuff, rehearse upgrades to see if there are any issues before committing to them, practice a version upcast, or simulate multiple hosts for distribution purposes. It might be mostly for contributors, but it's totally possible there's good reasons to do it as a user, too.
+
+## How?
+
+For both the server itself, and any CLI usage against the server, you'll add the `--data-dir <path> --address <ip:port>` args to your oneiros commands, basically.
+
+- The data dir points you at a new storage location folder, which is where the event log and projections and config all go.
+- Address is an ip (not host!) to bind to, usually `127.0.0.1`, but there's no defaults.
+
+Two different instances with two different data directories and addresses won't ever see each other, or share db files, so no contention.
+
+### Server
+
+For example, kicking off a new instance of the server:
+
+```sh
+oneiros service run
+```
+
+That works against defaults. Meanwhile, this starts it up on a custom port with a scratchpad tmp directory:
+
+```sh
+oneiros service run \
+  --data-dir /tmp/oneiros-scratch \
+  --address 127.0.0.1:8081
+```
+
+### Client
+
+Much the same as the server, running the client has defaults, so:
+
+```sh
+oneiros cognition list
+```
+
+Gets a list of the most recent cognitions from the default oneiros instance. So, to see what's on your fresh instance, use the same args:
+
+```sh
+oneiros cognition list \
+  --data-dir /tmp/oneiros-scratch \
+  --address 127.0.0.1:8081
+```
+
+## Local export / import
+
+A pretty common reason to do this is to test out exports locally before doing anything with the main install.
+
+```sh
+# Export from the production install (defaults)
+oneiros project export --target /tmp/export-dir
+
+# Import into the scratch install
+oneiros project import /tmp/export-dir/<brain>-<date>-export.jsonl \
+  --data-dir /tmp/oneiros-scratch \
+  --brain <brain>
+```
+
+## Peeking under the hood
+
+Oneiros uses sqlite3 for persistence so you can take a gander at the databases if you like. It can be faster than using the CLI sometimes if you know where everything is, since you don't have to stand the server up to see what's in the db files.
+
+```sh
+# See the event log for a given brain.
+sqlite3 /tmp/oneiros-scratch/<brain>/events.db \
+  'select count(*) from events'
+
+# See the table schemas for the brain's "main" bookmark.
+sqlite3 /tmp/oneiros-scratch/<brain>/bookmarks/main.db \
+  '.tables'
+
+# See the total cognitions for the brain's "main" bookmark.
+sqlite3 /tmp/oneiros-scratch/<brain>/bookmarks/main.db \
+  'select count(*) from cognitions'
+```
+
+## Common gotchas
+
+**`--address` is a no-op for local-DB commands.** `project import`, `project export`, and `project replay` open the data directory directly — they do not route through HTTP. Passing `--address 127.0.0.1:8081` on these commands does *not* send them to the instance on 8081. Use `--data-dir` to target a specific instance's data.
+
+**Brain name is auto-detected from cwd.** Running `oneiros project import foo.jsonl` from `/tmp` will create a brain called `tmp`. Pass `--brain <name>` explicitly when running from an unrelated directory, or `cd` into a directory whose basename matches the target brain.
+
+**Ticket/token are per-instance.** An imported brain has no ticket on the destination until one is issued. HTTP queries against the imported brain will return `401 Missing authorization header` until a token is in place. Direct CLI commands that open the DB locally work regardless. You can conjure a token with `oneiros project init --brain <brain>`.


### PR DESCRIPTION
We've uncovered a bug! Import doesn't actually manage the process of initializing or migrating tables, meaning fresh setups do tend to work but imports fail out occasionally, especially if events isn't already attached.

This commit resolves the issue and adds some tests describing the problem, so we don't need to worry about regressions on the expected behavior.

For what it's worth, conducting testing without clobbering your local setup is possible and always has been, so we're creating a guide on how to do that.