### PR TITLE
Explicit event match arms

### DIFF
--- a/crates/oneiros-engine/src/domains/bookmark/store.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/store.rs
@@ -23,14 +23,21 @@ impl<'a> BookmarkStore<'a> {
     }
 
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
-        match &event.data {
-            Events::Bookmark(BookmarkEvents::BookmarkCreated(created)) => {
-                self.insert(&created.brain, &created.name, &event.created_at)?;
+        if let Events::Bookmark(bookmark_event) = &event.data {
+            match bookmark_event {
+                BookmarkEvents::BookmarkCreated(created) => {
+                    self.insert(&created.brain, &created.name, &event.created_at)?;
+                }
+                BookmarkEvents::BookmarkForked(forked) => {
+                    self.insert(&forked.brain, &forked.name, &event.created_at)?;
+                }
+                BookmarkEvents::BookmarkSwitched(_)
+                | BookmarkEvents::BookmarkMerged(_)
+                | BookmarkEvents::BookmarkShared(_)
+                | BookmarkEvents::BookmarkFollowed(_)
+                | BookmarkEvents::BookmarkCollected(_)
+                | BookmarkEvents::BookmarkUnfollowed(_) => {}
             }
-            Events::Bookmark(BookmarkEvents::BookmarkForked(forked)) => {
-                self.insert(&forked.brain, &forked.name, &event.created_at)?;
-            }
-            _ => {}
         }
         Ok(())
     }

--- a/crates/oneiros-engine/src/domains/follow/features/state.rs
+++ b/crates/oneiros-engine/src/domains/follow/features/state.rs
@@ -12,7 +12,12 @@ impl FollowState {
                 BookmarkEvents::BookmarkUnfollowed(unfollowed) => {
                     canon.follows.remove(unfollowed.follow_id);
                 }
-                _ => {}
+                BookmarkEvents::BookmarkCreated(_)
+                | BookmarkEvents::BookmarkForked(_)
+                | BookmarkEvents::BookmarkSwitched(_)
+                | BookmarkEvents::BookmarkMerged(_)
+                | BookmarkEvents::BookmarkShared(_)
+                | BookmarkEvents::BookmarkCollected(_) => {}
             }
         }
         canon

--- a/crates/oneiros-engine/src/domains/follow/store.rs
+++ b/crates/oneiros-engine/src/domains/follow/store.rs
@@ -16,17 +16,23 @@ impl<'a> FollowStore<'a> {
     }
 
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
-        match &event.data {
-            Events::Bookmark(BookmarkEvents::BookmarkFollowed(follow)) => {
-                self.create_record(follow)?;
+        if let Events::Bookmark(bookmark_event) = &event.data {
+            match bookmark_event {
+                BookmarkEvents::BookmarkFollowed(follow) => {
+                    self.create_record(follow)?;
+                }
+                BookmarkEvents::BookmarkCollected(collected) => {
+                    self.advance_checkpoint(collected)?;
+                }
+                BookmarkEvents::BookmarkUnfollowed(unfollowed) => {
+                    self.delete_record(unfollowed.follow_id)?;
+                }
+                BookmarkEvents::BookmarkCreated(_)
+                | BookmarkEvents::BookmarkForked(_)
+                | BookmarkEvents::BookmarkSwitched(_)
+                | BookmarkEvents::BookmarkMerged(_)
+                | BookmarkEvents::BookmarkShared(_) => {}
             }
-            Events::Bookmark(BookmarkEvents::BookmarkCollected(collected)) => {
-                self.advance_checkpoint(collected)?;
-            }
-            Events::Bookmark(BookmarkEvents::BookmarkUnfollowed(unfollowed)) => {
-                self.delete_record(unfollowed.follow_id)?;
-            }
-            _ => {}
         }
         Ok(())
     }

--- a/crates/oneiros-engine/src/domains/peer/store.rs
+++ b/crates/oneiros-engine/src/domains/peer/store.rs
@@ -12,17 +12,18 @@ impl<'a> PeerStore<'a> {
     }
 
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
-        match &event.data {
-            Events::Peer(PeerEvents::PeerAdded(peer)) => {
-                self.create_record(peer)?;
+        if let Events::Peer(peer_event) = &event.data {
+            match peer_event {
+                PeerEvents::PeerAdded(peer) => {
+                    self.create_record(peer)?;
+                }
+                PeerEvents::PeerUpdated(peer) => {
+                    self.create_record(peer)?;
+                }
+                PeerEvents::PeerRemoved(removed) => {
+                    self.delete_record(removed.id)?;
+                }
             }
-            Events::Peer(PeerEvents::PeerUpdated(peer)) => {
-                self.create_record(peer)?;
-            }
-            Events::Peer(PeerEvents::PeerRemoved(removed)) => {
-                self.delete_record(removed.id)?;
-            }
-            _ => {}
         }
         Ok(())
     }


### PR DESCRIPTION
In a few spots, we're matching against event enums without accounting for all variants. Basically, we have fallthroughs. Broadly, we don't want to do that with events anymore because we're about to start using match cases for versioning and upcasting. So, what this commit does is go through a bunch of these spots and make all the matches explicit, with no base cases that might catch newly introduced variants.