### PR TITLE
Versionable protocol.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,6 +2898,7 @@ dependencies = [
  "inquire",
  "iroh",
  "kinded",
+ "paste",
  "pkcs8",
  "postcard",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ inquire = "0.9.4"
 iroh = "0.98"
 kinded = "0.5.0"
 oneiros-engine = { path = "crates/oneiros-engine", version = "0.0.9" }
+paste = "1"
 # Pinned RustCrypto formats stack: ed25519 3.0.0-rc.4 (via iroh → ed25519-dalek
 # 3.0.0-pre.6) was compiled against pkcs8 0.11.0-rc.10, which in turn was
 # compiled against der 0.8.0-rc.10 and spki 0.8.0-rc.4. Each later rc / stable

--- a/crates/oneiros-engine/Cargo.toml
+++ b/crates/oneiros-engine/Cargo.toml
@@ -22,6 +22,7 @@ flate2.workspace = true
 inquire.workspace = true
 iroh.workspace = true
 kinded.workspace = true
+paste.workspace = true
 pkcs8.workspace = true
 postcard.workspace = true
 reqwest.workspace = true

--- a/crates/oneiros-engine/src/cli.rs
+++ b/crates/oneiros-engine/src/cli.rs
@@ -213,52 +213,62 @@ impl Command {
 
             // Flat lifecycle shortcuts — delegate to ContinuityCommands
             Command::Wake { name } => {
-                ContinuityCommands::Wake(WakeAgent {
-                    agent: name.clone(),
-                })
-                .execute(&config.project())
-                .await?
+                ContinuityCommands::Wake(WakeAgent::builder_v1().agent(name.clone()).build().into())
+                    .execute(&config.project())
+                    .await?
             }
             Command::Dream { name } => {
-                ContinuityCommands::Dream(DreamAgent {
-                    agent: name.clone(),
-                })
+                ContinuityCommands::Dream(
+                    DreamAgent::builder_v1().agent(name.clone()).build().into(),
+                )
                 .execute(&config.project())
                 .await?
             }
             Command::Introspect { name } => {
-                ContinuityCommands::Introspect(IntrospectAgent {
-                    agent: name.clone(),
-                })
+                ContinuityCommands::Introspect(
+                    IntrospectAgent::builder_v1()
+                        .agent(name.clone())
+                        .build()
+                        .into(),
+                )
                 .execute(&config.project())
                 .await?
             }
             Command::Reflect { name } => {
-                ContinuityCommands::Reflect(ReflectAgent {
-                    agent: name.clone(),
-                })
+                ContinuityCommands::Reflect(
+                    ReflectAgent::builder_v1()
+                        .agent(name.clone())
+                        .build()
+                        .into(),
+                )
                 .execute(&config.project())
                 .await?
             }
             Command::Sense { name, content } => {
-                ContinuityCommands::Sense(SenseContent {
-                    agent: name.clone(),
-                    content: content.clone(),
-                })
+                ContinuityCommands::Sense(
+                    SenseContent::builder_v1()
+                        .agent(name.clone())
+                        .content(content.clone())
+                        .build()
+                        .into(),
+                )
                 .execute(&config.project())
                 .await?
             }
             Command::Sleep { name } => {
-                ContinuityCommands::Sleep(SleepAgent {
-                    agent: name.clone(),
-                })
+                ContinuityCommands::Sleep(
+                    SleepAgent::builder_v1().agent(name.clone()).build().into(),
+                )
                 .execute(&config.project())
                 .await?
             }
             Command::Guidebook { name } => {
-                ContinuityCommands::Guidebook(GuidebookAgent {
-                    agent: name.clone(),
-                })
+                ContinuityCommands::Guidebook(
+                    GuidebookAgent::builder_v1()
+                        .agent(name.clone())
+                        .build()
+                        .into(),
+                )
                 .execute(&config.project())
                 .await?
             }
@@ -269,25 +279,33 @@ impl Command {
                 persona,
                 description,
             } => {
-                ContinuityCommands::Emerge(EmergeAgent {
-                    name: name.clone(),
-                    persona: persona.clone(),
-                    description: description.clone(),
-                })
+                ContinuityCommands::Emerge(
+                    EmergeAgent::builder_v1()
+                        .name(name.clone())
+                        .persona(persona.clone())
+                        .description(description.clone())
+                        .build()
+                        .into(),
+                )
                 .execute(&config.project())
                 .await?
             }
             Command::Recede { name } => {
-                ContinuityCommands::Recede(RecedeAgent {
-                    agent: name.clone(),
-                })
+                ContinuityCommands::Recede(
+                    RecedeAgent::builder_v1().agent(name.clone()).build().into(),
+                )
                 .execute(&config.project())
                 .await?
             }
             Command::Status => {
-                ContinuityCommands::Status(StatusAgent::default())
-                    .execute(&config.project())
-                    .await?
+                ContinuityCommands::Status(
+                    StatusAgent::builder_v1()
+                        .filters(SearchFilters::default())
+                        .build()
+                        .into(),
+                )
+                .execute(&config.project())
+                .await?
             }
         })
     }

--- a/crates/oneiros-engine/src/client.rs
+++ b/crates/oneiros-engine/src/client.rs
@@ -32,6 +32,9 @@ pub enum ClientError {
 
     #[error("Invalid request: {0}")]
     InvalidRequest(String),
+
+    #[error(transparent)]
+    Upcast(#[from] UpcastError),
 }
 
 impl IntoResponse for ClientError {

--- a/crates/oneiros-engine/src/domains/actor/client.rs
+++ b/crates/oneiros-engine/src/domains/actor/client.rs
@@ -18,15 +18,17 @@ impl<'a> ActorClient<'a> {
     }
 
     /// Retrieve a single actor by key (id or ref).
-    pub async fn get(&self, request: &GetActor) -> Result<ActorResponse, ClientError> {
-        self.client.get(&format!("/actors/{}", request.key)).await
+    pub async fn get(&self, lookup: &GetActor) -> Result<ActorResponse, ClientError> {
+        let GetActor::V1(lookup) = lookup;
+        self.client.get(&format!("/actors/{}", lookup.key)).await
     }
 
     /// List all actors.
-    pub async fn list(&self, request: &ListActors) -> Result<ActorResponse, ClientError> {
+    pub async fn list(&self, listing: &ListActors) -> Result<ActorResponse, ClientError> {
+        let ListActors::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset,
+            listing.filters.limit, listing.filters.offset,
         );
         self.client.get(&format!("/actors?{query}")).await
     }

--- a/crates/oneiros-engine/src/domains/actor/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/actor/features/cli.rs
@@ -2,6 +2,9 @@ use clap::Subcommand;
 
 use crate::*;
 
+/// CLI subcommands for the actor domain. Each variant carries a versioned
+/// protocol request directly — clap derives parsing through the wrapper's
+/// `Args` impl, which delegates to the latest version's struct.
 #[derive(Debug, Subcommand)]
 pub enum ActorCommands {
     Create(CreateActor),
@@ -18,9 +21,9 @@ impl ActorCommands {
         let actor_client = ActorClient::new(&client);
 
         let response = match self {
-            ActorCommands::Create(creation) => actor_client.create(creation).await?,
-            ActorCommands::Get(get) => actor_client.get(get).await?,
-            ActorCommands::List(list) => actor_client.list(list).await?,
+            Self::Create(creation) => actor_client.create(creation).await?,
+            Self::Get(lookup) => actor_client.get(lookup).await?,
+            Self::List(listing) => actor_client.list(listing).await?,
         };
 
         Ok(ActorView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/actor/features/http.rs
+++ b/crates/oneiros-engine/src/domains/actor/features/http.rs
@@ -52,6 +52,6 @@ async fn show(
     Path(key): Path<ResourceKey<ActorId>>,
 ) -> Result<Json<ActorResponse>, ActorError> {
     Ok(Json(
-        ActorService::get(&context, &GetActor::builder().key(key).build()).await?,
+        ActorService::get(&context, &GetActor::builder_v1().key(key).build().into()).await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/actor/features/state.rs
+++ b/crates/oneiros-engine/src/domains/actor/features/state.rs
@@ -4,10 +4,10 @@ pub struct ActorState;
 
 impl ActorState {
     pub fn reduce(mut canon: SystemCanon, event: &Events) -> SystemCanon {
-        if let Events::Actor(actor_event) = event {
-            match actor_event {
-                ActorEvents::ActorCreated(actor) => canon.actors.set(actor),
-            };
+        if let Events::Actor(actor_event) = event
+            && let Some(actor) = actor_event.maybe_actor()
+        {
+            canon.actors.set(&actor);
         }
 
         canon

--- a/crates/oneiros-engine/src/domains/actor/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/actor/protocol/events.rs
@@ -7,7 +7,23 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = ActorEventsType, display = "kebab-case")]
 pub enum ActorEvents {
-    ActorCreated(Actor),
+    ActorCreated(ActorCreated),
+}
+
+impl ActorEvents {
+    pub fn maybe_actor(&self) -> Option<Actor> {
+        match self {
+            ActorEvents::ActorCreated(event) => event.clone().current().ok().map(|v| v.actor),
+        }
+    }
+}
+
+versioned! {
+    pub enum ActorCreated {
+        V1 => {
+            #[serde(flatten)] pub actor: Actor,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -17,5 +33,53 @@ mod tests {
     #[test]
     fn event_types_are_kebab_cased() {
         assert_eq!(&ActorEventsType::ActorCreated.to_string(), "actor-created");
+    }
+
+    #[test]
+    fn actor_created_wire_format_is_flat() {
+        // The embedded `actor: Actor` field is `#[serde(flatten)]`, so the
+        // wire shape stays at the model fields rather than gaining an
+        // `actor` envelope.
+        let actor = Actor::builder()
+            .tenant_id(TenantId::new())
+            .name(ActorName::new("alice"))
+            .build();
+
+        let event = ActorEvents::ActorCreated(ActorCreated::V1(ActorCreatedV1 {
+            actor: actor.clone(),
+        }));
+        let json = serde_json::to_value(&event).unwrap();
+
+        assert_eq!(json["type"], "actor-created");
+        assert!(
+            json["data"].get("actor").is_none(),
+            "flatten must elide the actor envelope on the wire"
+        );
+        assert_eq!(json["data"]["id"], actor.id.to_string());
+        assert_eq!(json["data"]["name"], "alice");
+        assert!(json["data"].get("tenant_id").is_some());
+        assert!(json["data"].get("created_at").is_some());
+    }
+
+    #[test]
+    fn actor_created_round_trips() {
+        let actor = Actor::builder()
+            .tenant_id(TenantId::new())
+            .name(ActorName::new("alice"))
+            .build();
+
+        let original = ActorEvents::ActorCreated(ActorCreated::V1(ActorCreatedV1 {
+            actor: actor.clone(),
+        }));
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: ActorEvents = serde_json::from_str(&json).unwrap();
+
+        match decoded {
+            ActorEvents::ActorCreated(creation) => {
+                let v1 = creation.current().unwrap();
+                assert_eq!(v1.actor.name, actor.name);
+                assert_eq!(v1.actor.id, actor.id);
+            }
+        }
     }
 }

--- a/crates/oneiros-engine/src/domains/actor/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/actor/protocol/requests.rs
@@ -1,32 +1,42 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct CreateActor {
-    #[arg(long)]
-    #[builder(into)]
-    pub tenant_id: TenantId,
-    #[builder(into)]
-    pub name: ActorName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum CreateActor {
+        #[derive(clap::Args)]
+        V1 => {
+            #[arg(long)]
+            #[builder(into)] pub tenant_id: TenantId,
+            #[builder(into)] pub name: ActorName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetActor {
-    #[builder(into)]
-    pub key: ResourceKey<ActorId>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetActor {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<ActorId>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListActors {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListActors {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/actor/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/actor/protocol/responses.rs
@@ -1,13 +1,38 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = ActorResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ActorResponse {
-    Created(Response<Actor>),
-    Found(Response<Actor>),
-    Listed(Listed<Response<Actor>>),
+    Created(ActorCreatedResponse),
+    Found(ActorFoundResponse),
+    Listed(ActorsResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ActorCreatedResponse {
+        V1 => { #[serde(flatten)] pub actor: Actor }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ActorFoundResponse {
+        V1 => { #[serde(flatten)] pub actor: Actor }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ActorsResponse {
+        V1 => {
+            pub items: Vec<Actor>,
+            pub total: usize,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/actor/service.rs
+++ b/crates/oneiros-engine/src/domains/actor/service.rs
@@ -5,45 +5,59 @@ pub struct ActorService;
 impl ActorService {
     pub async fn create(
         context: &SystemContext,
-        CreateActor { tenant_id, name }: &CreateActor,
+        request: &CreateActor,
     ) -> Result<ActorResponse, ActorError> {
+        let CreateActor::V1(create) = request;
+
         let actor = Actor::builder()
-            .tenant_id(*tenant_id)
-            .name(name.clone())
+            .tenant_id(create.tenant_id)
+            .name(create.name.clone())
             .build();
 
         context
-            .emit(ActorEvents::ActorCreated(actor.clone()))
+            .emit(ActorEvents::ActorCreated(
+                ActorCreated::builder_v1()
+                    .actor(actor.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        let ref_token = RefToken::new(Ref::actor(actor.id));
+
         Ok(ActorResponse::Created(
-            Response::new(actor).with_ref_token(ref_token),
+            ActorCreatedResponse::builder_v1()
+                .actor(actor)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn get(
         context: &SystemContext,
-        selector: &GetActor,
+        request: &GetActor,
     ) -> Result<ActorResponse, ActorError> {
-        let id = selector.key.resolve()?;
+        let GetActor::V1(lookup) = request;
+        let id = lookup.key.resolve()?;
         let actor = ActorRepo::new(context)
             .get(id)
             .await?
             .ok_or(ActorError::NotFound(id))?;
-        let ref_token = RefToken::new(Ref::actor(actor.id));
         Ok(ActorResponse::Found(
-            Response::new(actor).with_ref_token(ref_token),
+            ActorFoundResponse::builder_v1().actor(actor).build().into(),
         ))
     }
 
     pub async fn list(
         context: &SystemContext,
-        ListActors { filters }: &ListActors,
+        request: &ListActors,
     ) -> Result<ActorResponse, ActorError> {
-        let listed = ActorRepo::new(context).list(filters).await?;
-        Ok(ActorResponse::Listed(listed.map(|a| {
-            let ref_token = RefToken::new(Ref::actor(a.id));
-            Response::new(a).with_ref_token(ref_token)
-        })))
+        let ListActors::V1(listing) = request;
+        let listed = ActorRepo::new(context).list(&listing.filters).await?;
+        Ok(ActorResponse::Listed(
+            ActorsResponse::builder_v1()
+                .items(listed.items)
+                .total(listed.total)
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/actor/store.rs
+++ b/crates/oneiros-engine/src/domains/actor/store.rs
@@ -12,8 +12,9 @@ impl<'a> ActorStore<'a> {
     }
 
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
-        if let Event::Known(Events::Actor(ActorEvents::ActorCreated(actor))) = &event.data {
-            self.create_record(actor)?;
+        if let Event::Known(Events::Actor(ActorEvents::ActorCreated(creation))) = &event.data {
+            let actor = creation.current()?.actor;
+            self.write_actor(&actor)?;
         }
         Ok(())
     }
@@ -35,7 +36,7 @@ impl<'a> ActorStore<'a> {
         Ok(())
     }
 
-    fn create_record(&self, actor: &Actor) -> Result<(), EventError> {
+    fn write_actor(&self, actor: &Actor) -> Result<(), EventError> {
         self.conn.execute(
             "insert or replace into actors (id, tenant_id, name, created_at)
              values (?1, ?2, ?3, ?4)",

--- a/crates/oneiros-engine/src/domains/actor/view.rs
+++ b/crates/oneiros-engine/src/domains/actor/view.rs
@@ -11,30 +11,41 @@ impl ActorView {
 
     pub fn render(self) -> Rendered<ActorResponse> {
         match self.response {
-            ActorResponse::Created(wrapped) => {
-                let prompt = Confirmation::new("Actor", wrapped.data.name.to_string(), "created")
+            ActorResponse::Created(ActorCreatedResponse::V1(created)) => {
+                let prompt = Confirmation::new("Actor", created.actor.name.to_string(), "created")
                     .to_string();
-                Rendered::new(ActorResponse::Created(wrapped), prompt, String::new())
+                Rendered::new(
+                    ActorResponse::Created(ActorCreatedResponse::V1(created)),
+                    prompt,
+                    String::new(),
+                )
             }
-            ActorResponse::Found(wrapped) => {
-                let prompt = Detail::new(wrapped.data.name.to_string())
-                    .field("id:", wrapped.data.id.to_string())
-                    .field("tenant_id:", wrapped.data.tenant_id.to_string())
+            ActorResponse::Found(ActorFoundResponse::V1(found)) => {
+                let prompt = Detail::new(found.actor.name.to_string())
+                    .field("id:", found.actor.id.to_string())
+                    .field("tenant_id:", found.actor.tenant_id.to_string())
                     .to_string();
-                Rendered::new(ActorResponse::Found(wrapped), prompt, String::new())
+                Rendered::new(
+                    ActorResponse::Found(ActorFoundResponse::V1(found)),
+                    prompt,
+                    String::new(),
+                )
             }
-            ActorResponse::Listed(listed) => {
+            ActorResponse::Listed(ActorsResponse::V1(listed)) => {
                 let mut table =
                     Table::new(vec![Column::key("name", "Name"), Column::key("id", "ID")]);
-                for wrapped in &listed.items {
-                    let actor = &wrapped.data;
+                for actor in &listed.items {
                     table.push_row(vec![actor.name.to_string(), actor.id.to_string()]);
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
-                Rendered::new(ActorResponse::Listed(listed), prompt, String::new())
+                Rendered::new(
+                    ActorResponse::Listed(ActorsResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/agent/client.rs
+++ b/crates/oneiros-engine/src/domains/agent/client.rs
@@ -13,25 +13,31 @@ impl<'a> AgentClient<'a> {
         self.client.post("/agents", creation).await
     }
 
-    pub async fn list(&self, request: &ListAgents) -> Result<AgentResponse, ClientError> {
+    pub async fn list(&self, listing: &ListAgents) -> Result<AgentResponse, ClientError> {
+        let ListAgents::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset
+            listing.filters.limit, listing.filters.offset
         );
         self.client.get(&format!("/agents?{query}")).await
     }
 
-    pub async fn get(&self, request: &GetAgent) -> Result<AgentResponse, ClientError> {
-        self.client.get(&format!("/agents/{}", request.key)).await
+    pub async fn get(&self, lookup: &GetAgent) -> Result<AgentResponse, ClientError> {
+        let GetAgent::V1(lookup) = lookup;
+        self.client.get(&format!("/agents/{}", lookup.key)).await
     }
 
-    pub async fn update(&self, changes: &UpdateAgent) -> Result<AgentResponse, ClientError> {
+    pub async fn update(&self, update: &UpdateAgent) -> Result<AgentResponse, ClientError> {
+        let UpdateAgent::V1(body) = update;
         self.client
-            .put(&format!("/agents/{name}", name = changes.name), changes)
+            .put(&format!("/agents/{name}", name = body.name), update)
             .await
     }
 
-    pub async fn remove(&self, name: &AgentName) -> Result<AgentResponse, ClientError> {
-        self.client.delete(&format!("/agents/{name}")).await
+    pub async fn remove(&self, removal: &RemoveAgent) -> Result<AgentResponse, ClientError> {
+        let RemoveAgent::V1(removal) = removal;
+        self.client
+            .delete(&format!("/agents/{}", removal.name))
+            .await
     }
 }

--- a/crates/oneiros-engine/src/domains/agent/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/agent/features/cli.rs
@@ -2,6 +2,11 @@ use clap::Subcommand;
 
 use crate::*;
 
+/// CLI subcommands for the agent domain. Each variant carries a versioned
+/// protocol request directly — clap derives parsing through the wrapper's
+/// `Args` impl, which delegates to the latest version's struct. The
+/// dispatcher passes the wrapper through to the client without rebuilding,
+/// since the operation type *is* the domain command.
 #[derive(Debug, Subcommand)]
 pub enum AgentCommands {
     Create(CreateAgent),
@@ -21,10 +26,10 @@ impl AgentCommands {
 
         let response = match self {
             Self::Create(creation) => agent_client.create(creation).await?,
-            Self::Show(get) => agent_client.get(get).await?,
+            Self::Show(lookup) => agent_client.get(lookup).await?,
             Self::List(listing) => agent_client.list(listing).await?,
             Self::Update(update) => agent_client.update(update).await?,
-            Self::Remove(removal) => agent_client.remove(&removal.name).await?,
+            Self::Remove(removal) => agent_client.remove(removal).await?,
         };
 
         Ok(AgentView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/agent/features/http.rs
+++ b/crates/oneiros-engine/src/domains/agent/features/http.rs
@@ -61,7 +61,7 @@ async fn show(
     Path(key): Path<ResourceKey<AgentName>>,
 ) -> Result<Json<AgentResponse>, AgentError> {
     Ok(Json(
-        AgentService::get(&context, &GetAgent::builder().key(key).build()).await?,
+        AgentService::get(&context, &GetAgent::builder_v1().key(key).build().into()).await?,
     ))
 }
 
@@ -78,6 +78,10 @@ async fn remove(
     Path(name): Path<AgentName>,
 ) -> Result<Json<AgentResponse>, AgentError> {
     Ok(Json(
-        AgentService::remove(&context, &RemoveAgent::builder().name(name).build()).await?,
+        AgentService::remove(
+            &context,
+            &RemoveAgent::builder_v1().name(name).build().into(),
+        )
+        .await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/agent/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/agent/features/mcp.rs
@@ -152,22 +152,26 @@ mod agent_mcp {
     ) -> Result<McpResponse, ToolError> {
         let agent = AgentService::get(
             context,
-            &GetAgent {
-                key: ResourceKey::Key(name.clone()),
-            },
+            &GetAgent::builder_v1()
+                .key(ResourceKey::Key(name.clone()))
+                .build()
+                .into(),
         )
         .await
         .map_err(Error::from)?;
 
         let agent_ref = match agent {
-            AgentResponse::AgentDetails(wrapped) => RefToken::from(Ref::agent(wrapped.data.id)),
+            AgentResponse::AgentDetails(AgentDetailsResponse::V1(details)) => {
+                RefToken::from(Ref::agent(details.agent.id))
+            }
             _ => return Err(ToolError::NotFound(format!("Agent not found: {name}"))),
         };
 
-        let listing = ListConnections {
-            entity: Some(agent_ref),
-            filters: SearchFilters::default(),
-        };
+        let listing: ListConnections = ListConnections::builder_v1()
+            .entity(agent_ref)
+            .filters(SearchFilters::default())
+            .build()
+            .into();
         let request = ConnectionRequest::ListConnections(listing.clone());
         ConnectionMcp.resource(context, &request).await
     }

--- a/crates/oneiros-engine/src/domains/agent/features/state.rs
+++ b/crates/oneiros-engine/src/domains/agent/features/state.rs
@@ -5,17 +5,13 @@ pub struct AgentState;
 impl AgentState {
     pub fn reduce(mut canon: BrainCanon, event: &Events) -> BrainCanon {
         if let Events::Agent(agent_event) = event {
-            match agent_event {
-                AgentEvents::AgentCreated(agent) => {
-                    canon.agents.set(agent);
-                }
-                AgentEvents::AgentUpdated(agent) => {
-                    canon.agents.set(agent);
-                }
-                AgentEvents::AgentRemoved(removed) => {
-                    canon.agents.remove_by_name(&removed.name);
-                }
+            if let Some(agent) = agent_event.maybe_agent() {
+                canon.agents.set(&agent);
             };
+
+            if let AgentEvents::AgentRemoved(AgentRemoved::V1(removal)) = agent_event {
+                canon.agents.remove_by_name(&removal.name);
+            }
         }
 
         canon
@@ -32,16 +28,17 @@ mod tests {
 
     #[test]
     fn creates_agent() {
-        let canon = BrainCanon::default();
         let agent = Agent::builder()
             .name("test.agent")
             .persona("process")
             .description("A test")
             .prompt("You are a test")
             .build();
-        let event = Events::Agent(AgentEvents::AgentCreated(agent.clone()));
+        let event = Events::Agent(AgentEvents::AgentCreated(
+            AgentCreated::builder_v1().agent(agent).build().into(),
+        ));
 
-        let next = AgentState::reduce(canon, &event);
+        let next = AgentState::reduce(BrainCanon::default(), &event);
 
         assert_eq!(next.agents.len(), 1);
     }
@@ -57,9 +54,11 @@ mod tests {
             .build();
         canon.agents.set(&agent);
 
-        let event = Events::Agent(AgentEvents::AgentRemoved(AgentRemoved {
-            name: agent.name.clone(),
-        }));
+        let event = Events::Agent(AgentEvents::AgentRemoved(AgentRemoved::V1(
+            AgentRemovedV1 {
+                name: agent.name.clone(),
+            },
+        )));
         let next = AgentState::reduce(canon, &event);
 
         assert_eq!(next.agents.len(), 0);

--- a/crates/oneiros-engine/src/domains/agent/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/agent/protocol/errors.rs
@@ -29,6 +29,9 @@ pub enum AgentError {
     Event(#[from] EventError),
 
     #[error(transparent)]
+    Upcast(#[from] UpcastError),
+
+    #[error(transparent)]
     Client(#[from] ClientError),
 }
 
@@ -42,7 +45,7 @@ impl IntoResponse for AgentError {
             AgentError::PersonaNotFound(_) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
             AgentError::Conflict(_) => (StatusCode::CONFLICT, self.to_string()),
             AgentError::Resolve(_) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
-            AgentError::Database(_) | AgentError::Event(_) => {
+            AgentError::Database(_) | AgentError::Event(_) | AgentError::Upcast(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
             }
             AgentError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),

--- a/crates/oneiros-engine/src/domains/agent/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/agent/protocol/events.rs
@@ -7,14 +7,70 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = AgentEventsType, display = "kebab-case")]
 pub enum AgentEvents {
-    AgentCreated(Agent),
-    AgentUpdated(Agent),
+    AgentCreated(AgentCreated),
+    AgentUpdated(AgentUpdated),
     AgentRemoved(AgentRemoved),
+}
+
+impl AgentEvents {
+    pub fn maybe_agent(&self) -> Option<Agent> {
+        match self {
+            AgentEvents::AgentCreated(event) => event.clone().current().ok().map(|v| v.agent),
+            AgentEvents::AgentUpdated(event) => event.clone().current().ok().map(|v| v.agent),
+            AgentEvents::AgentRemoved(_) => None,
+        }
+    }
+}
+
+versioned! {
+    pub enum AgentCreated {
+        V1 => {
+            #[serde(flatten)] pub agent: Agent,
+        },
+        V0 => {
+            #[builder(into)] pub name: AgentName,
+            #[builder(into)] pub persona: PersonaName,
+            #[builder(into)] pub description: Description,
+            #[builder(into)] pub prompt: Prompt,
+        }
+    }
+}
+
+upcast_versions! {
+    AgentCreatedV0 { name, persona, description, prompt } => AgentCreatedV1 {
+        agent: Agent::builder()
+            .name(name)
+            .persona(persona)
+            .description(description)
+            .prompt(prompt)
+            .build()
+    }
+}
+
+versioned! {
+    pub enum AgentUpdated {
+        V1 => { #[serde(flatten)] pub agent: Agent },
+    }
+}
+
+versioned! {
+    pub enum AgentRemoved {
+        V1 => { #[builder(into)] pub name: AgentName },
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_agent() -> Agent {
+        Agent::builder()
+            .name("test.process")
+            .persona("process")
+            .description("desc")
+            .prompt("prompt")
+            .build()
+    }
 
     #[test]
     fn event_types_are_kebab_cased() {
@@ -27,9 +83,78 @@ mod tests {
             assert_eq!(&event_type.to_string(), expectation);
         }
     }
-}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentRemoved {
-    pub name: AgentName,
+    #[test]
+    fn agent_created_wire_format_is_flat() {
+        // V1 embeds `Agent` with `#[serde(flatten)]`, so the wire shape stays
+        // at the model fields and never gains an `agent` envelope.
+        let event = AgentEvents::AgentCreated(AgentCreated::V1(AgentCreatedV1 {
+            agent: sample_agent(),
+        }));
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "agent-created");
+        assert!(
+            json["data"].get("agent").is_none(),
+            "flatten must elide the agent envelope on the wire"
+        );
+        assert_eq!(json["data"]["name"], "test.process");
+        assert_eq!(json["data"]["persona"], "process");
+        assert!(json["data"].get("id").is_some());
+        assert!(
+            json["data"].get("V1").is_none(),
+            "V1 layer must not appear on the wire"
+        );
+    }
+
+    #[test]
+    fn agent_removed_round_trips_through_v1_layer() {
+        let original = AgentEvents::AgentRemoved(AgentRemoved::V1(AgentRemovedV1 {
+            name: AgentName::new("test.process"),
+        }));
+
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: AgentEvents = serde_json::from_str(&json).unwrap();
+
+        match decoded {
+            AgentEvents::AgentRemoved(removed) => {
+                let v1 = removed.current().unwrap();
+                assert_eq!(v1.name.to_string(), "test.process");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn deserialize_accepts_pre_version_wire_shape() {
+        // Old (pre-versioning) wire shape was just the bare struct fields.
+        // Untagged V1 must accept this byte-identical shape.
+        let pre_version_json = serde_json::json!({
+            "type": "agent-removed",
+            "data": { "name": "test.process" }
+        });
+
+        let event: AgentEvents = serde_json::from_value(pre_version_json).unwrap();
+        match event {
+            AgentEvents::AgentRemoved(AgentRemoved::V1(v)) => {
+                assert_eq!(v.name.to_string(), "test.process");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn agent_created_v0_upcasts_to_v1_via_agent() {
+        // The V0 → V1 upcast constructs an `Agent` inline using the legacy
+        // V0 fields and a fresh `id`.
+        let v0 = AgentCreatedV0 {
+            name: AgentName::new("legacy.process"),
+            persona: PersonaName::new("process"),
+            description: Description::new("legacy"),
+            prompt: Prompt::new(""),
+        };
+        let v1: AgentCreatedV1 = v0.into();
+        assert_eq!(v1.agent.name.to_string(), "legacy.process");
+        assert_eq!(v1.agent.persona.to_string(), "process");
+    }
 }

--- a/crates/oneiros-engine/src/domains/agent/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/agent/protocol/requests.rs
@@ -1,57 +1,74 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct CreateAgent {
-    #[builder(into)]
-    pub name: AgentName,
-    #[builder(into)]
-    pub persona: PersonaName,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub description: Description,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub prompt: Prompt,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum CreateAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: AgentName,
+            #[builder(into)] pub persona: PersonaName,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub description: Description,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub prompt: Prompt,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetAgent {
-    #[builder(into)]
-    pub key: ResourceKey<AgentName>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<AgentName>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Default, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListAgents {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListAgents {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct RemoveAgent {
-    #[builder(into)]
-    pub name: AgentName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum UpdateAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: AgentName,
+            #[builder(into)] pub persona: PersonaName,
+            #[arg(long, default_value = "")]
+            #[builder(into)]
+            pub description: Description,
+            #[arg(long, default_value = "")]
+            #[builder(into)]
+            pub prompt: Prompt,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct UpdateAgent {
-    #[builder(into)]
-    pub name: AgentName,
-    #[builder(into)]
-    pub persona: PersonaName,
-    #[arg(long, default_value = "")]
-    #[builder(into)]
-    pub description: Description,
-    #[arg(long, default_value = "")]
-    #[builder(into)]
-    pub prompt: Prompt,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum RemoveAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: AgentName,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]
@@ -82,5 +99,23 @@ mod tests {
         for (request_type, expectation) in cases {
             assert_eq!(&request_type.to_string(), expectation)
         }
+    }
+
+    #[test]
+    fn create_agent_wire_format_is_unwrapped() {
+        let request = CreateAgent::V1(CreateAgentV1 {
+            name: AgentName::new("test.process"),
+            persona: PersonaName::new("process"),
+            description: Description::new("desc"),
+            prompt: Prompt::new("prompt"),
+        });
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["name"], "test.process");
+        assert_eq!(json["persona"], "process");
+        assert!(
+            json.get("V1").is_none(),
+            "V1 layer must not appear on the wire"
+        );
     }
 }

--- a/crates/oneiros-engine/src/domains/agent/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/agent/protocol/responses.rs
@@ -8,10 +8,45 @@ use crate::*;
 #[kinded(kind = AgentResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum AgentResponse {
-    AgentCreated(AgentName),
-    AgentDetails(Response<Agent>),
-    Agents(Listed<Response<Agent>>),
+    AgentCreated(AgentCreatedResponse),
+    AgentDetails(AgentDetailsResponse),
+    Agents(AgentsResponse),
     NoAgents,
-    AgentUpdated(AgentName),
-    AgentRemoved(AgentName),
+    AgentUpdated(AgentUpdatedResponse),
+    AgentRemoved(AgentRemovedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum AgentCreatedResponse {
+        V1 => { #[serde(flatten)] pub agent: Agent }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum AgentDetailsResponse {
+        V1 => { #[serde(flatten)] pub agent: Agent }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum AgentsResponse {
+        V1 => { pub items: Vec<Agent>, pub total: usize }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum AgentUpdatedResponse {
+        V1 => { #[serde(flatten)] pub agent: Agent }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum AgentRemovedResponse {
+        V1 => { #[builder(into)] pub name: AgentName }
+    }
 }

--- a/crates/oneiros-engine/src/domains/agent/service.rs
+++ b/crates/oneiros-engine/src/domains/agent/service.rs
@@ -5,21 +5,21 @@ pub struct AgentService;
 impl AgentService {
     pub async fn create(
         context: &ProjectContext,
-        CreateAgent {
-            name,
-            persona,
-            description,
-            prompt,
-        }: &CreateAgent,
+        request: &CreateAgent,
     ) -> Result<AgentResponse, AgentError> {
+        let CreateAgent::V1(create) = request;
+
         // Cross-resource validation: persona must exist
-        //
-        if PersonaRepo::new(context).get(persona).await?.is_none() {
-            return Err(AgentError::PersonaNotFound(persona.clone()));
+        if PersonaRepo::new(context)
+            .get(&create.persona)
+            .await?
+            .is_none()
+        {
+            return Err(AgentError::PersonaNotFound(create.persona.clone()));
         }
 
         // Normalize name: append .persona if not already present
-        let normalized_name = name.normalize_with(persona);
+        let normalized_name = create.name.normalize_with(&create.persona);
 
         // Validate name uniqueness
         if AgentRepo::new(context)
@@ -30,23 +30,36 @@ impl AgentService {
         }
 
         let agent = Agent::builder()
-            .name(normalized_name.clone())
-            .persona(persona.clone())
-            .description(description.clone())
-            .prompt(prompt.clone())
+            .name(normalized_name)
+            .persona(create.persona.clone())
+            .description(create.description.clone())
+            .prompt(create.prompt.clone())
             .build();
 
-        context.emit(AgentEvents::AgentCreated(agent)).await?;
+        context
+            .emit(AgentEvents::AgentCreated(
+                AgentCreated::builder_v1()
+                    .agent(agent.clone())
+                    .build()
+                    .into(),
+            ))
+            .await?;
 
-        Ok(AgentResponse::AgentCreated(normalized_name))
+        Ok(AgentResponse::AgentCreated(
+            AgentCreatedResponse::builder_v1()
+                .agent(agent)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn get(
         context: &ProjectContext,
-        selector: &GetAgent,
+        request: &GetAgent,
     ) -> Result<AgentResponse, AgentError> {
+        let GetAgent::V1(lookup) = request;
         let repo = AgentRepo::new(context);
-        let agent = match &selector.key {
+        let agent = match &lookup.key {
             ResourceKey::Key(name) => repo
                 .get(name)
                 .await?
@@ -67,71 +80,94 @@ impl AgentService {
                 }
             }
         };
-        let ref_token = RefToken::new(Ref::agent(agent.id));
         Ok(AgentResponse::AgentDetails(
-            Response::new(agent).with_ref_token(ref_token),
+            AgentDetailsResponse::builder_v1()
+                .agent(agent)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn list(
         context: &ProjectContext,
-        ListAgents { filters }: &ListAgents,
+        request: &ListAgents,
     ) -> Result<AgentResponse, AgentError> {
-        let listed = AgentRepo::new(context).list(filters).await?;
+        let ListAgents::V1(listing) = request;
+        let listed = AgentRepo::new(context).list(&listing.filters).await?;
 
         if listed.total == 0 {
             Ok(AgentResponse::NoAgents)
         } else {
-            Ok(AgentResponse::Agents(listed.map(|e| {
-                let ref_token = RefToken::new(Ref::agent(e.id));
-                Response::new(e).with_ref_token(ref_token)
-            })))
+            Ok(AgentResponse::Agents(
+                AgentsResponse::builder_v1()
+                    .items(listed.items)
+                    .total(listed.total)
+                    .build()
+                    .into(),
+            ))
         }
     }
 
     pub async fn update(
         context: &ProjectContext,
-        UpdateAgent {
-            name,
-            persona,
-            description,
-            prompt,
-        }: &UpdateAgent,
+        request: &UpdateAgent,
     ) -> Result<AgentResponse, AgentError> {
+        let UpdateAgent::V1(update) = request;
         let existing = AgentRepo::new(context)
-            .get(name)
+            .get(&update.name)
             .await?
-            .ok_or_else(|| AgentError::NotFound(name.clone()))?;
+            .ok_or_else(|| AgentError::NotFound(update.name.clone()))?;
 
         let agent = Agent::builder()
             .id(existing.id)
-            .name(name.clone())
-            .persona(persona.clone())
-            .description(description.clone())
-            .prompt(prompt.clone())
+            .name(update.name.clone())
+            .persona(update.persona.clone())
+            .description(update.description.clone())
+            .prompt(update.prompt.clone())
             .build();
 
-        context.emit(AgentEvents::AgentUpdated(agent)).await?;
+        context
+            .emit(AgentEvents::AgentUpdated(
+                AgentUpdated::builder_v1()
+                    .agent(agent.clone())
+                    .build()
+                    .into(),
+            ))
+            .await?;
 
-        Ok(AgentResponse::AgentUpdated(name.clone()))
+        Ok(AgentResponse::AgentUpdated(
+            AgentUpdatedResponse::builder_v1()
+                .agent(agent)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn remove(
         context: &ProjectContext,
-        selector: &RemoveAgent,
+        request: &RemoveAgent,
     ) -> Result<AgentResponse, AgentError> {
-        let exists = AgentRepo::new(context).name_exists(&selector.name).await?;
+        let RemoveAgent::V1(removal) = request;
+        let exists = AgentRepo::new(context).name_exists(&removal.name).await?;
 
         if !exists {
-            return Err(AgentError::NotFound(selector.name.clone()));
+            return Err(AgentError::NotFound(removal.name.clone()));
         }
 
         context
-            .emit(AgentEvents::AgentRemoved(AgentRemoved {
-                name: selector.name.clone(),
-            }))
+            .emit(AgentEvents::AgentRemoved(
+                AgentRemoved::builder_v1()
+                    .name(removal.name.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
 
-        Ok(AgentResponse::AgentRemoved(selector.name.clone()))
+        Ok(AgentResponse::AgentRemoved(
+            AgentRemovedResponse::builder_v1()
+                .name(removal.name.clone())
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/agent/store.rs
+++ b/crates/oneiros-engine/src/domains/agent/store.rs
@@ -15,11 +15,12 @@ impl<'a> AgentStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Agent(agent_event)) = &event.data {
             match agent_event {
-                AgentEvents::AgentCreated(agent) => self.create_record(agent)?,
-                AgentEvents::AgentUpdated(agent) => self.update(agent)?,
-                AgentEvents::AgentRemoved(removed) => self.remove(&removed.name)?,
+                AgentEvents::AgentCreated(agent_created) => self.create(agent_created)?,
+                AgentEvents::AgentUpdated(agent_updated) => self.update(agent_updated)?,
+                AgentEvents::AgentRemoved(agent_removed) => self.remove(agent_removed)?,
             }
         }
+
         Ok(())
     }
 
@@ -30,12 +31,12 @@ impl<'a> AgentStore<'a> {
 
     pub fn migrate(&self) -> Result<(), EventError> {
         self.conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS agents (
-                id TEXT PRIMARY KEY,
-                name TEXT NOT NULL UNIQUE,
-                persona TEXT NOT NULL DEFAULT '',
-                description TEXT NOT NULL DEFAULT '',
-                prompt TEXT NOT NULL DEFAULT ''
+            "create table if not exists agents (
+                id          text primary key,
+                name        text not null unique,
+                persona     text not null default '',
+                description text not null default '',
+                prompt      text not null default ''
             )",
         )?;
         Ok(())
@@ -131,40 +132,36 @@ impl<'a> AgentStore<'a> {
         Ok(count > 0)
     }
 
-    fn create_record(&self, agent: &Agent) -> Result<(), EventError> {
-        self.conn.execute(
-            "insert or replace into agents (id, name, persona, description, prompt)
-             values (?1, ?2, ?3, ?4, ?5)",
-            params![
-                agent.id.to_string(),
-                agent.name.to_string(),
-                agent.persona.to_string(),
-                agent.description.to_string(),
-                agent.prompt.to_string()
-            ],
-        )?;
-        Ok(())
+    fn create(&self, creation: &AgentCreated) -> Result<(), EventError> {
+        let agent = creation.current()?.agent;
+        self.write_agent(&agent)
     }
 
-    fn update(&self, agent: &Agent) -> Result<(), EventError> {
-        self.conn.execute(
-            "insert or replace into agents (id, name, persona, description, prompt)
-             values (?1, ?2, ?3, ?4, ?5)",
-            params![
-                agent.id.to_string(),
-                agent.name.to_string(),
-                agent.persona.to_string(),
-                agent.description.to_string(),
-                agent.prompt.to_string()
-            ],
-        )?;
-        Ok(())
+    fn update(&self, update: &AgentUpdated) -> Result<(), EventError> {
+        let agent = update.current()?.agent;
+        self.write_agent(&agent)
     }
 
-    fn remove(&self, name: &AgentName) -> Result<(), EventError> {
+    fn remove(&self, removal: &AgentRemoved) -> Result<(), EventError> {
+        let name = removal.current()?.name;
         self.conn.execute(
             "delete from agents where name = ?1",
             params![name.to_string()],
+        )?;
+        Ok(())
+    }
+
+    fn write_agent(&self, agent: &Agent) -> Result<(), EventError> {
+        self.conn.execute(
+            "insert or replace into agents (id, name, persona, description, prompt)
+             values (?1, ?2, ?3, ?4, ?5)",
+            params![
+                agent.id.to_string(),
+                agent.name.to_string(),
+                agent.persona.to_string(),
+                agent.description.to_string(),
+                agent.prompt.to_string()
+            ],
         )?;
         Ok(())
     }

--- a/crates/oneiros-engine/src/domains/agent/view.rs
+++ b/crates/oneiros-engine/src/domains/agent/view.rs
@@ -17,33 +17,43 @@ impl AgentView {
     pub fn mcp(&self) -> McpResponse {
         let response = &self.response;
         match response {
-            AgentResponse::AgentCreated(name) => McpResponse::new(format!("Agent created: {name}"))
-                .hint_set(HintSet::agent_created(
-                    AgentCreatedHints::builder().agent(name.clone()).build(),
-                )),
-            AgentResponse::AgentDetails(wrapped) => McpResponse::new(format!(
-                "# {}\n\n**persona:** {}\n**description:** {}\n\n{}\n",
-                wrapped.data.name,
-                wrapped.data.persona,
-                wrapped.data.description,
-                wrapped.data.prompt
-            ))
-            .hint(Hint::inspect(
-                ResourcePath::AgentCognitions(wrapped.data.name.clone()).uri(),
-                "Browse cognitions",
-            ))
-            .hint(Hint::inspect(
-                ResourcePath::AgentPressure(wrapped.data.name.clone()).uri(),
-                "Check pressure",
-            )),
-            AgentResponse::Agents(listed) => {
-                let mut md = format!("# Agents\n\n{} of {} total\n\n", listed.len(), listed.total);
+            AgentResponse::AgentCreated(AgentCreatedResponse::V1(created)) => {
+                let agent = &created.agent;
+                McpResponse::new(format!("Agent created: {}", agent.name)).hint_set(
+                    HintSet::agent_created(
+                        AgentCreatedHints::builder()
+                            .agent(agent.name.clone())
+                            .build(),
+                    ),
+                )
+            }
+            AgentResponse::AgentDetails(AgentDetailsResponse::V1(details)) => {
+                let agent = &details.agent;
+                McpResponse::new(format!(
+                    "# {}\n\n**persona:** {}\n**description:** {}\n\n{}\n",
+                    agent.name, agent.persona, agent.description, agent.prompt
+                ))
+                .hint(Hint::inspect(
+                    ResourcePath::AgentCognitions(agent.name.clone()).uri(),
+                    "Browse cognitions",
+                ))
+                .hint(Hint::inspect(
+                    ResourcePath::AgentPressure(agent.name.clone()).uri(),
+                    "Check pressure",
+                ))
+            }
+            AgentResponse::Agents(AgentsResponse::V1(agents)) => {
+                let mut md = format!(
+                    "# Agents\n\n{} of {} total\n\n",
+                    agents.items.len(),
+                    agents.total
+                );
                 md.push_str("| Name | Persona | Description |\n");
                 md.push_str("|------|---------|-------------|\n");
-                for wrapped in &listed.items {
+                for agent in &agents.items {
                     md.push_str(&format!(
                         "| {} | {} | {} |\n",
-                        wrapped.data.name, wrapped.data.persona, wrapped.data.description
+                        agent.name, agent.persona, agent.description
                     ));
                 }
                 McpResponse::new(md).hint(Hint::suggest(
@@ -54,46 +64,58 @@ impl AgentView {
             AgentResponse::NoAgents => McpResponse::new("# Agents\n\nNo agents configured.").hint(
                 Hint::suggest("create-agent", "Bring a new agent into the brain"),
             ),
-            AgentResponse::AgentUpdated(name) => McpResponse::new(format!("Agent updated: {name}"))
-                .hint(Hint::inspect(
-                    ResourcePath::Agent(name.clone()).uri(),
+            AgentResponse::AgentUpdated(AgentUpdatedResponse::V1(updated)) => {
+                let agent = &updated.agent;
+                McpResponse::new(format!("Agent updated: {}", agent.name)).hint(Hint::inspect(
+                    ResourcePath::Agent(agent.name.clone()).uri(),
                     "View agent details",
-                )),
-            AgentResponse::AgentRemoved(name) => McpResponse::new(format!("Agent removed: {name}"))
-                .hint(Hint::inspect(
+                ))
+            }
+            AgentResponse::AgentRemoved(AgentRemovedResponse::V1(removed)) => {
+                McpResponse::new(format!("Agent removed: {}", removed.name)).hint(Hint::inspect(
                     ResourcePath::Agents.uri(),
                     "See remaining agents",
-                )),
+                ))
+            }
         }
     }
 
     pub fn render(self) -> Rendered<AgentResponse> {
         match self.response {
-            AgentResponse::AgentCreated(name) => {
-                let prompt = Confirmation::new("Agent", name.to_string(), "created").to_string();
-                let hints = HintSet::agent_created(
-                    AgentCreatedHints::builder().agent(name.clone()).build(),
-                );
-                Rendered::new(AgentResponse::AgentCreated(name), prompt, String::new())
-                    .with_hints(hints)
-            }
-            AgentResponse::AgentDetails(wrapped) => {
-                let agent = &wrapped.data;
-                let prompt = Detail::new(agent.name.to_string())
-                    .field("persona:", agent.persona.to_string())
-                    .field("description:", agent.description.to_string())
-                    .field("prompt:", agent.prompt.to_string())
+            AgentResponse::AgentCreated(AgentCreatedResponse::V1(created)) => {
+                let prompt = Confirmation::new("Agent", created.agent.name.to_string(), "created")
                     .to_string();
-                Rendered::new(AgentResponse::AgentDetails(wrapped), prompt, String::new())
+                let hints = HintSet::agent_created(
+                    AgentCreatedHints::builder()
+                        .agent(created.agent.name.clone())
+                        .build(),
+                );
+                Rendered::new(
+                    AgentResponse::AgentCreated(AgentCreatedResponse::V1(created)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
-            AgentResponse::Agents(listed) => {
+            AgentResponse::AgentDetails(AgentDetailsResponse::V1(details)) => {
+                let prompt = Detail::new(details.agent.name.to_string())
+                    .field("persona:", details.agent.persona.to_string())
+                    .field("description:", details.agent.description.to_string())
+                    .field("prompt:", details.agent.prompt.to_string())
+                    .to_string();
+                Rendered::new(
+                    AgentResponse::AgentDetails(AgentDetailsResponse::V1(details)),
+                    prompt,
+                    String::new(),
+                )
+            }
+            AgentResponse::Agents(AgentsResponse::V1(agents)) => {
                 let mut table = Table::new(vec![
                     Column::key("name", "Name"),
                     Column::key("persona", "Persona"),
                     Column::key("description", "Description").max(60),
                 ]);
-                for wrapped in &listed.items {
-                    let agent = &wrapped.data;
+                for agent in &agents.items {
                     table.push_row(vec![
                         agent.name.to_string(),
                         agent.persona.to_string(),
@@ -102,22 +124,36 @@ impl AgentView {
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", agents.items.len(), agents.total).muted(),
                 );
-                Rendered::new(AgentResponse::Agents(listed), prompt, String::new())
+                Rendered::new(
+                    AgentResponse::Agents(AgentsResponse::V1(agents)),
+                    prompt,
+                    String::new(),
+                )
             }
             AgentResponse::NoAgents => Rendered::new(
                 AgentResponse::NoAgents,
                 format!("{}", "No agents configured.".muted()),
                 String::new(),
             ),
-            AgentResponse::AgentUpdated(name) => {
-                let prompt = Confirmation::new("Agent", name.to_string(), "updated").to_string();
-                Rendered::new(AgentResponse::AgentUpdated(name), prompt, String::new())
+            AgentResponse::AgentUpdated(AgentUpdatedResponse::V1(updated)) => {
+                let prompt = Confirmation::new("Agent", updated.agent.name.to_string(), "updated")
+                    .to_string();
+                Rendered::new(
+                    AgentResponse::AgentUpdated(AgentUpdatedResponse::V1(updated)),
+                    prompt,
+                    String::new(),
+                )
             }
-            AgentResponse::AgentRemoved(name) => {
-                let prompt = Confirmation::new("Agent", name.to_string(), "removed").to_string();
-                Rendered::new(AgentResponse::AgentRemoved(name), prompt, String::new())
+            AgentResponse::AgentRemoved(AgentRemovedResponse::V1(removed)) => {
+                let prompt =
+                    Confirmation::new("Agent", removed.name.to_string(), "removed").to_string();
+                Rendered::new(
+                    AgentResponse::AgentRemoved(AgentRemovedResponse::V1(removed)),
+                    prompt,
+                    String::new(),
+                )
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/bookmark/client.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/client.rs
@@ -9,45 +9,46 @@ impl<'a> BookmarkClient<'a> {
         Self { client }
     }
 
-    pub async fn create(&self, request: &CreateBookmark) -> Result<BookmarkResponse, ClientError> {
-        self.client.post("/bookmarks", request).await
+    pub async fn create(&self, creation: &CreateBookmark) -> Result<BookmarkResponse, ClientError> {
+        self.client.post("/bookmarks", creation).await
     }
 
-    pub async fn switch(&self, request: &SwitchBookmark) -> Result<BookmarkResponse, ClientError> {
-        self.client.post("/bookmarks/switch", request).await
+    pub async fn switch(&self, switch: &SwitchBookmark) -> Result<BookmarkResponse, ClientError> {
+        self.client.post("/bookmarks/switch", switch).await
     }
 
-    pub async fn merge(&self, request: &MergeBookmark) -> Result<BookmarkResponse, ClientError> {
-        self.client.post("/bookmarks/merge", request).await
+    pub async fn merge(&self, merge: &MergeBookmark) -> Result<BookmarkResponse, ClientError> {
+        self.client.post("/bookmarks/merge", merge).await
     }
 
-    pub async fn list(&self, request: &ListBookmarks) -> Result<BookmarkResponse, ClientError> {
+    pub async fn list(&self, listing: &ListBookmarks) -> Result<BookmarkResponse, ClientError> {
+        let ListBookmarks::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset,
+            listing.filters.limit, listing.filters.offset,
         );
         self.client.get(&format!("/bookmarks?{query}")).await
     }
 
-    pub async fn share(&self, request: &ShareBookmark) -> Result<BookmarkResponse, ClientError> {
-        self.client.post("/bookmarks/share", request).await
+    pub async fn share(&self, share: &ShareBookmark) -> Result<BookmarkResponse, ClientError> {
+        self.client.post("/bookmarks/share", share).await
     }
 
-    pub async fn follow(&self, request: &FollowBookmark) -> Result<BookmarkResponse, ClientError> {
-        self.client.post("/bookmarks/follow", request).await
+    pub async fn follow(&self, follow: &FollowBookmark) -> Result<BookmarkResponse, ClientError> {
+        self.client.post("/bookmarks/follow", follow).await
     }
 
     pub async fn collect(
         &self,
-        request: &CollectBookmark,
+        collect: &CollectBookmark,
     ) -> Result<BookmarkResponse, ClientError> {
-        self.client.post("/bookmarks/collect", request).await
+        self.client.post("/bookmarks/collect", collect).await
     }
 
     pub async fn unfollow(
         &self,
-        request: &UnfollowBookmark,
+        unfollow: &UnfollowBookmark,
     ) -> Result<BookmarkResponse, ClientError> {
-        self.client.post("/bookmarks/unfollow", request).await
+        self.client.post("/bookmarks/unfollow", unfollow).await
     }
 }

--- a/crates/oneiros-engine/src/domains/bookmark/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/features/cli.rs
@@ -23,14 +23,14 @@ impl BookmarkCommands {
         let bookmark_client = BookmarkClient::new(&client);
 
         let response = match self {
-            BookmarkCommands::Create(create) => bookmark_client.create(create).await?,
-            BookmarkCommands::Switch(switch) => bookmark_client.switch(switch).await?,
-            BookmarkCommands::Merge(merge) => bookmark_client.merge(merge).await?,
-            BookmarkCommands::List(list) => bookmark_client.list(list).await?,
-            BookmarkCommands::Share(share) => bookmark_client.share(share).await?,
-            BookmarkCommands::Follow(follow) => bookmark_client.follow(follow).await?,
-            BookmarkCommands::Collect(collect) => bookmark_client.collect(collect).await?,
-            BookmarkCommands::Unfollow(unfollow) => bookmark_client.unfollow(unfollow).await?,
+            Self::Create(creation) => bookmark_client.create(creation).await?,
+            Self::Switch(switch) => bookmark_client.switch(switch).await?,
+            Self::Merge(merge) => bookmark_client.merge(merge).await?,
+            Self::List(listing) => bookmark_client.list(listing).await?,
+            Self::Share(share) => bookmark_client.share(share).await?,
+            Self::Follow(follow) => bookmark_client.follow(follow).await?,
+            Self::Collect(collect) => bookmark_client.collect(collect).await?,
+            Self::Unfollow(unfollow) => bookmark_client.unfollow(unfollow).await?,
         };
 
         Ok(BookmarkView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/bookmark/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/features/mcp.rs
@@ -80,7 +80,8 @@ mod bookmark_mcp {
 
         let value = match request_type {
             BookmarkRequestType::ListBookmarks => {
-                let request: ListBookmarks = serde_json::from_str(params).unwrap_or_default();
+                let request: ListBookmarks = serde_json::from_str(params)
+                    .unwrap_or_else(|_| ListBookmarks::builder_v1().build().into());
                 BookmarkService::list(state, brain, &request)
                     .await
                     .map_err(Error::from)?

--- a/crates/oneiros-engine/src/domains/bookmark/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/protocol/events.rs
@@ -13,19 +13,126 @@ pub enum BookmarkEvents {
     BookmarkMerged(BookmarkMerged),
     /// Distribution — a bookmark was shared, minting a ticket for it.
     BookmarkShared(BookmarkShared),
-    /// Distribution — a local bookmark begins following a source (local
-    /// ref or peer link). Carries the full Follow record.
-    BookmarkFollowed(Follow),
+    /// Distribution — a local bookmark begins following a source.
+    BookmarkFollowed(BookmarkFollowed),
     /// Distribution — a follow advanced its checkpoint after a collect.
     BookmarkCollected(BookmarkCollected),
-    /// Distribution — a follow was removed. Its last-collected events
-    /// remain in the local bookmark; only the remote binding is severed.
+    /// Distribution — a follow was removed.
     BookmarkUnfollowed(BookmarkUnfollowed),
+}
+
+impl BookmarkEvents {
+    /// The full `Bookmark` carried by creation-style events. `Forked`
+    /// also carries one (the new fork) — its `from` is a reference, not
+    /// a full record.
+    pub fn maybe_bookmark(&self) -> Option<Bookmark> {
+        match self {
+            BookmarkEvents::BookmarkCreated(event) => {
+                event.clone().current().ok().map(|v| v.bookmark)
+            }
+            BookmarkEvents::BookmarkForked(event) => {
+                event.clone().current().ok().map(|v| v.bookmark)
+            }
+            BookmarkEvents::BookmarkSwitched(_)
+            | BookmarkEvents::BookmarkMerged(_)
+            | BookmarkEvents::BookmarkShared(_)
+            | BookmarkEvents::BookmarkFollowed(_)
+            | BookmarkEvents::BookmarkCollected(_)
+            | BookmarkEvents::BookmarkUnfollowed(_) => None,
+        }
+    }
+}
+
+versioned! {
+    pub enum BookmarkCreated {
+        V1 => {
+            #[serde(flatten)] pub bookmark: Bookmark,
+        }
+    }
+}
+
+versioned! {
+    pub enum BookmarkForked {
+        V1 => {
+            #[serde(flatten)] pub bookmark: Bookmark,
+            pub from: BookmarkName,
+        }
+    }
+}
+
+versioned! {
+    pub enum BookmarkSwitched {
+        V1 => {
+            pub brain: BrainName,
+            pub name: BookmarkName,
+        }
+    }
+}
+
+versioned! {
+    pub enum BookmarkMerged {
+        V1 => {
+            pub brain: BrainName,
+            pub source: BookmarkName,
+            pub target: BookmarkName,
+        }
+    }
+}
+
+versioned! {
+    pub enum BookmarkShared {
+        V1 => {
+            pub brain: BrainName,
+            pub bookmark: BookmarkName,
+            pub ticket_id: TicketId,
+            pub shared_by: ActorId,
+        }
+    }
+}
+
+versioned! {
+    pub enum BookmarkFollowed {
+        V1 => {
+            #[builder(default)] pub id: FollowId,
+            pub brain: BrainName,
+            pub bookmark: BookmarkName,
+            pub source: FollowSource,
+            #[builder(default = Checkpoint::empty())] pub checkpoint: Checkpoint,
+            #[builder(default = Timestamp::now())] pub created_at: Timestamp,
+        }
+    }
+}
+
+versioned! {
+    pub enum BookmarkCollected {
+        V1 => {
+            pub follow_id: FollowId,
+            pub checkpoint: Checkpoint,
+            pub events_received: u64,
+        }
+    }
+}
+
+versioned! {
+    pub enum BookmarkUnfollowed {
+        V1 => {
+            pub follow_id: FollowId,
+            pub brain: BrainName,
+            pub bookmark: BookmarkName,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_bookmark() -> Bookmark {
+        Bookmark::builder()
+            .brain(BrainName::new("test-brain"))
+            .name(BookmarkName::new("main"))
+            .build()
+    }
 
     #[test]
     fn event_types_are_kebab_cased() {
@@ -46,65 +153,41 @@ mod tests {
             assert_eq!(&event_type.to_string(), expectation);
         }
     }
-}
 
-/// Genesis — a bookmark comes into existence (e.g. "main" at brain init).
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct BookmarkCreated {
-    pub brain: BrainName,
-    pub name: BookmarkName,
-}
+    #[test]
+    fn bookmark_created_wire_format_is_flat() {
+        let bookmark = sample_bookmark();
+        let event = BookmarkEvents::BookmarkCreated(BookmarkCreated::V1(BookmarkCreatedV1 {
+            bookmark: bookmark.clone(),
+        }));
+        let json = serde_json::to_value(&event).unwrap();
 
-/// Derivation — a new bookmark forked from an existing one.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct BookmarkForked {
-    pub brain: BrainName,
-    pub name: BookmarkName,
-    pub from: BookmarkName,
-}
+        assert_eq!(json["type"], "bookmark-created");
+        assert!(
+            json["data"].get("bookmark").is_none(),
+            "flatten must elide the bookmark envelope on the wire"
+        );
+        assert_eq!(json["data"]["id"], bookmark.id.to_string());
+        assert_eq!(json["data"]["name"], "main");
+        assert_eq!(json["data"]["brain"], "test-brain");
+        assert!(json["data"].get("created_at").is_some());
+    }
 
-/// Navigation — the active bookmark changed.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct BookmarkSwitched {
-    pub brain: BrainName,
-    pub name: BookmarkName,
-}
+    #[test]
+    fn bookmark_forked_wire_format_is_flat() {
+        let bookmark = sample_bookmark();
+        let event = BookmarkEvents::BookmarkForked(BookmarkForked::V1(BookmarkForkedV1 {
+            bookmark: bookmark.clone(),
+            from: BookmarkName::new("main"),
+        }));
+        let json = serde_json::to_value(&event).unwrap();
 
-/// Convergence — one bookmark's changes merged into another.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct BookmarkMerged {
-    pub brain: BrainName,
-    pub source: BookmarkName,
-    pub target: BookmarkName,
-}
-
-/// Distribution — a bookmark was shared. Records the ticket that was
-/// minted and the actor who shared it. Does not carry the composed URI
-/// because that's derivable from the ticket + current host identity and
-/// shouldn't be frozen in the event log.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BookmarkShared {
-    pub brain: BrainName,
-    pub bookmark: BookmarkName,
-    pub ticket_id: TicketId,
-    pub shared_by: ActorId,
-}
-
-/// Distribution — a follow advanced its checkpoint after a collect
-/// operation. The checkpoint is the new position after applying the
-/// received events.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BookmarkCollected {
-    pub follow_id: FollowId,
-    pub checkpoint: Checkpoint,
-    pub events_received: u64,
-}
-
-/// Distribution — a follow was removed. Only the remote binding is
-/// severed; events already collected into the local bookmark stay.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct BookmarkUnfollowed {
-    pub follow_id: FollowId,
-    pub brain: BrainName,
-    pub bookmark: BookmarkName,
+        assert_eq!(json["type"], "bookmark-forked");
+        assert!(
+            json["data"].get("bookmark").is_none(),
+            "flatten must elide the bookmark envelope on the wire"
+        );
+        assert_eq!(json["data"]["id"], bookmark.id.to_string());
+        assert_eq!(json["data"]["from"], "main");
+    }
 }

--- a/crates/oneiros-engine/src/domains/bookmark/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/protocol/requests.rs
@@ -1,82 +1,95 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct CreateBookmark {
-    #[builder(into)]
-    pub name: BookmarkName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum CreateBookmark {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: BookmarkName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct SwitchBookmark {
-    #[builder(into)]
-    pub name: BookmarkName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SwitchBookmark {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: BookmarkName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct MergeBookmark {
-    /// The source bookmark to merge into the active bookmark.
-    #[builder(into)]
-    pub source: BookmarkName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum MergeBookmark {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub source: BookmarkName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Default, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListBookmarks {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListBookmarks {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
-/// Mint a distribution ticket for a bookmark and return a shareable
-/// `oneiros://` URI. The ticket is self-contained — anyone holding the URI
-/// can present the embedded token to reach the bookmark via this host's
-/// iroh endpoint.
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ShareBookmark {
-    /// The bookmark to share.
-    #[builder(into)]
-    pub name: BookmarkName,
-    /// The actor issuing the share. When omitted, the service picks the
-    /// first actor in the host's tenant (matching the project-init
-    /// convention). This keeps the common case a single-arg command.
-    #[arg(long)]
-    pub actor_id: Option<ActorId>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ShareBookmark {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: BookmarkName,
+            #[arg(long)]
+            pub actor_id: Option<ActorId>,
+        }
+    }
 }
 
-/// Follow a bookmark via a URI. For `ref:` URIs the source is local;
-/// for `oneiros://` URIs the source is a peer. The URI's token (for the
-/// peer case) is presented during collect to authorize event transfer.
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct FollowBookmark {
-    /// The URI to follow. Must be either a `ref:` or `oneiros://` form.
-    pub uri: String,
-    /// Local name for the new bookmark that will mirror the remote.
-    #[builder(into)]
-    #[arg(long)]
-    pub name: BookmarkName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum FollowBookmark {
+        #[derive(clap::Args)]
+        V1 => {
+            pub uri: String,
+            #[arg(long)]
+            #[builder(into)]
+            pub name: BookmarkName,
+        }
+    }
 }
 
-/// Collect events from a followed bookmark's source. For Local follows
-/// this reads from the local CanonIndex. For Peer follows this opens an
-/// iroh connection and runs the sync protocol.
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct CollectBookmark {
-    #[builder(into)]
-    pub name: BookmarkName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum CollectBookmark {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: BookmarkName,
+        }
+    }
 }
 
-/// Remove a follow. The bookmark itself and any previously-collected
-/// events stay; only the remote binding is severed.
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct UnfollowBookmark {
-    #[builder(into)]
-    pub name: BookmarkName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum UnfollowBookmark {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: BookmarkName,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/bookmark/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/protocol/responses.rs
@@ -1,28 +1,78 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = BookmarkResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum BookmarkResponse {
-    Created(BookmarkCreated),
-    Forked(BookmarkForked),
-    Switched(BookmarkSwitched),
-    Merged(BookmarkMerged),
+    Created(BookmarkCreatedResponse),
+    Forked(BookmarkForkedResponse),
+    Switched(BookmarkSwitchedResponse),
+    Merged(BookmarkMergedResponse),
     Bookmarks(Listed<Bookmark>),
     Shared(BookmarkShareResult),
     Followed(Follow),
     Collected(BookmarkCollectResult),
-    Unfollowed(BookmarkUnfollowed),
+    Unfollowed(BookmarkUnfollowedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum BookmarkCreatedResponse {
+        V1 => { #[serde(flatten)] pub bookmark: Bookmark }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum BookmarkForkedResponse {
+        V1 => {
+            #[serde(flatten)] pub bookmark: Bookmark,
+            pub from: BookmarkName,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum BookmarkSwitchedResponse {
+        V1 => {
+            pub brain: BrainName,
+            pub name: BookmarkName,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum BookmarkMergedResponse {
+        V1 => {
+            pub brain: BrainName,
+            pub source: BookmarkName,
+            pub target: BookmarkName,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum BookmarkUnfollowedResponse {
+        V1 => {
+            pub follow_id: FollowId,
+            pub brain: BrainName,
+            pub bookmark: BookmarkName,
+        }
+    }
 }
 
 /// The outcome of a successful `bookmark share` — the minted ticket and
 /// the composed URI. The URI is derivable from the ticket plus current
 /// host identity, but it's convenient to return it alongside so callers
 /// don't need to reconstruct it.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct BookmarkShareResult {
     pub ticket: Ticket,
     pub uri: String,
@@ -30,7 +80,7 @@ pub struct BookmarkShareResult {
 
 /// The outcome of a successful `bookmark collect` — how many events were
 /// received and the new checkpoint after applying them.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct BookmarkCollectResult {
     pub follow_id: FollowId,
     pub events_received: u64,

--- a/crates/oneiros-engine/src/domains/bookmark/service.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/service.rs
@@ -6,81 +6,112 @@ impl BookmarkService {
     pub async fn create(
         state: &ServerState,
         brain: &BrainName,
-        CreateBookmark { name }: &CreateBookmark,
+        request: &CreateBookmark,
     ) -> Result<BookmarkResponse, BookmarkError> {
+        let CreateBookmark::V1(creation) = request;
+        let name = &creation.name;
         let from = state.canons().active_bookmark(brain)?;
         state.canons().fork_brain(brain, name)?;
 
         // Create the new bookmark's DB and replay the source events into it.
         Self::create_bookmark_db(state.config(), brain, name)?;
 
-        let forked = BookmarkForked {
-            brain: brain.clone(),
-            name: name.clone(),
-            from,
-        };
+        let bookmark = Bookmark::builder()
+            .brain(brain.clone())
+            .name(name.clone())
+            .build();
 
         state
             .system_context()
-            .emit(BookmarkEvents::BookmarkForked(forked.clone()))
+            .emit(BookmarkEvents::BookmarkForked(
+                BookmarkForked::builder_v1()
+                    .bookmark(bookmark.clone())
+                    .from(from.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
 
-        Ok(BookmarkResponse::Forked(forked))
+        Ok(BookmarkResponse::Forked(
+            BookmarkForkedResponse::builder_v1()
+                .bookmark(bookmark)
+                .from(from)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn switch(
         state: &ServerState,
         brain: &BrainName,
-        SwitchBookmark { name }: &SwitchBookmark,
+        request: &SwitchBookmark,
     ) -> Result<BookmarkResponse, BookmarkError> {
-        // With per-bookmark DBs, switch just updates the default.
-        // Both bookmark DBs already exist with current projections.
+        let SwitchBookmark::V1(switching) = request;
+        let name = &switching.name;
         state.canons().switch_brain(brain, name)?;
 
-        let switched = BookmarkSwitched {
-            brain: brain.clone(),
-            name: name.clone(),
-        };
+        let event = BookmarkSwitched::builder_v1()
+            .brain(brain.clone())
+            .name(name.clone())
+            .build();
 
         state
             .system_context()
-            .emit(BookmarkEvents::BookmarkSwitched(switched.clone()))
+            .emit(BookmarkEvents::BookmarkSwitched(event.into()))
             .await?;
 
-        Ok(BookmarkResponse::Switched(switched))
+        Ok(BookmarkResponse::Switched(
+            BookmarkSwitchedResponse::builder_v1()
+                .brain(brain.clone())
+                .name(name.clone())
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn merge(
         state: &ServerState,
         brain: &BrainName,
-        MergeBookmark { source }: &MergeBookmark,
+        request: &MergeBookmark,
     ) -> Result<BookmarkResponse, BookmarkError> {
+        let MergeBookmark::V1(merging) = request;
+        let source = &merging.source;
         let target = state.canons().active_bookmark(brain)?;
         state.canons().merge_brain(brain, source, &target)?;
 
         Self::replay_bookmark(state.config(), brain, &target)?;
 
-        let merged = BookmarkMerged {
-            brain: brain.clone(),
-            source: source.clone(),
-            target,
-        };
+        let event = BookmarkMerged::builder_v1()
+            .brain(brain.clone())
+            .source(source.clone())
+            .target(target.clone())
+            .build();
 
         state
             .system_context()
-            .emit(BookmarkEvents::BookmarkMerged(merged.clone()))
+            .emit(BookmarkEvents::BookmarkMerged(event.into()))
             .await?;
 
-        Ok(BookmarkResponse::Merged(merged))
+        Ok(BookmarkResponse::Merged(
+            BookmarkMergedResponse::builder_v1()
+                .brain(brain.clone())
+                .source(source.clone())
+                .target(target)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn list(
         state: &ServerState,
         brain: &BrainName,
-        ListBookmarks { filters }: &ListBookmarks,
+        request: &ListBookmarks,
     ) -> Result<BookmarkResponse, BookmarkError> {
+        let ListBookmarks::V1(listing) = request;
         let system = state.system_context();
-        let listed = BookmarkRepo::new(&system).list(brain, filters).await?;
+        let listed = BookmarkRepo::new(&system)
+            .list(brain, &listing.filters)
+            .await?;
         Ok(BookmarkResponse::Bookmarks(listed))
     }
 
@@ -91,8 +122,11 @@ impl BookmarkService {
     pub async fn share(
         state: &ServerState,
         brain: &BrainName,
-        ShareBookmark { name, actor_id }: &ShareBookmark,
+        request: &ShareBookmark,
     ) -> Result<BookmarkResponse, BookmarkError> {
+        let ShareBookmark::V1(sharing) = request;
+        let name = &sharing.name;
+        let actor_id = &sharing.actor_id;
         let system = state.system_context();
         let all = SearchFilters {
             limit: Limit(usize::MAX),
@@ -133,12 +167,15 @@ impl BookmarkService {
         let uri = OneirosUri::Peer(peer_link).to_string();
 
         system
-            .emit(BookmarkEvents::BookmarkShared(BookmarkShared {
-                brain: brain.clone(),
-                bookmark: name.clone(),
-                ticket_id: ticket.id,
-                shared_by: resolved_actor_id,
-            }))
+            .emit(BookmarkEvents::BookmarkShared(
+                BookmarkShared::builder_v1()
+                    .brain(brain.clone())
+                    .bookmark(name.clone())
+                    .ticket_id(ticket.id)
+                    .shared_by(resolved_actor_id)
+                    .build()
+                    .into(),
+            ))
             .await?;
 
         Ok(BookmarkResponse::Shared(BookmarkShareResult {
@@ -151,8 +188,11 @@ impl BookmarkService {
     pub async fn follow(
         state: &ServerState,
         brain: &BrainName,
-        FollowBookmark { uri, name }: &FollowBookmark,
+        request: &FollowBookmark,
     ) -> Result<BookmarkResponse, BookmarkError> {
+        let FollowBookmark::V1(following) = request;
+        let uri = &following.uri;
+        let name = &following.name;
         let system = state.system_context();
         let parsed: OneirosUri = uri
             .parse()
@@ -168,11 +208,18 @@ impl BookmarkService {
             }
         };
 
+        let bookmark = Bookmark::builder()
+            .brain(brain.clone())
+            .name(name.clone())
+            .build();
+
         system
-            .emit(BookmarkEvents::BookmarkCreated(BookmarkCreated {
-                brain: brain.clone(),
-                name: name.clone(),
-            }))
+            .emit(BookmarkEvents::BookmarkCreated(
+                BookmarkCreated::builder_v1()
+                    .bookmark(bookmark)
+                    .build()
+                    .into(),
+            ))
             .await?;
         state.canons().fork_brain(brain, name)?;
 
@@ -187,8 +234,10 @@ impl BookmarkService {
     pub async fn collect(
         state: &ServerState,
         brain: &BrainName,
-        CollectBookmark { name }: &CollectBookmark,
+        request: &CollectBookmark,
     ) -> Result<BookmarkResponse, BookmarkError> {
+        let CollectBookmark::V1(collection) = request;
+        let name = &collection.name;
         let system = state.system_context();
         let follow = FollowService::for_bookmark(&system, brain, name)
             .await?
@@ -321,8 +370,10 @@ impl BookmarkService {
     pub async fn unfollow(
         state: &ServerState,
         brain: &BrainName,
-        UnfollowBookmark { name }: &UnfollowBookmark,
+        request: &UnfollowBookmark,
     ) -> Result<BookmarkResponse, BookmarkError> {
+        let UnfollowBookmark::V1(unfollowing) = request;
+        let name = &unfollowing.name;
         let system = state.system_context();
         let follow = FollowService::for_bookmark(&system, brain, name)
             .await?
@@ -331,11 +382,14 @@ impl BookmarkService {
         let id = follow.id;
         FollowService::remove(&system, id).await?;
 
-        Ok(BookmarkResponse::Unfollowed(BookmarkUnfollowed {
-            follow_id: id,
-            brain: brain.clone(),
-            bookmark: name.clone(),
-        }))
+        Ok(BookmarkResponse::Unfollowed(
+            BookmarkUnfollowedResponse::builder_v1()
+                .follow_id(id)
+                .brain(brain.clone())
+                .bookmark(name.clone())
+                .build()
+                .into(),
+        ))
     }
 
     /// Replay the event log into a specific bookmark's projection DB.

--- a/crates/oneiros-engine/src/domains/bookmark/store.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/store.rs
@@ -23,40 +23,23 @@ impl<'a> BookmarkStore<'a> {
     }
 
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
-        if let Event::Known(Events::Bookmark(bookmark_event)) = &event.data {
-            match bookmark_event {
-                BookmarkEvents::BookmarkCreated(created) => {
-                    self.insert(&created.brain, &created.name, &event.created_at)?;
-                }
-                BookmarkEvents::BookmarkForked(forked) => {
-                    self.insert(&forked.brain, &forked.name, &event.created_at)?;
-                }
-                BookmarkEvents::BookmarkSwitched(_)
-                | BookmarkEvents::BookmarkMerged(_)
-                | BookmarkEvents::BookmarkShared(_)
-                | BookmarkEvents::BookmarkFollowed(_)
-                | BookmarkEvents::BookmarkCollected(_)
-                | BookmarkEvents::BookmarkUnfollowed(_) => {}
-            }
+        if let Event::Known(Events::Bookmark(bookmark_event)) = &event.data
+            && let Some(bookmark) = bookmark_event.maybe_bookmark()
+        {
+            self.write_bookmark(&bookmark)?;
         }
         Ok(())
     }
 
-    fn insert(
-        &self,
-        brain: &BrainName,
-        name: &BookmarkName,
-        created_at: &Timestamp,
-    ) -> Result<(), EventError> {
-        let id = BookmarkId::new();
+    fn write_bookmark(&self, bookmark: &Bookmark) -> Result<(), EventError> {
         self.db.execute(
             "INSERT OR REPLACE INTO bookmarks (id, brain, name, created_at)
              VALUES (?1, ?2, ?3, ?4)",
             rusqlite::params![
-                id.to_string(),
-                brain.to_string(),
-                name.to_string(),
-                created_at.to_string(),
+                bookmark.id.to_string(),
+                bookmark.brain.to_string(),
+                bookmark.name.to_string(),
+                bookmark.created_at.to_string(),
             ],
         )?;
         Ok(())

--- a/crates/oneiros-engine/src/domains/bookmark/view.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/view.rs
@@ -11,34 +11,51 @@ impl BookmarkView {
 
     pub fn render(self) -> Rendered<BookmarkResponse> {
         match self.response {
-            BookmarkResponse::Created(created) => {
+            BookmarkResponse::Created(BookmarkCreatedResponse::V1(created)) => {
                 let prompt =
-                    Confirmation::new("Bookmark", created.name.to_string(), "created").to_string();
-                Rendered::new(BookmarkResponse::Created(created), prompt, String::new())
+                    Confirmation::new("Bookmark", created.bookmark.name.to_string(), "created")
+                        .to_string();
+                Rendered::new(
+                    BookmarkResponse::Created(BookmarkCreatedResponse::V1(created)),
+                    prompt,
+                    String::new(),
+                )
             }
-            BookmarkResponse::Forked(forked) => {
+            BookmarkResponse::Forked(BookmarkForkedResponse::V1(forked)) => {
                 let prompt = Confirmation::new(
                     "Bookmark",
-                    forked.name.to_string(),
+                    forked.bookmark.name.to_string(),
                     format!("forked from '{}'", forked.from),
                 )
                 .to_string();
-                Rendered::new(BookmarkResponse::Forked(forked), prompt, String::new())
+                Rendered::new(
+                    BookmarkResponse::Forked(BookmarkForkedResponse::V1(forked)),
+                    prompt,
+                    String::new(),
+                )
             }
-            BookmarkResponse::Switched(switched) => {
+            BookmarkResponse::Switched(BookmarkSwitchedResponse::V1(switched)) => {
                 let prompt =
                     Confirmation::new("Bookmark", switched.name.to_string(), "switched to")
                         .to_string();
-                Rendered::new(BookmarkResponse::Switched(switched), prompt, String::new())
+                Rendered::new(
+                    BookmarkResponse::Switched(BookmarkSwitchedResponse::V1(switched)),
+                    prompt,
+                    String::new(),
+                )
             }
-            BookmarkResponse::Merged(merged) => {
+            BookmarkResponse::Merged(BookmarkMergedResponse::V1(merged)) => {
                 let prompt = Confirmation::new(
                     "Bookmark",
                     merged.source.to_string(),
                     format!("merged into '{}'", merged.target),
                 )
                 .to_string();
-                Rendered::new(BookmarkResponse::Merged(merged), prompt, String::new())
+                Rendered::new(
+                    BookmarkResponse::Merged(BookmarkMergedResponse::V1(merged)),
+                    prompt,
+                    String::new(),
+                )
             }
             BookmarkResponse::Bookmarks(listed) => {
                 let mut table = Table::new(vec![Column::key("name", "Name")]);
@@ -69,12 +86,12 @@ impl BookmarkView {
                 .to_string();
                 Rendered::new(BookmarkResponse::Collected(result), prompt, String::new())
             }
-            BookmarkResponse::Unfollowed(unfollowed) => {
+            BookmarkResponse::Unfollowed(BookmarkUnfollowedResponse::V1(unfollowed)) => {
                 let prompt =
                     Confirmation::new("Bookmark", unfollowed.bookmark.to_string(), "unfollowed")
                         .to_string();
                 Rendered::new(
-                    BookmarkResponse::Unfollowed(unfollowed),
+                    BookmarkResponse::Unfollowed(BookmarkUnfollowedResponse::V1(unfollowed)),
                     prompt,
                     String::new(),
                 )

--- a/crates/oneiros-engine/src/domains/brain/client.rs
+++ b/crates/oneiros-engine/src/domains/brain/client.rs
@@ -18,15 +18,17 @@ impl<'a> BrainClient<'a> {
     }
 
     /// Retrieve a single brain by key (name or ref).
-    pub async fn get(&self, request: &GetBrain) -> Result<BrainResponse, ClientError> {
-        self.client.get(&format!("/brains/{}", request.key)).await
+    pub async fn get(&self, lookup: &GetBrain) -> Result<BrainResponse, ClientError> {
+        let GetBrain::V1(lookup) = lookup;
+        self.client.get(&format!("/brains/{}", lookup.key)).await
     }
 
     /// List all brains.
-    pub async fn list(&self, request: &ListBrains) -> Result<BrainResponse, ClientError> {
+    pub async fn list(&self, listing: &ListBrains) -> Result<BrainResponse, ClientError> {
+        let ListBrains::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset,
+            listing.filters.limit, listing.filters.offset,
         );
         self.client.get(&format!("/brains?{query}")).await
     }

--- a/crates/oneiros-engine/src/domains/brain/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/brain/features/cli.rs
@@ -2,6 +2,9 @@ use clap::Subcommand;
 
 use crate::*;
 
+/// CLI subcommands for the brain domain. Each variant carries a versioned
+/// protocol request directly — clap derives parsing through the wrapper's
+/// `Args` impl, which delegates to the latest version's struct.
 #[derive(Debug, Subcommand)]
 pub enum BrainCommands {
     Create(CreateBrain),
@@ -18,9 +21,9 @@ impl BrainCommands {
         let brain_client = BrainClient::new(&client);
 
         let response = match self {
-            BrainCommands::Create(create) => brain_client.create(create).await?,
-            BrainCommands::Get(get) => brain_client.get(get).await?,
-            BrainCommands::List(list) => brain_client.list(list).await?,
+            Self::Create(creation) => brain_client.create(creation).await?,
+            Self::Get(lookup) => brain_client.get(lookup).await?,
+            Self::List(listing) => brain_client.list(listing).await?,
         };
 
         Ok(BrainView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/brain/features/http.rs
+++ b/crates/oneiros-engine/src/domains/brain/features/http.rs
@@ -52,6 +52,6 @@ async fn show(
     Path(key): Path<ResourceKey<BrainName>>,
 ) -> Result<Json<BrainResponse>, BrainError> {
     Ok(Json(
-        BrainService::get(&context, &GetBrain::builder().key(key).build()).await?,
+        BrainService::get(&context, &GetBrain::builder_v1().key(key).build().into()).await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/brain/features/state.rs
+++ b/crates/oneiros-engine/src/domains/brain/features/state.rs
@@ -4,8 +4,10 @@ pub struct BrainState;
 
 impl BrainState {
     pub fn reduce(mut canon: SystemCanon, event: &Events) -> SystemCanon {
-        if let Events::Brain(BrainEvents::BrainCreated(brain)) = event {
-            canon.brains.set(brain);
+        if let Events::Brain(brain_event) = event
+            && let Some(brain) = brain_event.maybe_brain()
+        {
+            canon.brains.set(&brain);
         }
 
         canon

--- a/crates/oneiros-engine/src/domains/brain/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/brain/protocol/events.rs
@@ -7,7 +7,23 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = BrainEventsType, display = "kebab-case")]
 pub enum BrainEvents {
-    BrainCreated(Brain),
+    BrainCreated(BrainCreated),
+}
+
+impl BrainEvents {
+    pub fn maybe_brain(&self) -> Option<Brain> {
+        match self {
+            BrainEvents::BrainCreated(event) => event.clone().current().ok().map(|v| v.brain),
+        }
+    }
+}
+
+versioned! {
+    pub enum BrainCreated {
+        V1 => {
+            #[serde(flatten)] pub brain: Brain,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -17,5 +33,24 @@ mod tests {
     #[test]
     fn event_types_are_kebab_cased() {
         assert_eq!(&BrainEventsType::BrainCreated.to_string(), "brain-created");
+    }
+
+    #[test]
+    fn brain_created_wire_format_is_flat() {
+        let brain = Brain::builder().name(BrainName::new("test-brain")).build();
+
+        let event = BrainEvents::BrainCreated(BrainCreated::V1(BrainCreatedV1 {
+            brain: brain.clone(),
+        }));
+        let json = serde_json::to_value(&event).unwrap();
+
+        assert_eq!(json["type"], "brain-created");
+        assert!(
+            json["data"].get("brain").is_none(),
+            "flatten must elide the brain envelope on the wire"
+        );
+        assert_eq!(json["data"]["id"], brain.id.to_string());
+        assert_eq!(json["data"]["name"], "test-brain");
+        assert!(json["data"].get("created_at").is_some());
     }
 }

--- a/crates/oneiros-engine/src/domains/brain/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/brain/protocol/requests.rs
@@ -1,29 +1,40 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct CreateBrain {
-    #[builder(into)]
-    pub name: BrainName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum CreateBrain {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: BrainName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetBrain {
-    #[builder(into)]
-    pub key: ResourceKey<BrainName>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetBrain {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<BrainName>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListBrains {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListBrains {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/brain/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/brain/protocol/responses.rs
@@ -1,13 +1,38 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = BrainResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum BrainResponse {
-    Created(Response<Brain>),
-    Found(Response<Brain>),
-    Listed(Listed<Response<Brain>>),
+    Created(BrainCreatedResponse),
+    Found(BrainFoundResponse),
+    Listed(BrainsResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum BrainCreatedResponse {
+        V1 => { #[serde(flatten)] pub brain: Brain }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum BrainFoundResponse {
+        V1 => { #[serde(flatten)] pub brain: Brain }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum BrainsResponse {
+        V1 => {
+            pub items: Vec<Brain>,
+            pub total: usize,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/brain/service.rs
+++ b/crates/oneiros-engine/src/domains/brain/service.rs
@@ -5,32 +5,41 @@ pub struct BrainService;
 impl BrainService {
     pub async fn create(
         context: &SystemContext,
-        CreateBrain { name }: &CreateBrain,
+        request: &CreateBrain,
     ) -> Result<BrainResponse, BrainError> {
-        let already_exists = BrainRepo::new(context).name_exists(name).await?;
+        let CreateBrain::V1(create) = request;
+        let already_exists = BrainRepo::new(context).name_exists(&create.name).await?;
 
         if already_exists {
-            return Err(BrainError::Conflict(name.clone()));
+            return Err(BrainError::Conflict(create.name.clone()));
         }
 
-        let brain = Brain::builder().name(name.clone()).build();
+        let brain = Brain::builder().name(create.name.clone()).build();
 
         context
-            .emit(BrainEvents::BrainCreated(brain.clone()))
+            .emit(BrainEvents::BrainCreated(
+                BrainCreated::builder_v1()
+                    .brain(brain.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
 
-        let ref_token = RefToken::new(Ref::brain(brain.id));
         Ok(BrainResponse::Created(
-            Response::new(brain).with_ref_token(ref_token),
+            BrainCreatedResponse::builder_v1()
+                .brain(brain)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn get(
         context: &SystemContext,
-        selector: &GetBrain,
+        request: &GetBrain,
     ) -> Result<BrainResponse, BrainError> {
+        let GetBrain::V1(lookup) = request;
         let repo = BrainRepo::new(context);
-        let brain = match &selector.key {
+        let brain = match &lookup.key {
             ResourceKey::Key(name) => repo
                 .get(name)
                 .await?
@@ -51,20 +60,23 @@ impl BrainService {
                 }
             }
         };
-        let ref_token = RefToken::new(Ref::brain(brain.id));
         Ok(BrainResponse::Found(
-            Response::new(brain).with_ref_token(ref_token),
+            BrainFoundResponse::builder_v1().brain(brain).build().into(),
         ))
     }
 
     pub async fn list(
         context: &SystemContext,
-        ListBrains { filters }: &ListBrains,
+        request: &ListBrains,
     ) -> Result<BrainResponse, BrainError> {
-        let listed = BrainRepo::new(context).list(filters).await?;
-        Ok(BrainResponse::Listed(listed.map(|b| {
-            let ref_token = RefToken::new(Ref::brain(b.id));
-            Response::new(b).with_ref_token(ref_token)
-        })))
+        let ListBrains::V1(listing) = request;
+        let listed = BrainRepo::new(context).list(&listing.filters).await?;
+        Ok(BrainResponse::Listed(
+            BrainsResponse::builder_v1()
+                .items(listed.items)
+                .total(listed.total)
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/brain/store.rs
+++ b/crates/oneiros-engine/src/domains/brain/store.rs
@@ -12,8 +12,9 @@ impl<'a> BrainStore<'a> {
     }
 
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
-        if let Event::Known(Events::Brain(BrainEvents::BrainCreated(brain))) = &event.data {
-            self.create_record(brain)?;
+        if let Event::Known(Events::Brain(BrainEvents::BrainCreated(creation))) = &event.data {
+            let brain = creation.current()?.brain;
+            self.write_brain(&brain)?;
         }
         Ok(())
     }
@@ -34,7 +35,7 @@ impl<'a> BrainStore<'a> {
         Ok(())
     }
 
-    fn create_record(&self, brain: &Brain) -> Result<(), EventError> {
+    fn write_brain(&self, brain: &Brain) -> Result<(), EventError> {
         self.conn.execute(
             "insert or replace into brains (id, name, created_at) values (?1, ?2, ?3)",
             params![

--- a/crates/oneiros-engine/src/domains/brain/view.rs
+++ b/crates/oneiros-engine/src/domains/brain/view.rs
@@ -11,25 +11,37 @@ impl BrainView {
 
     pub fn render(self) -> Rendered<BrainResponse> {
         match self.response {
-            BrainResponse::Created(wrapped) => {
-                let prompt = Confirmation::new("Brain", wrapped.data.name.to_string(), "created")
+            BrainResponse::Created(BrainCreatedResponse::V1(created)) => {
+                let prompt = Confirmation::new("Brain", created.brain.name.to_string(), "created")
                     .to_string();
-                Rendered::new(BrainResponse::Created(wrapped), prompt, String::new())
+                Rendered::new(
+                    BrainResponse::Created(BrainCreatedResponse::V1(created)),
+                    prompt,
+                    String::new(),
+                )
             }
-            BrainResponse::Found(wrapped) => {
-                let prompt = Detail::new(wrapped.data.name.to_string()).to_string();
-                Rendered::new(BrainResponse::Found(wrapped), prompt, String::new())
+            BrainResponse::Found(BrainFoundResponse::V1(found)) => {
+                let prompt = Detail::new(found.brain.name.to_string()).to_string();
+                Rendered::new(
+                    BrainResponse::Found(BrainFoundResponse::V1(found)),
+                    prompt,
+                    String::new(),
+                )
             }
-            BrainResponse::Listed(listed) => {
+            BrainResponse::Listed(BrainsResponse::V1(listed)) => {
                 let mut table = Table::new(vec![Column::key("name", "Name")]);
-                for wrapped in &listed.items {
-                    table.push_row(vec![wrapped.data.name.to_string()]);
+                for brain in &listed.items {
+                    table.push_row(vec![brain.name.to_string()]);
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
-                Rendered::new(BrainResponse::Listed(listed), prompt, String::new())
+                Rendered::new(
+                    BrainResponse::Listed(BrainsResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/bridge/protocol/mod.rs
+++ b/crates/oneiros-engine/src/domains/bridge/protocol/mod.rs
@@ -1,3 +1,80 @@
+//! Bridge protocol — peer-to-peer chronicle sync over iroh.
+//!
+//! These shapes carry over the `/oneiros/sync/1` ALPN via QUIC. They are
+//! the wire format for the Merkle diff exchange between two peers that
+//! share a bookmark.
+//!
+//! # TODO: this module is intentionally exempt from `versioned!`
+//!
+//! Every other protocol module in oneiros wraps its shapes in the
+//! `versioned!` macro (see `agent/protocol/`). Bridge does not. The
+//! exemption is deliberate — and worth revisiting when any of the
+//! conditions below change.
+//!
+//! ## Why bridge isn't versioned today
+//!
+//! `versioned!`'s inline form hardcodes a `JsonSchema` derive on every
+//! V_n struct. Bridge requests/responses carry `LedgerNode` (HAMT
+//! internals from `values/ledger.rs`) and `StoredEvent` (the canonical
+//! persisted-event envelope from `domains/event/model.rs`) directly.
+//! Wrapping bridge with `versioned!` would force `JsonSchema` onto:
+//!
+//! - `LedgerNode` and `BTreeMap<u8, ContentHash>` (HAMT shape)
+//! - `StoredEvent`, `Event`, `Events`, every `*Events` enum, and every
+//!   V_n payload struct in every domain
+//!
+//! That's ~50+ types acquiring a derive that nothing reads. The
+//! derive's purpose is to publish shapes in OpenAPI for API consumers;
+//! the bridge wire isn't an API surface — it's machine-to-machine sync.
+//!
+//! ## What bridge actually transports
+//!
+//! Bridge does not create or consume domain events. It moves
+//! already-canonical `StoredEvent`s between peers. `BridgeEvents.events`
+//! carries items that already passed through the domain → `NewEvent` →
+//! `EventLog::append` pipeline on the source peer. The destination
+//! imports them via `EventLog::import` (preserves id, sequence,
+//! source, timestamp) and replays locally. The "events" flowing through
+//! bridge are the same events as everywhere else — just in motion.
+//!
+//! ## How bridge versions today
+//!
+//! Protocol-level, not shape-level: the ALPN identifier
+//! `/oneiros/sync/1` is the version. If the protocol shape changes,
+//! the path is to introduce `/oneiros/sync/2` and run both during
+//! transition. That's how QUIC application protocols typically
+//! evolve.
+//!
+//! ## Open threads worth preserving
+//!
+//! - **Bridge as part of "our interface"**: even though it isn't an
+//!   API consumer surface, it *is* a contract between peers. If we
+//!   ever want shape-level evolvability (add a field to
+//!   `BridgeFetchEvents`, change `BridgeNodes` pagination), the
+//!   shape-level pattern would help.
+//!
+//! - **Ephemeral framing**: bridge requests/responses *could* be
+//!   modeled as `Events::Ephemeral` events (RPCs-as-events), which
+//!   would make them consistent with the rest of the codebase's
+//!   event-driven shape. They aren't today because they're synchronous
+//!   query/response, not state-change facts. The framing is worth
+//!   considering if cross-peer telemetry or auditing becomes a need.
+//!
+//! - **A `versioned!` variant without `JsonSchema`**: the right path
+//!   to fold bridge back in is making the macro's schemars derive
+//!   optional (e.g., `versioned_no_schema!` or an attribute to opt
+//!   out). Then bridge could use `versioned!` without dragging
+//!   `JsonSchema` across the chronicle/event infrastructure.
+//!
+//! ## When to revisit
+//!
+//! Take this exemption back out when:
+//! 1. We need to evolve a bridge shape and want shape-level versioning
+//!    rather than ALPN-level versioning, OR
+//! 2. We extend `versioned!` with an optional-schema variant, OR
+//! 3. The chronicle/event infrastructure gains `JsonSchema` for some
+//!    other reason and the cascade cost disappears.
+
 mod errors;
 mod requests;
 mod responses;

--- a/crates/oneiros-engine/src/domains/cognition/client.rs
+++ b/crates/oneiros-engine/src/domains/cognition/client.rs
@@ -9,23 +9,24 @@ impl<'a> CognitionClient<'a> {
         Self { client }
     }
 
-    pub async fn add(&self, request: &AddCognition) -> Result<CognitionResponse, ClientError> {
-        self.client.post("/cognitions", request).await
+    pub async fn add(&self, addition: &AddCognition) -> Result<CognitionResponse, ClientError> {
+        self.client.post("/cognitions", addition).await
     }
 
-    pub async fn list(&self, request: &ListCognitions) -> Result<CognitionResponse, ClientError> {
+    pub async fn list(&self, listing: &ListCognitions) -> Result<CognitionResponse, ClientError> {
+        let ListCognitions::V1(listing) = listing;
         let mut params: Vec<(&str, String)> = Vec::new();
 
-        if let Some(agent_name) = &request.agent {
+        if let Some(agent_name) = &listing.agent {
             params.push(("agent", agent_name.to_string()));
         }
 
-        if let Some(texture_name) = &request.texture {
+        if let Some(texture_name) = &listing.texture {
             params.push(("texture", texture_name.to_string()));
         }
 
-        params.push(("limit", request.filters.limit.to_string()));
-        params.push(("offset", request.filters.offset.to_string()));
+        params.push(("limit", listing.filters.limit.to_string()));
+        params.push(("offset", listing.filters.offset.to_string()));
 
         let query = params
             .iter()
@@ -36,9 +37,10 @@ impl<'a> CognitionClient<'a> {
         self.client.get(&format!("/cognitions?{query}")).await
     }
 
-    pub async fn get(&self, request: &GetCognition) -> Result<CognitionResponse, ClientError> {
+    pub async fn get(&self, lookup: &GetCognition) -> Result<CognitionResponse, ClientError> {
+        let GetCognition::V1(lookup) = lookup;
         self.client
-            .get(&format!("/cognitions/{}", request.key))
+            .get(&format!("/cognitions/{}", lookup.key))
             .await
     }
 }

--- a/crates/oneiros-engine/src/domains/cognition/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/cognition/features/cli.rs
@@ -18,18 +18,18 @@ impl CognitionCommands {
         let cognition_client = CognitionClient::new(&client);
 
         let (response, request) = match self {
-            CognitionCommands::Add(addition) => {
-                let response = cognition_client.add(addition).await?;
-                (response, CognitionRequest::AddCognition(addition.clone()))
-            }
-            CognitionCommands::Show(get) => {
-                let response = cognition_client.get(get).await?;
-                (response, CognitionRequest::GetCognition(get.clone()))
-            }
-            CognitionCommands::List(listing) => {
-                let response = cognition_client.list(listing).await?;
-                (response, CognitionRequest::ListCognitions(listing.clone()))
-            }
+            Self::Add(addition) => (
+                cognition_client.add(addition).await?,
+                CognitionRequest::AddCognition(addition.clone()),
+            ),
+            Self::Show(lookup) => (
+                cognition_client.get(lookup).await?,
+                CognitionRequest::GetCognition(lookup.clone()),
+            ),
+            Self::List(listing) => (
+                cognition_client.list(listing).await?,
+                CognitionRequest::ListCognitions(listing.clone()),
+            ),
         };
 
         Ok(CognitionView::new(response, &request)

--- a/crates/oneiros-engine/src/domains/cognition/features/http.rs
+++ b/crates/oneiros-engine/src/domains/cognition/features/http.rs
@@ -55,6 +55,10 @@ async fn show(
     Path(key): Path<ResourceKey<CognitionId>>,
 ) -> Result<Json<CognitionResponse>, CognitionError> {
     Ok(Json(
-        CognitionService::get(&context, &GetCognition::builder().key(key).build()).await?,
+        CognitionService::get(
+            &context,
+            &GetCognition::builder_v1().key(key).build().into(),
+        )
+        .await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/cognition/features/state.rs
+++ b/crates/oneiros-engine/src/domains/cognition/features/state.rs
@@ -4,8 +4,10 @@ pub struct CognitionState;
 
 impl CognitionState {
     pub fn reduce(mut canon: BrainCanon, event: &Events) -> BrainCanon {
-        if let Events::Cognition(CognitionEvents::CognitionAdded(cognition)) = event {
-            canon.cognitions.set(cognition);
+        if let Events::Cognition(CognitionEvents::CognitionAdded(added)) = event
+            && let Ok(current) = added.current()
+        {
+            canon.cognitions.set(&current.cognition);
         }
 
         canon
@@ -28,7 +30,11 @@ mod tests {
             .texture("observation")
             .content("Something noticed")
             .build();
-        let event = Events::Cognition(CognitionEvents::CognitionAdded(cognition.clone()));
+        let added = CognitionAdded::builder_v1()
+            .cognition(cognition)
+            .build()
+            .into();
+        let event = Events::Cognition(CognitionEvents::CognitionAdded(added));
 
         let next = CognitionState::reduce(canon, &event);
 

--- a/crates/oneiros-engine/src/domains/cognition/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/cognition/protocol/events.rs
@@ -7,18 +7,57 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = CognitionEventsType, display = "kebab-case")]
 pub enum CognitionEvents {
-    CognitionAdded(Cognition),
+    CognitionAdded(CognitionAdded),
+}
+
+versioned! {
+    pub enum CognitionAdded {
+        V1 => {
+            #[serde(flatten)] pub cognition: Cognition,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn sample_cognition() -> Cognition {
+        Cognition::builder()
+            .agent_id(AgentId::new())
+            .texture("observation")
+            .content("Something noticed")
+            .build()
+    }
+
     #[test]
     fn event_types_are_kebab_cased() {
         assert_eq!(
             &CognitionEventsType::CognitionAdded.to_string(),
             "cognition-added"
+        );
+    }
+
+    #[test]
+    fn cognition_added_wire_format_is_flat() {
+        // V1 embeds `Cognition` with `#[serde(flatten)]`, so the wire shape stays
+        // at the model fields and never gains a `cognition` envelope.
+        let event = CognitionEvents::CognitionAdded(CognitionAdded::V1(CognitionAddedV1 {
+            cognition: sample_cognition(),
+        }));
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "cognition-added");
+        assert!(
+            json["data"].get("cognition").is_none(),
+            "flatten must elide the cognition envelope on the wire"
+        );
+        assert_eq!(json["data"]["texture"], "observation");
+        assert_eq!(json["data"]["content"], "Something noticed");
+        assert!(json["data"].get("id").is_some());
+        assert!(
+            json["data"].get("V1").is_none(),
+            "V1 layer must not appear on the wire"
         );
     }
 }

--- a/crates/oneiros-engine/src/domains/cognition/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/cognition/protocol/requests.rs
@@ -1,37 +1,46 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct AddCognition {
-    #[builder(into)]
-    pub agent: AgentName,
-    #[builder(into)]
-    pub texture: TextureName,
-    #[builder(into)]
-    pub content: Content,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum AddCognition {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+            #[builder(into)] pub texture: TextureName,
+            #[builder(into)] pub content: Content,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetCognition {
-    #[builder(into)]
-    pub key: ResourceKey<CognitionId>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetCognition {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<CognitionId>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListCognitions {
-    #[arg(long)]
-    pub agent: Option<AgentName>,
-    #[arg(long)]
-    pub texture: Option<TextureName>,
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListCognitions {
+        #[derive(clap::Args)]
+        V1 => {
+            #[arg(long)]
+            pub agent: Option<AgentName>,
+            #[arg(long)]
+            pub texture: Option<TextureName>,
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/cognition/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/cognition/protocol/responses.rs
@@ -1,14 +1,39 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = CognitionResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum CognitionResponse {
-    CognitionAdded(Response<Cognition>),
-    CognitionDetails(Response<Cognition>),
-    Cognitions(Listed<Response<Cognition>>),
+    CognitionAdded(CognitionAddedResponse),
+    CognitionDetails(CognitionDetailsResponse),
+    Cognitions(CognitionsResponse),
     NoCognitions,
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum CognitionAddedResponse {
+        V1 => { #[serde(flatten)] pub cognition: Cognition }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum CognitionDetailsResponse {
+        V1 => { #[serde(flatten)] pub cognition: Cognition }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum CognitionsResponse {
+        V1 => {
+            pub items: Vec<Cognition>,
+            pub total: usize,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/cognition/service.rs
+++ b/crates/oneiros-engine/src/domains/cognition/service.rs
@@ -5,56 +5,61 @@ pub struct CognitionService;
 impl CognitionService {
     pub async fn add(
         context: &ProjectContext,
-        AddCognition {
-            agent,
-            texture,
-            content,
-        }: &AddCognition,
+        request: &AddCognition,
     ) -> Result<CognitionResponse, CognitionError> {
+        let AddCognition::V1(addition) = request;
         let agent_record = AgentRepo::new(context)
-            .get(agent)
+            .get(&addition.agent)
             .await?
-            .ok_or_else(|| CognitionError::AgentNotFound(agent.clone()))?;
+            .ok_or_else(|| CognitionError::AgentNotFound(addition.agent.clone()))?;
 
         let cognition = Cognition::builder()
             .agent_id(agent_record.id)
-            .texture(texture.clone())
-            .content(content.clone())
+            .texture(addition.texture.clone())
+            .content(addition.content.clone())
             .build();
 
         context
-            .emit(CognitionEvents::CognitionAdded(cognition.clone()))
+            .emit(CognitionEvents::CognitionAdded(
+                CognitionAdded::builder_v1()
+                    .cognition(cognition.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        let ref_token = RefToken::new(Ref::cognition(cognition.id));
+
         Ok(CognitionResponse::CognitionAdded(
-            Response::new(cognition).with_ref_token(ref_token),
+            CognitionAddedResponse::builder_v1()
+                .cognition(cognition)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn get(
         context: &ProjectContext,
-        selector: &GetCognition,
+        request: &GetCognition,
     ) -> Result<CognitionResponse, CognitionError> {
-        let id = selector.key.resolve()?;
+        let GetCognition::V1(lookup) = request;
+        let id = lookup.key.resolve()?;
         let cognition = CognitionRepo::new(context)
             .get(&id)
             .await?
             .ok_or(CognitionError::NotFound(id))?;
-        let ref_token = RefToken::new(Ref::cognition(cognition.id));
         Ok(CognitionResponse::CognitionDetails(
-            Response::new(cognition).with_ref_token(ref_token),
+            CognitionDetailsResponse::builder_v1()
+                .cognition(cognition)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn list(
         context: &ProjectContext,
-        ListCognitions {
-            agent,
-            texture,
-            filters,
-        }: &ListCognitions,
+        request: &ListCognitions,
     ) -> Result<CognitionResponse, CognitionError> {
-        let agent_id = match agent {
+        let ListCognitions::V1(listing) = request;
+        let agent_id = match &listing.agent {
             Some(name) => {
                 let record = AgentRepo::new(context)
                     .get(name)
@@ -66,15 +71,22 @@ impl CognitionService {
         };
 
         let listed = CognitionRepo::new(context)
-            .list(agent_id.as_ref(), texture.as_ref(), filters)
+            .list(
+                agent_id.as_ref(),
+                listing.texture.as_ref(),
+                &listing.filters,
+            )
             .await?;
         Ok(if listed.total == 0 {
             CognitionResponse::NoCognitions
         } else {
-            CognitionResponse::Cognitions(listed.map(|c| {
-                let ref_token = RefToken::new(Ref::cognition(c.id));
-                Response::new(c).with_ref_token(ref_token)
-            }))
+            CognitionResponse::Cognitions(
+                CognitionsResponse::builder_v1()
+                    .items(listed.items)
+                    .total(listed.total)
+                    .build()
+                    .into(),
+            )
         })
     }
 }

--- a/crates/oneiros-engine/src/domains/cognition/store.rs
+++ b/crates/oneiros-engine/src/domains/cognition/store.rs
@@ -15,7 +15,10 @@ impl<'a> CognitionStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Cognition(cognition_event)) = &event.data {
             match cognition_event {
-                CognitionEvents::CognitionAdded(cognition) => self.insert(cognition)?,
+                CognitionEvents::CognitionAdded(added) => {
+                    let cognition = added.current()?.cognition;
+                    self.write_cognition(&cognition)?
+                }
             }
         }
         Ok(())
@@ -181,7 +184,7 @@ impl<'a> CognitionStore<'a> {
         Ok(cognitions)
     }
 
-    fn insert(&self, cognition: &Cognition) -> Result<(), EventError> {
+    fn write_cognition(&self, cognition: &Cognition) -> Result<(), EventError> {
         self.conn.execute(
             "INSERT OR REPLACE INTO cognitions (id, agent_id, texture, content, created_at)
              VALUES (?1, ?2, ?3, ?4, ?5)",

--- a/crates/oneiros-engine/src/domains/cognition/view.rs
+++ b/crates/oneiros-engine/src/domains/cognition/view.rs
@@ -12,27 +12,27 @@ impl<'a> CognitionView<'a> {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            CognitionResponse::CognitionAdded(wrapped) => {
-                let ref_token = RefToken::from(Ref::cognition(wrapped.data.id));
+            CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(added)) => {
+                let ref_token = RefToken::from(Ref::cognition(added.cognition.id));
                 McpResponse::new(format!(
                     "Thought recorded ({}).\n\n**texture:** {}\n**ref:** {}",
-                    wrapped.data.texture, wrapped.data.texture, ref_token
+                    added.cognition.texture, added.cognition.texture, ref_token
                 ))
                 .hint_set(HintSet::cognition_added(
                     CognitionAddedHints::builder()
-                        .agent(AgentName::new(wrapped.data.agent_id.to_string()))
+                        .agent(AgentName::new(added.cognition.agent_id.to_string()))
                         .ref_token(ref_token)
                         .build(),
                 ))
             }
-            CognitionResponse::CognitionDetails(wrapped) => {
-                let ref_token = RefToken::from(Ref::cognition(wrapped.data.id));
+            CognitionResponse::CognitionDetails(CognitionDetailsResponse::V1(details)) => {
+                let ref_token = RefToken::from(Ref::cognition(details.cognition.id));
                 McpResponse::new(format!(
                     "# Cognition\n\n**texture:** {}\n**agent:** {}\n**created:** {}\n\n{}\n",
-                    wrapped.data.texture,
-                    wrapped.data.agent_id,
-                    wrapped.data.created_at,
-                    wrapped.data.content
+                    details.cognition.texture,
+                    details.cognition.agent_id,
+                    details.cognition.created_at,
+                    details.cognition.content
                 ))
                 .hint(Hint::suggest(
                     format!("create-connection <nature> {ref_token} <target>"),
@@ -40,24 +40,30 @@ impl<'a> CognitionView<'a> {
                 ))
                 .hint(Hint::suggest("search-query", "Search for related entities"))
             }
-            CognitionResponse::Cognitions(listed) => {
+            CognitionResponse::Cognitions(CognitionsResponse::V1(listed)) => {
                 let title = match self.request {
-                    CognitionRequest::ListCognitions(listing) => match &listing.agent {
-                        Some(agent) => format!("# Cognitions — {agent}\n\n"),
-                        None => "# Cognitions\n\n".to_string(),
-                    },
+                    CognitionRequest::ListCognitions(ListCognitions::V1(listing)) => {
+                        match &listing.agent {
+                            Some(agent) => format!("# Cognitions — {agent}\n\n"),
+                            None => "# Cognitions\n\n".to_string(),
+                        }
+                    }
                     _ => "# Cognitions\n\n".to_string(),
                 };
-                let mut md = format!("{title}{} of {} total\n\n", listed.len(), listed.total);
-                for wrapped in &listed.items {
+                let mut md = format!(
+                    "{title}{} of {} total\n\n",
+                    listed.items.len(),
+                    listed.total
+                );
+                for item in &listed.items {
                     md.push_str(&format!(
                         "### {} — {}\n{}\n\n",
-                        wrapped.data.texture, wrapped.data.created_at, wrapped.data.content
+                        item.texture, item.created_at, item.content
                     ));
                 }
                 let mut response =
                     McpResponse::new(md).hint(Hint::suggest("add-cognition", "Record a thought"));
-                if let CognitionRequest::ListCognitions(listing) = self.request
+                if let CognitionRequest::ListCognitions(ListCognitions::V1(listing)) = self.request
                     && let Some(agent) = &listing.agent
                 {
                     response = response.hint(Hint::inspect(
@@ -75,83 +81,70 @@ impl<'a> CognitionView<'a> {
     pub fn render(self) -> Rendered<CognitionResponse> {
         match (self.response, self.request) {
             (
-                CognitionResponse::CognitionAdded(wrapped),
-                CognitionRequest::AddCognition(addition),
+                CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(added)),
+                CognitionRequest::AddCognition(AddCognition::V1(addition)),
             ) => {
-                let subject = wrapped
-                    .meta()
-                    .ref_token()
-                    .map(|ref_token| {
-                        format!(
-                            "{} Cognition recorded: {}",
-                            "✓".success(),
-                            ref_token.muted()
-                        )
-                    })
-                    .unwrap_or_default();
-
-                let hints = match wrapped.meta().ref_token() {
-                    Some(ref_token) => HintSet::cognition_added(
-                        CognitionAddedHints::builder()
-                            .agent(addition.agent.clone())
-                            .ref_token(ref_token)
-                            .build(),
-                    ),
-                    None => HintSet::None,
-                };
+                let ref_token = RefToken::from(Ref::cognition(added.cognition.id));
+                let subject = format!(
+                    "{} Cognition recorded: {}",
+                    "✓".success(),
+                    ref_token.clone().muted()
+                );
+                let hints = HintSet::cognition_added(
+                    CognitionAddedHints::builder()
+                        .agent(addition.agent.clone())
+                        .ref_token(ref_token)
+                        .build(),
+                );
 
                 Rendered::new(
-                    CognitionResponse::CognitionAdded(wrapped),
+                    CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(added)),
                     subject,
                     String::new(),
                 )
                 .with_hints(hints)
             }
-            (CognitionResponse::CognitionDetails(wrapped), _) => {
-                let prompt = Detail::new(wrapped.data.texture.to_string())
-                    .field("content:", wrapped.data.content.to_string())
+            (CognitionResponse::CognitionDetails(CognitionDetailsResponse::V1(details)), _) => {
+                let prompt = Detail::new(details.cognition.texture.to_string())
+                    .field("content:", details.cognition.content.to_string())
                     .to_string();
-
-                let hints = match wrapped.meta().ref_token() {
-                    Some(ref_token) => {
-                        HintSet::mutation(MutationHints::builder().ref_token(ref_token).build())
-                    }
-                    None => HintSet::None,
-                };
+                let ref_token = RefToken::from(Ref::cognition(details.cognition.id));
+                let hints =
+                    HintSet::mutation(MutationHints::builder().ref_token(ref_token).build());
 
                 Rendered::new(
-                    CognitionResponse::CognitionDetails(wrapped),
+                    CognitionResponse::CognitionDetails(CognitionDetailsResponse::V1(details)),
                     prompt,
                     String::new(),
                 )
                 .with_hints(hints)
             }
-            (CognitionResponse::Cognitions(listed), _) => {
+            (CognitionResponse::Cognitions(CognitionsResponse::V1(listed)), _) => {
                 let mut table = Table::new(vec![
                     Column::key("texture", "Texture"),
                     Column::key("content", "Content").max(60),
                     Column::key("ref_token", "Ref"),
                 ]);
 
-                for wrapped in &listed.items {
-                    let ref_token = wrapped
-                        .meta()
-                        .ref_token()
-                        .map(|t| t.to_string())
-                        .unwrap_or_default();
+                for item in &listed.items {
+                    let ref_token = RefToken::from(Ref::cognition(item.id));
                     table.push_row(vec![
-                        wrapped.data.texture.to_string(),
-                        wrapped.data.content.to_string(),
-                        ref_token,
+                        item.texture.to_string(),
+                        item.content.to_string(),
+                        ref_token.to_string(),
                     ]);
                 }
 
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
 
-                Rendered::new(CognitionResponse::Cognitions(listed), prompt, String::new())
+                Rendered::new(
+                    CognitionResponse::Cognitions(CognitionsResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
             (CognitionResponse::NoCognitions, _) => Rendered::new(
                 CognitionResponse::NoCognitions,

--- a/crates/oneiros-engine/src/domains/connection/client.rs
+++ b/crates/oneiros-engine/src/domains/connection/client.rs
@@ -11,20 +11,21 @@ impl<'a> ConnectionClient<'a> {
 
     pub async fn create(
         &self,
-        request: &CreateConnection,
+        creation: &CreateConnection,
     ) -> Result<ConnectionResponse, ClientError> {
-        self.client.post("/connections", request).await
+        self.client.post("/connections", creation).await
     }
 
-    pub async fn list(&self, request: &ListConnections) -> Result<ConnectionResponse, ClientError> {
+    pub async fn list(&self, listing: &ListConnections) -> Result<ConnectionResponse, ClientError> {
+        let ListConnections::V1(listing) = listing;
         let mut params: Vec<(&str, String)> = Vec::new();
 
-        if let Some(entity) = &request.entity {
+        if let Some(entity) = &listing.entity {
             params.push(("entity", entity.to_string()));
         }
 
-        params.push(("limit", request.filters.limit.to_string()));
-        params.push(("offset", request.filters.offset.to_string()));
+        params.push(("limit", listing.filters.limit.to_string()));
+        params.push(("offset", listing.filters.offset.to_string()));
 
         let query = params
             .iter()
@@ -35,18 +36,20 @@ impl<'a> ConnectionClient<'a> {
         self.client.get(&format!("/connections?{query}")).await
     }
 
-    pub async fn get(&self, request: &GetConnection) -> Result<ConnectionResponse, ClientError> {
+    pub async fn get(&self, lookup: &GetConnection) -> Result<ConnectionResponse, ClientError> {
+        let GetConnection::V1(lookup) = lookup;
         self.client
-            .get(&format!("/connections/{}", request.key))
+            .get(&format!("/connections/{}", lookup.key))
             .await
     }
 
     pub async fn remove(
         &self,
-        request: &RemoveConnection,
+        removal: &RemoveConnection,
     ) -> Result<ConnectionResponse, ClientError> {
+        let RemoveConnection::V1(removal) = removal;
         self.client
-            .delete(&format!("/connections/{}", request.id))
+            .delete(&format!("/connections/{}", removal.id))
             .await
     }
 }

--- a/crates/oneiros-engine/src/domains/connection/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/connection/features/cli.rs
@@ -19,28 +19,22 @@ impl ConnectionCommands {
         let connection_client = ConnectionClient::new(&client);
 
         let (response, request) = match self {
-            ConnectionCommands::Create(creation) => {
-                let response = connection_client.create(creation).await?;
-                (
-                    response,
-                    ConnectionRequest::CreateConnection(creation.clone()),
-                )
-            }
-            ConnectionCommands::Show(get) => {
-                let response = connection_client.get(get).await?;
-                (response, ConnectionRequest::GetConnection(get.clone()))
-            }
-            ConnectionCommands::List(list) => {
-                let response = connection_client.list(list).await?;
-                (response, ConnectionRequest::ListConnections(list.clone()))
-            }
-            ConnectionCommands::Remove(remove) => {
-                let response = connection_client.remove(remove).await?;
-                (
-                    response,
-                    ConnectionRequest::RemoveConnection(remove.clone()),
-                )
-            }
+            Self::Create(creation) => (
+                connection_client.create(creation).await?,
+                ConnectionRequest::CreateConnection(creation.clone()),
+            ),
+            Self::Show(lookup) => (
+                connection_client.get(lookup).await?,
+                ConnectionRequest::GetConnection(lookup.clone()),
+            ),
+            Self::List(listing) => (
+                connection_client.list(listing).await?,
+                ConnectionRequest::ListConnections(listing.clone()),
+            ),
+            Self::Remove(removal) => (
+                connection_client.remove(removal).await?,
+                ConnectionRequest::RemoveConnection(removal.clone()),
+            ),
         };
 
         Ok(ConnectionView::new(response, &request)

--- a/crates/oneiros-engine/src/domains/connection/features/http.rs
+++ b/crates/oneiros-engine/src/domains/connection/features/http.rs
@@ -58,7 +58,11 @@ async fn show(
     Path(key): Path<ResourceKey<ConnectionId>>,
 ) -> Result<Json<ConnectionResponse>, ConnectionError> {
     Ok(Json(
-        ConnectionService::get(&context, &GetConnection::builder().key(key).build()).await?,
+        ConnectionService::get(
+            &context,
+            &GetConnection::builder_v1().key(key).build().into(),
+        )
+        .await?,
     ))
 }
 
@@ -67,6 +71,10 @@ async fn remove(
     Path(id): Path<ConnectionId>,
 ) -> Result<Json<ConnectionResponse>, ConnectionError> {
     Ok(Json(
-        ConnectionService::remove(&context, &RemoveConnection::builder().id(id).build()).await?,
+        ConnectionService::remove(
+            &context,
+            &RemoveConnection::builder_v1().id(id).build().into(),
+        )
+        .await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/connection/features/state.rs
+++ b/crates/oneiros-engine/src/domains/connection/features/state.rs
@@ -6,11 +6,15 @@ impl ConnectionState {
     pub fn reduce(mut canon: BrainCanon, event: &Events) -> BrainCanon {
         if let Events::Connection(connection_event) = event {
             match connection_event {
-                ConnectionEvents::ConnectionCreated(connection) => {
-                    canon.connections.set(connection);
+                ConnectionEvents::ConnectionCreated(created) => {
+                    if let Ok(current) = created.current() {
+                        canon.connections.set(&current.connection);
+                    }
                 }
                 ConnectionEvents::ConnectionRemoved(removed) => {
-                    canon.connections.remove(removed.id);
+                    if let Ok(current) = removed.current() {
+                        canon.connections.remove(current.id);
+                    }
                 }
             };
         }

--- a/crates/oneiros-engine/src/domains/connection/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/connection/protocol/events.rs
@@ -7,13 +7,37 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = ConnectionEventsType, display = "kebab-case")]
 pub enum ConnectionEvents {
-    ConnectionCreated(Connection),
+    ConnectionCreated(ConnectionCreated),
     ConnectionRemoved(ConnectionRemoved),
+}
+
+versioned! {
+    pub enum ConnectionCreated {
+        V1 => {
+            #[serde(flatten)] pub connection: Connection,
+        }
+    }
+}
+
+versioned! {
+    pub enum ConnectionRemoved {
+        V1 => {
+            pub id: ConnectionId,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_connection() -> Connection {
+        Connection::builder()
+            .from_ref(Ref::cognition(CognitionId::new()))
+            .to_ref(Ref::memory(MemoryId::new()))
+            .nature("references")
+            .build()
+    }
 
     #[test]
     fn event_types_are_kebab_cased() {
@@ -31,9 +55,26 @@ mod tests {
             assert_eq!(&event_type.to_string(), expectation);
         }
     }
-}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConnectionRemoved {
-    pub id: ConnectionId,
+    #[test]
+    fn connection_created_wire_format_is_flat() {
+        let event =
+            ConnectionEvents::ConnectionCreated(ConnectionCreated::V1(ConnectionCreatedV1 {
+                connection: sample_connection(),
+            }));
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "connection-created");
+        assert!(
+            json["data"].get("connection").is_none(),
+            "flatten must elide the connection envelope on the wire"
+        );
+        assert_eq!(json["data"]["nature"], "references");
+        assert!(json["data"].get("from_ref").is_some());
+        assert!(json["data"].get("to_ref").is_some());
+        assert!(
+            json["data"].get("V1").is_none(),
+            "V1 layer must not appear on the wire"
+        );
+    }
 }

--- a/crates/oneiros-engine/src/domains/connection/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/connection/protocol/requests.rs
@@ -1,39 +1,54 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct CreateConnection {
-    #[builder(into)]
-    pub nature: NatureName,
-    pub from_ref: RefToken,
-    pub to_ref: RefToken,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum CreateConnection {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub nature: NatureName,
+            pub from_ref: RefToken,
+            pub to_ref: RefToken,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetConnection {
-    #[builder(into)]
-    pub key: ResourceKey<ConnectionId>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetConnection {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<ConnectionId>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListConnections {
-    #[arg(long)]
-    pub entity: Option<RefToken>,
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListConnections {
+        #[derive(clap::Args)]
+        V1 => {
+            #[arg(long)]
+            pub entity: Option<RefToken>,
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct RemoveConnection {
-    #[builder(into)]
-    pub id: ConnectionId,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum RemoveConnection {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub id: ConnectionId,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/connection/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/connection/protocol/responses.rs
@@ -1,15 +1,49 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = ConnectionResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ConnectionResponse {
-    ConnectionCreated(Response<Connection>),
-    ConnectionDetails(Response<Connection>),
-    Connections(Listed<Response<Connection>>),
+    ConnectionCreated(ConnectionCreatedResponse),
+    ConnectionDetails(ConnectionDetailsResponse),
+    Connections(ConnectionsResponse),
     NoConnections,
-    ConnectionRemoved(ConnectionId),
+    ConnectionRemoved(ConnectionRemovedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ConnectionCreatedResponse {
+        V1 => { #[serde(flatten)] pub connection: Connection }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ConnectionDetailsResponse {
+        V1 => { #[serde(flatten)] pub connection: Connection }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ConnectionsResponse {
+        V1 => {
+            pub items: Vec<Connection>,
+            pub total: usize,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ConnectionRemovedResponse {
+        V1 => {
+            pub id: ConnectionId,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/connection/service.rs
+++ b/crates/oneiros-engine/src/domains/connection/service.rs
@@ -5,50 +5,58 @@ pub struct ConnectionService;
 impl ConnectionService {
     pub async fn create(
         context: &ProjectContext,
-        CreateConnection {
-            from_ref,
-            to_ref,
-            nature,
-        }: &CreateConnection,
+        request: &CreateConnection,
     ) -> Result<ConnectionResponse, ConnectionError> {
-        let from = from_ref.clone().into_inner();
-        let to = to_ref.clone().into_inner();
+        let CreateConnection::V1(creation) = request;
 
         let connection = Connection::builder()
-            .from_ref(from)
-            .to_ref(to)
-            .nature(nature.clone())
+            .from_ref(creation.from_ref.clone().into_inner())
+            .to_ref(creation.to_ref.clone().into_inner())
+            .nature(creation.nature.clone())
             .build();
 
         context
-            .emit(ConnectionEvents::ConnectionCreated(connection.clone()))
+            .emit(ConnectionEvents::ConnectionCreated(
+                ConnectionCreated::builder_v1()
+                    .connection(connection.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        let ref_token = RefToken::new(Ref::connection(connection.id));
+
         Ok(ConnectionResponse::ConnectionCreated(
-            Response::new(connection).with_ref_token(ref_token),
+            ConnectionCreatedResponse::builder_v1()
+                .connection(connection)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn get(
         context: &ProjectContext,
-        selector: &GetConnection,
+        request: &GetConnection,
     ) -> Result<ConnectionResponse, ConnectionError> {
-        let id = selector.key.resolve()?;
+        let GetConnection::V1(lookup) = request;
+        let id = lookup.key.resolve()?;
         let connection = ConnectionRepo::new(context)
             .get(&id)
             .await?
             .ok_or(ConnectionError::NotFound(id))?;
-        let ref_token = RefToken::new(Ref::connection(connection.id));
         Ok(ConnectionResponse::ConnectionDetails(
-            Response::new(connection).with_ref_token(ref_token),
+            ConnectionDetailsResponse::builder_v1()
+                .connection(connection)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn list(
         context: &ProjectContext,
-        ListConnections { entity, filters }: &ListConnections,
+        request: &ListConnections,
     ) -> Result<ConnectionResponse, ConnectionError> {
-        let ref_json = entity
+        let ListConnections::V1(listing) = request;
+        let ref_json = listing
+            .entity
             .as_ref()
             .map(|token| {
                 serde_json::to_string(&token.clone().into_inner())
@@ -57,35 +65,47 @@ impl ConnectionService {
             .transpose()?;
 
         let listed = ConnectionRepo::new(context)
-            .list(ref_json.as_deref(), filters)
+            .list(ref_json.as_deref(), &listing.filters)
             .await?;
         if listed.total == 0 {
             Ok(ConnectionResponse::NoConnections)
         } else {
-            Ok(ConnectionResponse::Connections(listed.map(|c| {
-                let ref_token = RefToken::new(Ref::connection(c.id));
-                Response::new(c).with_ref_token(ref_token)
-            })))
+            Ok(ConnectionResponse::Connections(
+                ConnectionsResponse::builder_v1()
+                    .items(listed.items)
+                    .total(listed.total)
+                    .build()
+                    .into(),
+            ))
         }
     }
 
     pub async fn remove(
         context: &ProjectContext,
-        selector: &RemoveConnection,
+        request: &RemoveConnection,
     ) -> Result<ConnectionResponse, ConnectionError> {
+        let RemoveConnection::V1(removal) = request;
         if ConnectionRepo::new(context)
-            .get(&selector.id)
+            .get(&removal.id)
             .await?
             .is_none()
         {
-            return Err(ConnectionError::NotFound(selector.id));
+            return Err(ConnectionError::NotFound(removal.id));
         }
 
         context
-            .emit(ConnectionEvents::ConnectionRemoved(ConnectionRemoved {
-                id: selector.id,
-            }))
+            .emit(ConnectionEvents::ConnectionRemoved(
+                ConnectionRemoved::builder_v1()
+                    .id(removal.id)
+                    .build()
+                    .into(),
+            ))
             .await?;
-        Ok(ConnectionResponse::ConnectionRemoved(selector.id))
+        Ok(ConnectionResponse::ConnectionRemoved(
+            ConnectionRemovedResponse::builder_v1()
+                .id(removal.id)
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/connection/store.rs
+++ b/crates/oneiros-engine/src/domains/connection/store.rs
@@ -15,8 +15,14 @@ impl<'a> ConnectionStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Connection(connection_event)) = &event.data {
             match connection_event {
-                ConnectionEvents::ConnectionCreated(connection) => self.insert(connection)?,
-                ConnectionEvents::ConnectionRemoved(removed) => self.remove(&removed.id)?,
+                ConnectionEvents::ConnectionCreated(created) => {
+                    let connection = created.current()?.connection;
+                    self.write_connection(&connection)?
+                }
+                ConnectionEvents::ConnectionRemoved(removed) => {
+                    let current = removed.current()?;
+                    self.remove(&current.id)?
+                }
             }
         }
         Ok(())
@@ -117,7 +123,7 @@ impl<'a> ConnectionStore<'a> {
         Ok(connections)
     }
 
-    fn insert(&self, connection: &Connection) -> Result<(), EventError> {
+    fn write_connection(&self, connection: &Connection) -> Result<(), EventError> {
         self.conn.execute(
             "INSERT OR REPLACE INTO connections
              (id, from_ref, to_ref, nature, created_at)

--- a/crates/oneiros-engine/src/domains/connection/view.rs
+++ b/crates/oneiros-engine/src/domains/connection/view.rs
@@ -14,35 +14,46 @@ impl<'a> ConnectionView<'a> {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            ConnectionResponse::ConnectionCreated(wrapped) => {
-                let ref_token = RefToken::from(Ref::connection(wrapped.data.id));
+            ConnectionResponse::ConnectionCreated(ConnectionCreatedResponse::V1(created)) => {
+                let ref_token = RefToken::from(Ref::connection(created.connection.id));
                 McpResponse::new(format!(
                     "Connection created.\n\n**nature:** {}\n**from:** {}\n**to:** {}\n**ref:** {}",
-                    wrapped.data.nature, wrapped.data.from_ref, wrapped.data.to_ref, ref_token
+                    created.connection.nature,
+                    created.connection.from_ref,
+                    created.connection.to_ref,
+                    ref_token
                 ))
                 .hint(Hint::suggest("search-query", "Search for related entities"))
             }
-            ConnectionResponse::ConnectionDetails(wrapped) => McpResponse::new(format!(
-                "# Connection\n\n**nature:** {}\n**from:** {}\n**to:** {}\n**created:** {}\n",
-                wrapped.data.nature,
-                wrapped.data.from_ref,
-                wrapped.data.to_ref,
-                wrapped.data.created_at
-            ))
-            .hint(Hint::suggest("search-query", "Search for related entities")),
-            ConnectionResponse::Connections(listed) => {
+            ConnectionResponse::ConnectionDetails(ConnectionDetailsResponse::V1(details)) => {
+                McpResponse::new(format!(
+                    "# Connection\n\n**nature:** {}\n**from:** {}\n**to:** {}\n**created:** {}\n",
+                    details.connection.nature,
+                    details.connection.from_ref,
+                    details.connection.to_ref,
+                    details.connection.created_at
+                ))
+                .hint(Hint::suggest("search-query", "Search for related entities"))
+            }
+            ConnectionResponse::Connections(ConnectionsResponse::V1(listed)) => {
                 let title = match self.request {
-                    ConnectionRequest::ListConnections(listing) => match &listing.entity {
-                        Some(entity) => format!("# Connections — {entity}\n\n"),
-                        None => "# Connections\n\n".to_string(),
-                    },
+                    ConnectionRequest::ListConnections(ListConnections::V1(listing)) => {
+                        match &listing.entity {
+                            Some(entity) => format!("# Connections — {entity}\n\n"),
+                            None => "# Connections\n\n".to_string(),
+                        }
+                    }
                     _ => "# Connections\n\n".to_string(),
                 };
-                let mut md = format!("{title}{} of {} total\n\n", listed.len(), listed.total);
-                for wrapped in &listed.items {
+                let mut md = format!(
+                    "{title}{} of {} total\n\n",
+                    listed.items.len(),
+                    listed.total
+                );
+                for item in &listed.items {
                     md.push_str(&format!(
                         "- **{}** {} → {}\n",
-                        wrapped.data.nature, wrapped.data.from_ref, wrapped.data.to_ref
+                        item.nature, item.from_ref, item.to_ref
                     ));
                 }
                 McpResponse::new(md)
@@ -53,83 +64,67 @@ impl<'a> ConnectionView<'a> {
                     .hint(Hint::suggest("search-query", "Search for related entities"))
             }
             ConnectionResponse::NoConnections => McpResponse::new("No connections yet."),
-            ConnectionResponse::ConnectionRemoved(id) => {
-                McpResponse::new(format!("Connection removed: {id}"))
+            ConnectionResponse::ConnectionRemoved(ConnectionRemovedResponse::V1(removed)) => {
+                McpResponse::new(format!("Connection removed: {}", removed.id))
             }
         }
     }
 
     pub fn render(self) -> Rendered<ConnectionResponse> {
         match self.response {
-            ConnectionResponse::ConnectionCreated(wrapped) => {
-                let subject = wrapped
-                    .meta()
-                    .ref_token()
-                    .map(|ref_token| {
-                        format!(
-                            "{} Connection recorded: {}",
-                            "✓".success(),
-                            ref_token.muted()
-                        )
-                    })
-                    .unwrap_or_default();
-                let hints = match wrapped.meta().ref_token() {
-                    Some(ref_token) => {
-                        HintSet::mutation(MutationHints::builder().ref_token(ref_token).build())
-                    }
-                    None => HintSet::None,
-                };
+            ConnectionResponse::ConnectionCreated(ConnectionCreatedResponse::V1(created)) => {
+                let ref_token = RefToken::from(Ref::connection(created.connection.id));
+                let subject = format!(
+                    "{} Connection recorded: {}",
+                    "✓".success(),
+                    ref_token.clone().muted()
+                );
+                let hints =
+                    HintSet::mutation(MutationHints::builder().ref_token(ref_token).build());
                 Rendered::new(
-                    ConnectionResponse::ConnectionCreated(wrapped),
+                    ConnectionResponse::ConnectionCreated(ConnectionCreatedResponse::V1(created)),
                     subject,
                     String::new(),
                 )
                 .with_hints(hints)
             }
-            ConnectionResponse::ConnectionDetails(wrapped) => {
-                let prompt = Detail::new(wrapped.data.nature.to_string())
-                    .field("from:", wrapped.data.from_ref.to_string())
-                    .field("to:", wrapped.data.to_ref.to_string())
+            ConnectionResponse::ConnectionDetails(ConnectionDetailsResponse::V1(details)) => {
+                let prompt = Detail::new(details.connection.nature.to_string())
+                    .field("from:", details.connection.from_ref.to_string())
+                    .field("to:", details.connection.to_ref.to_string())
                     .to_string();
-                let hints = match wrapped.meta().ref_token() {
-                    Some(ref_token) => {
-                        HintSet::mutation(MutationHints::builder().ref_token(ref_token).build())
-                    }
-                    None => HintSet::None,
-                };
+                let ref_token = RefToken::from(Ref::connection(details.connection.id));
+                let hints =
+                    HintSet::mutation(MutationHints::builder().ref_token(ref_token).build());
                 Rendered::new(
-                    ConnectionResponse::ConnectionDetails(wrapped),
+                    ConnectionResponse::ConnectionDetails(ConnectionDetailsResponse::V1(details)),
                     prompt,
                     String::new(),
                 )
                 .with_hints(hints)
             }
-            ConnectionResponse::Connections(listed) => {
+            ConnectionResponse::Connections(ConnectionsResponse::V1(listed)) => {
                 let mut table = Table::new(vec![
                     Column::key("nature", "Nature"),
                     Column::key("from_ref", "From"),
                     Column::key("to_ref", "To"),
                     Column::key("ref_token", "Ref"),
                 ]);
-                for wrapped in &listed.items {
-                    let ref_token = wrapped
-                        .meta()
-                        .ref_token()
-                        .map(|t| t.to_string())
-                        .unwrap_or_default();
+                for item in &listed.items {
+                    let ref_token = RefToken::from(Ref::connection(item.id));
                     table.push_row(vec![
-                        wrapped.data.nature.to_string(),
-                        wrapped.data.from_ref.to_string(),
-                        wrapped.data.to_ref.to_string(),
-                        ref_token,
+                        item.nature.to_string(),
+                        item.from_ref.to_string(),
+                        item.to_ref.to_string(),
+                        ref_token.to_string(),
                     ]);
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
                 Rendered::new(
-                    ConnectionResponse::Connections(listed),
+                    ConnectionResponse::Connections(ConnectionsResponse::V1(listed)),
                     prompt,
                     String::new(),
                 )
@@ -139,10 +134,11 @@ impl<'a> ConnectionView<'a> {
                 format!("{}", "No connections.".muted()),
                 String::new(),
             ),
-            ConnectionResponse::ConnectionRemoved(id) => {
-                let prompt = Confirmation::new("Connection", id.to_string(), "removed").to_string();
+            ConnectionResponse::ConnectionRemoved(ConnectionRemovedResponse::V1(removed)) => {
+                let prompt =
+                    Confirmation::new("Connection", removed.id.to_string(), "removed").to_string();
                 Rendered::new(
-                    ConnectionResponse::ConnectionRemoved(id),
+                    ConnectionResponse::ConnectionRemoved(ConnectionRemovedResponse::V1(removed)),
                     prompt,
                     String::new(),
                 )

--- a/crates/oneiros-engine/src/domains/continuity/client.rs
+++ b/crates/oneiros-engine/src/domains/continuity/client.rs
@@ -75,11 +75,12 @@ impl<'a> ContinuityClient<'a> {
     }
 
     /// Run the sense continuity operation for the given agent with the provided content.
-    pub async fn sense(&self, selector: &SenseContent) -> Result<ContinuityResponse, ClientError> {
+    pub async fn sense(&self, sensing: &SenseContent) -> Result<ContinuityResponse, ClientError> {
+        let SenseContent::V1(sense) = sensing;
         self.client
             .post(
-                &format!("/continuity/{agent}/sense", agent = selector.agent),
-                selector,
+                &format!("/continuity/{agent}/sense", agent = sense.agent),
+                sensing,
             )
             .await
     }

--- a/crates/oneiros-engine/src/domains/continuity/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/continuity/features/cli.rs
@@ -25,21 +25,36 @@ impl ContinuityCommands {
         let continuity_client = ContinuityClient::new(&client);
 
         let result = match self {
-            ContinuityCommands::Wake(wake) => continuity_client.wake(&wake.agent).await?,
-            ContinuityCommands::Dream(dream) => continuity_client.dream(&dream.agent).await?,
-            ContinuityCommands::Introspect(introspect) => {
-                continuity_client.introspect(&introspect.agent).await?
+            ContinuityCommands::Wake(wake) => {
+                let WakeAgent::V1(wake) = wake;
+                continuity_client.wake(&wake.agent).await?
             }
-            ContinuityCommands::Reflect(reflect) => {
-                continuity_client.reflect(&reflect.agent).await?
+            ContinuityCommands::Dream(dream) => {
+                let DreamAgent::V1(dream) = dream;
+                continuity_client.dream(&dream.agent).await?
             }
-            ContinuityCommands::Sense(sense) => continuity_client.sense(sense).await?,
-            ContinuityCommands::Sleep(sleep) => continuity_client.sleep(&sleep.agent).await?,
-            ContinuityCommands::Guidebook(guidebook) => {
-                continuity_client.guidebook(&guidebook.agent).await?
+            ContinuityCommands::Introspect(introspecting) => {
+                let IntrospectAgent::V1(introspecting) = introspecting;
+                continuity_client.introspect(&introspecting.agent).await?
             }
-            ContinuityCommands::Emerge(emerge) => continuity_client.emerge(emerge).await?,
-            ContinuityCommands::Recede(recede) => continuity_client.recede(&recede.agent).await?,
+            ContinuityCommands::Reflect(reflecting) => {
+                let ReflectAgent::V1(reflecting) = reflecting;
+                continuity_client.reflect(&reflecting.agent).await?
+            }
+            ContinuityCommands::Sense(sensing) => continuity_client.sense(sensing).await?,
+            ContinuityCommands::Sleep(sleeping) => {
+                let SleepAgent::V1(sleeping) = sleeping;
+                continuity_client.sleep(&sleeping.agent).await?
+            }
+            ContinuityCommands::Guidebook(lookup) => {
+                let GuidebookAgent::V1(lookup) = lookup;
+                continuity_client.guidebook(&lookup.agent).await?
+            }
+            ContinuityCommands::Emerge(emerging) => continuity_client.emerge(emerging).await?,
+            ContinuityCommands::Recede(receding) => {
+                let RecedeAgent::V1(receding) = receding;
+                continuity_client.recede(&receding.agent).await?
+            }
             ContinuityCommands::Status(_) => continuity_client.status().await?,
         };
 

--- a/crates/oneiros-engine/src/domains/continuity/features/http.rs
+++ b/crates/oneiros-engine/src/domains/continuity/features/http.rs
@@ -95,7 +95,11 @@ async fn recede(
     Path(agent): Path<AgentName>,
 ) -> Result<Json<ContinuityResponse>, ContinuityError> {
     Ok(Json(
-        ContinuityService::recede(&context, &RecedeAgent::builder().agent(agent).build()).await?,
+        ContinuityService::recede(
+            &context,
+            &RecedeAgent::builder_v1().agent(agent).build().into(),
+        )
+        .await?,
     ))
 }
 
@@ -114,7 +118,7 @@ async fn wake(
     Ok(Json(
         ContinuityService::wake(
             &context,
-            &WakeAgent::builder().agent(agent).build(),
+            &WakeAgent::builder_v1().agent(agent).build().into(),
             &overrides,
         )
         .await?,
@@ -129,7 +133,7 @@ async fn dream(
     Ok(Json(
         ContinuityService::dream(
             &context,
-            &DreamAgent::builder().agent(agent).build(),
+            &DreamAgent::builder_v1().agent(agent).build().into(),
             &overrides,
         )
         .await?,
@@ -144,7 +148,7 @@ async fn introspect(
     Ok(Json(
         ContinuityService::introspect(
             &context,
-            &IntrospectAgent::builder().agent(agent).build(),
+            &IntrospectAgent::builder_v1().agent(agent).build().into(),
             &overrides,
         )
         .await?,
@@ -159,7 +163,7 @@ async fn reflect(
     Ok(Json(
         ContinuityService::reflect(
             &context,
-            &ReflectAgent::builder().agent(agent).build(),
+            &ReflectAgent::builder_v1().agent(agent).build().into(),
             &overrides,
         )
         .await?,
@@ -171,12 +175,14 @@ async fn sense(
     Path(agent): Path<AgentName>,
     Json(body): Json<SenseContent>,
 ) -> Result<Json<ContinuityResponse>, ContinuityError> {
-    let selector = SenseContent::builder()
+    let SenseContent::V1(sensing) = body;
+    let request: SenseContent = SenseContent::builder_v1()
         .agent(agent)
-        .content(body.content)
-        .build();
+        .content(sensing.content)
+        .build()
+        .into();
     Ok(Json(
-        ContinuityService::sense(&context, &selector, &DreamOverrides::default()).await?,
+        ContinuityService::sense(&context, &request, &DreamOverrides::default()).await?,
     ))
 }
 
@@ -188,7 +194,7 @@ async fn sleep(
     Ok(Json(
         ContinuityService::sleep(
             &context,
-            &SleepAgent::builder().agent(agent).build(),
+            &SleepAgent::builder_v1().agent(agent).build().into(),
             &overrides,
         )
         .await?,
@@ -202,7 +208,7 @@ async fn guidebook(
 ) -> Result<Json<ContinuityResponse>, ContinuityError> {
     Ok(Json(ContinuityService::guidebook(
         &context,
-        &GuidebookAgent::builder().agent(agent).build(),
+        &GuidebookAgent::builder_v1().agent(agent).build().into(),
         &overrides,
     )?))
 }

--- a/crates/oneiros-engine/src/domains/continuity/presenter.rs
+++ b/crates/oneiros-engine/src/domains/continuity/presenter.rs
@@ -17,7 +17,8 @@ impl ContinuityPresenter {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            ContinuityResponse::Status(table) => {
+            ContinuityResponse::Status(StatusResponse::V1(details)) => {
+                let table = &details.table;
                 let mut md = String::from("# Agent Status\n\n");
                 md.push_str("| Agent | Cognitions | Memories | Experiences |\n");
                 md.push_str("|-------|------------|----------|-------------|\n");
@@ -41,20 +42,20 @@ impl ContinuityPresenter {
     /// Render this continuity response into all available forms.
     pub fn render(self) -> Rendered<ContinuityResponse> {
         let (prompt, text, hints) = match &self.response {
-            ContinuityResponse::Dreaming(context) | ContinuityResponse::Emerged(context) => {
+            ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => {
+                let context = &details.context;
                 let template = DreamTemplate::new(context).to_string();
-                let text = match &self.response {
-                    ContinuityResponse::Dreaming(_) => {
-                        format!("Dreaming as {}...", context.agent.name)
-                    }
-                    ContinuityResponse::Emerged(_) => {
-                        format!("Emerged as {}.", context.agent.name)
-                    }
-                    _ => unreachable!(),
-                };
+                let text = format!("Dreaming as {}...", context.agent.name);
                 (template, text, HintSet::None)
             }
-            ContinuityResponse::Waking(context) => {
+            ContinuityResponse::Emerged(EmergedResponse::V1(details)) => {
+                let context = &details.context;
+                let template = DreamTemplate::new(context).to_string();
+                let text = format!("Emerged as {}.", context.agent.name);
+                (template, text, HintSet::None)
+            }
+            ContinuityResponse::Waking(WakingResponse::V1(details)) => {
+                let context = &details.context;
                 let template = DreamTemplate::new(context).to_string();
                 let pressures = context
                     .pressures
@@ -73,12 +74,16 @@ impl ContinuityPresenter {
                     hints,
                 )
             }
-            ContinuityResponse::Status(table) => (
-                table.to_string(),
-                format!("{} agents.", table.agents.len()),
-                HintSet::None,
-            ),
-            ContinuityResponse::Introspecting(context) => {
+            ContinuityResponse::Status(StatusResponse::V1(details)) => {
+                let table = &details.table;
+                (
+                    table.to_string(),
+                    format!("{} agents.", table.agents.len()),
+                    HintSet::None,
+                )
+            }
+            ContinuityResponse::Introspecting(IntrospectingResponse::V1(details)) => {
+                let context = &details.context;
                 let pressures = Self::relevant_pressures(context);
                 (
                     IntrospectTemplate::new(&context.agent, pressures).to_string(),
@@ -86,7 +91,8 @@ impl ContinuityPresenter {
                     HintSet::None,
                 )
             }
-            ContinuityResponse::Reflecting(context) => {
+            ContinuityResponse::Reflecting(ReflectingResponse::V1(details)) => {
+                let context = &details.context;
                 let pressures = Self::relevant_pressures(context);
                 let hints = HintSet::reflect(
                     ReflectHints::builder()
@@ -99,7 +105,8 @@ impl ContinuityPresenter {
                     hints,
                 )
             }
-            ContinuityResponse::Sleeping(context) => {
+            ContinuityResponse::Sleeping(SleepingResponse::V1(details)) => {
+                let context = &details.context;
                 let pressures = Self::relevant_pressures(context);
                 (
                     IntrospectTemplate::new(&context.agent, pressures).to_string(),
@@ -107,17 +114,20 @@ impl ContinuityPresenter {
                     HintSet::None,
                 )
             }
-            ContinuityResponse::Guidebook(context) => (
-                GuidebookTemplate::new(context).to_string(),
-                format!("Guidebook for {}.", context.agent.name),
-                HintSet::None,
-            ),
-            ContinuityResponse::Receded(name) => (
+            ContinuityResponse::Guidebook(GuidebookResponse::V1(details)) => {
+                let context = &details.context;
+                (
+                    GuidebookTemplate::new(context).to_string(),
+                    format!("Guidebook for {}.", context.agent.name),
+                    HintSet::None,
+                )
+            }
+            ContinuityResponse::Receded(RecededResponse::V1(details)) => (
                 format!(
                     "Agent '{}' has receded. Their cognitions, memories, and experiences remain in the record, but they will no longer participate in active sessions.",
-                    name
+                    details.agent
                 ),
-                format!("Agent {} has receded.", name),
+                format!("Agent {} has receded.", details.agent),
                 HintSet::None,
             ),
         };

--- a/crates/oneiros-engine/src/domains/continuity/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/continuity/protocol/events.rs
@@ -7,11 +7,57 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = ContinuityEventsType, display = "kebab-case")]
 pub enum ContinuityEvents {
-    Dreamed(ContinuityEvent),
-    Introspected(ContinuityEvent),
-    Reflected(ContinuityEvent),
-    Sensed(SensedEvent),
-    Slept(ContinuityEvent),
+    Dreamed(Dreamed),
+    Introspected(Introspected),
+    Reflected(Reflected),
+    Sensed(Sensed),
+    Slept(Slept),
+}
+
+versioned! {
+    pub enum Dreamed {
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+            pub created_at: Timestamp,
+        }
+    }
+}
+
+versioned! {
+    pub enum Introspected {
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+            pub created_at: Timestamp,
+        }
+    }
+}
+
+versioned! {
+    pub enum Reflected {
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+            pub created_at: Timestamp,
+        }
+    }
+}
+
+versioned! {
+    pub enum Sensed {
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+            #[builder(into)] pub content: Content,
+            pub created_at: Timestamp,
+        }
+    }
+}
+
+versioned! {
+    pub enum Slept {
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+            pub created_at: Timestamp,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -31,17 +77,4 @@ mod tests {
             assert_eq!(&event_type.to_string(), expectation);
         }
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ContinuityEvent {
-    pub agent: AgentName,
-    pub created_at: Timestamp,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SensedEvent {
-    pub agent: AgentName,
-    pub content: Content,
-    pub created_at: Timestamp,
 }

--- a/crates/oneiros-engine/src/domains/continuity/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/continuity/protocol/requests.rs
@@ -1,78 +1,114 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct WakeAgent {
-    #[builder(into)]
-    pub agent: AgentName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum WakeAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct DreamAgent {
-    #[builder(into)]
-    pub agent: AgentName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum DreamAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct IntrospectAgent {
-    #[builder(into)]
-    pub agent: AgentName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum IntrospectAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ReflectAgent {
-    #[builder(into)]
-    pub agent: AgentName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ReflectAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct SenseContent {
-    #[builder(into)]
-    pub agent: AgentName,
-    #[builder(into)]
-    pub content: Content,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SenseContent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+            #[builder(into)] pub content: Content,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct SleepAgent {
-    #[builder(into)]
-    pub agent: AgentName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SleepAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GuidebookAgent {
-    #[builder(into)]
-    pub agent: AgentName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GuidebookAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct EmergeAgent {
-    #[builder(into)]
-    pub name: AgentName,
-    #[builder(into)]
-    pub persona: PersonaName,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub description: Description,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum EmergeAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: AgentName,
+            #[builder(into)] pub persona: PersonaName,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)] pub description: Description,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct RecedeAgent {
-    #[builder(into)]
-    pub agent: AgentName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum RecedeAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Default, Serialize, Deserialize, JsonSchema, Args)]
-pub struct StatusAgent {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum StatusAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/continuity/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/continuity/protocol/responses.rs
@@ -1,19 +1,101 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = ContinuityResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ContinuityResponse {
-    Emerged(DreamContext),
-    Waking(DreamContext),
-    Dreaming(DreamContext),
-    Introspecting(DreamContext),
-    Reflecting(DreamContext),
-    Sleeping(DreamContext),
-    Receded(AgentName),
-    Status(AgentActivityTable),
-    Guidebook(DreamContext),
+    Emerged(EmergedResponse),
+    Waking(WakingResponse),
+    Dreaming(DreamingResponse),
+    Introspecting(IntrospectingResponse),
+    Reflecting(ReflectingResponse),
+    Sleeping(SleepingResponse),
+    Receded(RecededResponse),
+    Status(StatusResponse),
+    Guidebook(GuidebookResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum EmergedResponse {
+        V1 => {
+            pub context: DreamContext,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum WakingResponse {
+        V1 => {
+            pub context: DreamContext,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum DreamingResponse {
+        V1 => {
+            pub context: DreamContext,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum IntrospectingResponse {
+        V1 => {
+            pub context: DreamContext,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ReflectingResponse {
+        V1 => {
+            pub context: DreamContext,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SleepingResponse {
+        V1 => {
+            pub context: DreamContext,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GuidebookResponse {
+        V1 => {
+            pub context: DreamContext,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum RecededResponse {
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum StatusResponse {
+        V1 => {
+            pub table: AgentActivityTable,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/continuity/service.rs
+++ b/crates/oneiros-engine/src/domains/continuity/service.rs
@@ -24,25 +24,23 @@ impl ContinuityService {
     /// Emerge — create an agent and immediately activate its continuity.
     pub async fn emerge(
         context: &ProjectContext,
-        EmergeAgent {
-            name,
-            persona,
-            description,
-        }: &EmergeAgent,
+        request: &EmergeAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
+        let EmergeAgent::V1(emerging) = request;
         let created = AgentService::create(
             context,
-            &CreateAgent::builder()
-                .name(name.clone())
-                .persona(persona.clone())
-                .description(description.clone())
-                .build(),
+            &CreateAgent::builder_v1()
+                .name(emerging.name.clone())
+                .persona(emerging.persona.clone())
+                .description(emerging.description.clone())
+                .build()
+                .into(),
         )
         .await?;
 
         let agent_name = match created {
-            AgentResponse::AgentCreated(n) => n,
+            AgentResponse::AgentCreated(AgentCreatedResponse::V1(created)) => created.agent.name,
             other => {
                 return Err(ContinuityError::UnexpectedResponse(format!("{other:?}")));
             }
@@ -51,31 +49,45 @@ impl ContinuityService {
         // Wake activates continuity; then gather the full context for the response.
         Self::wake(
             context,
-            &WakeAgent::builder().agent(agent_name.clone()).build(),
+            &WakeAgent::builder_v1()
+                .agent(agent_name.clone())
+                .build()
+                .into(),
             overrides,
         )
         .await?;
         let dream = Self::gather_context(context, &agent_name, overrides)?;
-        Ok(ContinuityResponse::Emerged(dream))
+        Ok(ContinuityResponse::Emerged(
+            EmergedResponse::builder_v1().context(dream).build().into(),
+        ))
     }
 
     /// Recede — retire an agent, ending its continuity.
     pub async fn recede(
         context: &ProjectContext,
-        selector: &RecedeAgent,
+        request: &RecedeAgent,
     ) -> Result<ContinuityResponse, ContinuityError> {
+        let RecedeAgent::V1(receding) = request;
         AgentService::remove(
             context,
-            &RemoveAgent::builder().name(selector.agent.clone()).build(),
+            &RemoveAgent::builder_v1()
+                .name(receding.agent.clone())
+                .build()
+                .into(),
         )
         .await?;
-        Ok(ContinuityResponse::Receded(selector.agent.clone()))
+        Ok(ContinuityResponse::Receded(
+            RecededResponse::builder_v1()
+                .agent(receding.agent.clone())
+                .build()
+                .into(),
+        ))
     }
 
     /// Status — cross-agent activity overview.
     pub fn status(
         context: &ProjectContext,
-        _selector: &StatusAgent,
+        _request: &StatusAgent,
     ) -> Result<ContinuityResponse, ContinuityError> {
         let db = context.db()?;
         let agents = AgentStore::new(&db).list()?;
@@ -138,118 +150,163 @@ impl ContinuityService {
             });
         }
 
-        Ok(ContinuityResponse::Status(AgentActivityTable {
-            agents: rows,
-        }))
+        Ok(ContinuityResponse::Status(
+            StatusResponse::builder_v1()
+                .table(AgentActivityTable { agents: rows })
+                .build()
+                .into(),
+        ))
     }
 
     /// Wake — restore an agent's full cognitive context (initial session start).
     pub async fn wake(
         context: &ProjectContext,
-        selector: &WakeAgent,
+        request: &WakeAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
-        let dream = Self::gather_context(context, &selector.agent, overrides)?;
+        let WakeAgent::V1(wake) = request;
+        let dream = Self::gather_context(context, &wake.agent, overrides)?;
 
         context
-            .emit(ContinuityEvents::Dreamed(ContinuityEvent {
-                agent: selector.agent.clone(),
-                created_at: Timestamp::now(),
-            }))
+            .emit(ContinuityEvents::Dreamed(
+                Dreamed::builder_v1()
+                    .agent(wake.agent.clone())
+                    .created_at(Timestamp::now())
+                    .build()
+                    .into(),
+            ))
             .await?;
 
-        Ok(ContinuityResponse::Waking(dream))
+        Ok(ContinuityResponse::Waking(
+            WakingResponse::builder_v1().context(dream).build().into(),
+        ))
     }
 
     /// Dream — restore an agent's full cognitive context.
     pub async fn dream(
         context: &ProjectContext,
-        selector: &DreamAgent,
+        request: &DreamAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
-        let dream = Self::gather_context(context, &selector.agent, overrides)?;
+        let DreamAgent::V1(dreaming) = request;
+        let dream = Self::gather_context(context, &dreaming.agent, overrides)?;
 
         context
-            .emit(ContinuityEvents::Dreamed(ContinuityEvent {
-                agent: selector.agent.clone(),
-                created_at: Timestamp::now(),
-            }))
+            .emit(ContinuityEvents::Dreamed(
+                Dreamed::builder_v1()
+                    .agent(dreaming.agent.clone())
+                    .created_at(Timestamp::now())
+                    .build()
+                    .into(),
+            ))
             .await?;
 
-        Ok(ContinuityResponse::Dreaming(dream))
+        Ok(ContinuityResponse::Dreaming(
+            DreamingResponse::builder_v1().context(dream).build().into(),
+        ))
     }
 
     /// Introspect — look inward, consolidate cognitive state.
     pub async fn introspect(
         context: &ProjectContext,
-        selector: &IntrospectAgent,
+        request: &IntrospectAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
-        let dream = Self::gather_context(context, &selector.agent, overrides)?;
+        let IntrospectAgent::V1(introspecting) = request;
+        let dream = Self::gather_context(context, &introspecting.agent, overrides)?;
 
         context
-            .emit(ContinuityEvents::Introspected(ContinuityEvent {
-                agent: selector.agent.clone(),
-                created_at: Timestamp::now(),
-            }))
+            .emit(ContinuityEvents::Introspected(
+                Introspected::builder_v1()
+                    .agent(introspecting.agent.clone())
+                    .created_at(Timestamp::now())
+                    .build()
+                    .into(),
+            ))
             .await?;
 
-        Ok(ContinuityResponse::Introspecting(dream))
+        Ok(ContinuityResponse::Introspecting(
+            IntrospectingResponse::builder_v1()
+                .context(dream)
+                .build()
+                .into(),
+        ))
     }
 
     /// Reflect — pause on something significant.
     pub async fn reflect(
         context: &ProjectContext,
-        selector: &ReflectAgent,
+        request: &ReflectAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
-        let dream = Self::gather_context(context, &selector.agent, overrides)?;
+        let ReflectAgent::V1(reflecting) = request;
+        let dream = Self::gather_context(context, &reflecting.agent, overrides)?;
 
         context
-            .emit(ContinuityEvents::Reflected(ContinuityEvent {
-                agent: selector.agent.clone(),
-                created_at: Timestamp::now(),
-            }))
+            .emit(ContinuityEvents::Reflected(
+                Reflected::builder_v1()
+                    .agent(reflecting.agent.clone())
+                    .created_at(Timestamp::now())
+                    .build()
+                    .into(),
+            ))
             .await?;
 
-        Ok(ContinuityResponse::Reflecting(dream))
+        Ok(ContinuityResponse::Reflecting(
+            ReflectingResponse::builder_v1()
+                .context(dream)
+                .build()
+                .into(),
+        ))
     }
 
     /// Sense — receive and interpret something from outside.
     pub async fn sense(
         context: &ProjectContext,
-        selector: &SenseContent,
+        request: &SenseContent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
-        let dream = Self::gather_context(context, &selector.agent, overrides)?;
+        let SenseContent::V1(sensing) = request;
+        let dream = Self::gather_context(context, &sensing.agent, overrides)?;
 
         context
-            .emit(ContinuityEvents::Sensed(SensedEvent {
-                agent: selector.agent.clone(),
-                content: Content::new(selector.content.as_str()),
-                created_at: Timestamp::now(),
-            }))
+            .emit(ContinuityEvents::Sensed(
+                Sensed::builder_v1()
+                    .agent(sensing.agent.clone())
+                    .content(Content::new(sensing.content.as_str()))
+                    .created_at(Timestamp::now())
+                    .build()
+                    .into(),
+            ))
             .await?;
 
-        Ok(ContinuityResponse::Sleeping(dream))
+        Ok(ContinuityResponse::Sleeping(
+            SleepingResponse::builder_v1().context(dream).build().into(),
+        ))
     }
 
     /// Sleep — end a session, capture continuity.
     pub async fn sleep(
         context: &ProjectContext,
-        selector: &SleepAgent,
+        request: &SleepAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
-        let dream = Self::gather_context(context, &selector.agent, overrides)?;
+        let SleepAgent::V1(sleeping) = request;
+        let dream = Self::gather_context(context, &sleeping.agent, overrides)?;
 
         context
-            .emit(ContinuityEvents::Slept(ContinuityEvent {
-                agent: selector.agent.clone(),
-                created_at: Timestamp::now(),
-            }))
+            .emit(ContinuityEvents::Slept(
+                Slept::builder_v1()
+                    .agent(sleeping.agent.clone())
+                    .created_at(Timestamp::now())
+                    .build()
+                    .into(),
+            ))
             .await?;
 
-        Ok(ContinuityResponse::Sleeping(dream))
+        Ok(ContinuityResponse::Sleeping(
+            SleepingResponse::builder_v1().context(dream).build().into(),
+        ))
     }
 
     /// Guidebook — gather cognitive context without emitting an event.
@@ -258,11 +315,17 @@ impl ContinuityService {
     /// sensations, levels, urges) without marking a continuity transition.
     pub fn guidebook(
         context: &ProjectContext,
-        selector: &GuidebookAgent,
+        request: &GuidebookAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
-        let dream = Self::gather_context(context, &selector.agent, overrides)?;
-        Ok(ContinuityResponse::Guidebook(dream))
+        let GuidebookAgent::V1(lookup) = request;
+        let dream = Self::gather_context(context, &lookup.agent, overrides)?;
+        Ok(ContinuityResponse::Guidebook(
+            GuidebookResponse::builder_v1()
+                .context(dream)
+                .build()
+                .into(),
+        ))
     }
 
     /// Gather the full cognitive context for an agent.

--- a/crates/oneiros-engine/src/domains/doctor/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/doctor/protocol/responses.rs
@@ -66,5 +66,14 @@ pub enum DoctorCheck {
 #[kinded(kind = DoctorResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum DoctorResponse {
-    CheckupStatus(Vec<DoctorCheck>),
+    CheckupStatus(CheckupStatusResponse),
+}
+
+versioned! {
+    #[derive(schemars::JsonSchema)]
+    pub enum CheckupStatusResponse {
+        V1 => {
+            pub checks: Vec<DoctorCheck>,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/doctor/service.rs
+++ b/crates/oneiros-engine/src/domains/doctor/service.rs
@@ -13,7 +13,12 @@ impl DoctorService {
             Ok(db) => db,
             Err(_) => {
                 checks.push(DoctorCheck::NotInitialized);
-                return DoctorResponse::CheckupStatus(checks);
+                return DoctorResponse::CheckupStatus(
+                    CheckupStatusResponse::builder_v1()
+                        .checks(checks)
+                        .build()
+                        .into(),
+                );
             }
         };
 
@@ -29,7 +34,12 @@ impl DoctorService {
 
         if tenant_count == 0 {
             checks.push(DoctorCheck::NotInitialized);
-            return DoctorResponse::CheckupStatus(checks);
+            return DoctorResponse::CheckupStatus(
+                CheckupStatusResponse::builder_v1()
+                    .checks(checks)
+                    .build()
+                    .into(),
+            );
         }
 
         checks.push(DoctorCheck::Initialized);
@@ -121,6 +131,11 @@ impl DoctorService {
             }
         }
 
-        DoctorResponse::CheckupStatus(checks)
+        DoctorResponse::CheckupStatus(
+            CheckupStatusResponse::builder_v1()
+                .checks(checks)
+                .build()
+                .into(),
+        )
     }
 }

--- a/crates/oneiros-engine/src/domains/doctor/view.rs
+++ b/crates/oneiros-engine/src/domains/doctor/view.rs
@@ -13,9 +13,18 @@ impl DoctorView {
 
     pub fn render(self) -> Rendered<DoctorResponse> {
         match self.response {
-            DoctorResponse::CheckupStatus(checks) => {
-                let prompt = Self::checklist(&checks);
-                Rendered::new(DoctorResponse::CheckupStatus(checks), prompt, String::new())
+            DoctorResponse::CheckupStatus(CheckupStatusResponse::V1(details)) => {
+                let prompt = Self::checklist(&details.checks);
+                Rendered::new(
+                    DoctorResponse::CheckupStatus(
+                        CheckupStatusResponse::builder_v1()
+                            .checks(details.checks)
+                            .build()
+                            .into(),
+                    ),
+                    prompt,
+                    String::new(),
+                )
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/event/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/event/protocol/errors.rs
@@ -1,4 +1,4 @@
-use crate::{BlobError, IdParseError, TimestampParseError};
+use crate::{BlobError, IdParseError, TimestampParseError, UpcastError};
 
 /// Event infrastructure errors.
 #[derive(Debug, thiserror::Error)]
@@ -17,6 +17,9 @@ pub enum EventError {
 
     #[error(transparent)]
     Blob(#[from] BlobError),
+
+    #[error(transparent)]
+    Upcast(#[from] UpcastError),
 
     #[error("Import error: {0}")]
     Import(String),

--- a/crates/oneiros-engine/src/domains/experience/client.rs
+++ b/crates/oneiros-engine/src/domains/experience/client.rs
@@ -11,56 +11,60 @@ impl<'a> ExperienceClient<'a> {
 
     pub async fn create(
         &self,
-        request: &CreateExperience,
+        creation: &CreateExperience,
     ) -> Result<ExperienceResponse, ClientError> {
-        self.client.post("/experiences", request).await
+        self.client.post("/experiences", creation).await
     }
 
-    pub async fn list(&self, request: &ListExperiences) -> Result<ExperienceResponse, ClientError> {
+    pub async fn list(&self, listing: &ListExperiences) -> Result<ExperienceResponse, ClientError> {
+        let ListExperiences::V1(listing) = listing;
         let mut params: Vec<(&str, String)> = Vec::new();
 
-        if let Some(a) = &request.agent {
-            params.push(("agent", a.to_string()));
+        if let Some(agent_name) = &listing.agent {
+            params.push(("agent", agent_name.to_string()));
         }
 
-        params.push(("limit", request.filters.limit.to_string()));
-        params.push(("offset", request.filters.offset.to_string()));
+        params.push(("limit", listing.filters.limit.to_string()));
+        params.push(("offset", listing.filters.offset.to_string()));
 
         let query = params
             .iter()
-            .map(|(k, v)| format!("{k}={v}"))
+            .map(|(key, value)| format!("{key}={value}"))
             .collect::<Vec<_>>()
             .join("&");
 
         self.client.get(&format!("/experiences?{query}")).await
     }
 
-    pub async fn get(&self, request: &GetExperience) -> Result<ExperienceResponse, ClientError> {
+    pub async fn get(&self, lookup: &GetExperience) -> Result<ExperienceResponse, ClientError> {
+        let GetExperience::V1(lookup) = lookup;
         self.client
-            .get(&format!("/experiences/{}", request.key))
+            .get(&format!("/experiences/{}", lookup.key))
             .await
     }
 
     pub async fn update_description(
         &self,
-        request: &UpdateExperienceDescription,
+        update: &UpdateExperienceDescription,
     ) -> Result<ExperienceResponse, ClientError> {
+        let UpdateExperienceDescription::V1(update) = update;
         self.client
             .put(
-                &format!("/experiences/{}/description", request.id),
-                &serde_json::json!({ "description": request.description }),
+                &format!("/experiences/{}/description", update.id),
+                &serde_json::json!({ "description": update.description }),
             )
             .await
     }
 
     pub async fn update_sensation(
         &self,
-        request: &UpdateExperienceSensation,
+        update: &UpdateExperienceSensation,
     ) -> Result<ExperienceResponse, ClientError> {
+        let UpdateExperienceSensation::V1(update) = update;
         self.client
             .put(
-                &format!("/experiences/{}/sensation", request.id),
-                &serde_json::json!({ "sensation": request.sensation }),
+                &format!("/experiences/{}/sensation", update.id),
+                &serde_json::json!({ "sensation": update.sensation }),
             )
             .await
     }

--- a/crates/oneiros-engine/src/domains/experience/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/experience/features/cli.rs
@@ -7,6 +7,9 @@ pub enum ExperienceCommands {
     Create(CreateExperience),
     Show(GetExperience),
     List(ListExperiences),
+    /// Update an experience's description and/or sensation. The
+    /// command dispatches to one of the protocol-level update
+    /// requests based on which fields are supplied.
     Update {
         id: String,
         #[arg(long)]
@@ -25,25 +28,19 @@ impl ExperienceCommands {
         let experience_client = ExperienceClient::new(&client);
 
         let (response, request) = match self {
-            ExperienceCommands::Create(creation) => {
-                let response = experience_client.create(creation).await?;
-                (
-                    response,
-                    ExperienceRequest::CreateExperience(creation.clone()),
-                )
-            }
-            ExperienceCommands::Show(get) => {
-                let response = experience_client.get(get).await?;
-                (response, ExperienceRequest::GetExperience(get.clone()))
-            }
-            ExperienceCommands::List(listing) => {
-                let response = experience_client.list(listing).await?;
-                (
-                    response,
-                    ExperienceRequest::ListExperiences(listing.clone()),
-                )
-            }
-            ExperienceCommands::Update {
+            Self::Create(creation) => (
+                experience_client.create(creation).await?,
+                ExperienceRequest::CreateExperience(creation.clone()),
+            ),
+            Self::Show(lookup) => (
+                experience_client.get(lookup).await?,
+                ExperienceRequest::GetExperience(lookup.clone()),
+            ),
+            Self::List(listing) => (
+                experience_client.list(listing).await?,
+                ExperienceRequest::ListExperiences(listing.clone()),
+            ),
+            Self::Update {
                 id,
                 description,
                 sensation,
@@ -52,10 +49,12 @@ impl ExperienceCommands {
                 let mut result: Option<(ExperienceResponse, ExperienceRequest)> = None;
 
                 if let Some(desc) = description {
-                    let update = UpdateExperienceDescription::builder()
-                        .id(id)
-                        .description(Description::new(desc))
-                        .build();
+                    let update: UpdateExperienceDescription =
+                        UpdateExperienceDescription::builder_v1()
+                            .id(id)
+                            .description(Description::new(desc))
+                            .build()
+                            .into();
                     let response = experience_client.update_description(&update).await?;
                     result = Some((
                         response,
@@ -64,10 +63,11 @@ impl ExperienceCommands {
                 }
 
                 if let Some(sens) = sensation {
-                    let update = UpdateExperienceSensation::builder()
+                    let update: UpdateExperienceSensation = UpdateExperienceSensation::builder_v1()
                         .id(id)
                         .sensation(SensationName::new(sens))
-                        .build();
+                        .build()
+                        .into();
                     let response = experience_client.update_sensation(&update).await?;
                     result = Some((
                         response,

--- a/crates/oneiros-engine/src/domains/experience/features/http.rs
+++ b/crates/oneiros-engine/src/domains/experience/features/http.rs
@@ -70,7 +70,11 @@ async fn show(
     Path(key): Path<ResourceKey<ExperienceId>>,
 ) -> Result<Json<ExperienceResponse>, ExperienceError> {
     Ok(Json(
-        ExperienceService::get(&context, &GetExperience::builder().key(key).build()).await?,
+        ExperienceService::get(
+            &context,
+            &GetExperience::builder_v1().key(key).build().into(),
+        )
+        .await?,
     ))
 }
 
@@ -82,10 +86,11 @@ async fn update_description(
     Ok(Json(
         ExperienceService::update_description(
             &context,
-            &UpdateExperienceDescription::builder()
+            &UpdateExperienceDescription::builder_v1()
                 .id(id)
                 .description(body.description)
-                .build(),
+                .build()
+                .into(),
         )
         .await?,
     ))
@@ -99,10 +104,11 @@ async fn update_sensation(
     Ok(Json(
         ExperienceService::update_sensation(
             &context,
-            &UpdateExperienceSensation::builder()
+            &UpdateExperienceSensation::builder_v1()
                 .id(id)
                 .sensation(body.sensation)
-                .build(),
+                .build()
+                .into(),
         )
         .await?,
     ))

--- a/crates/oneiros-engine/src/domains/experience/features/state.rs
+++ b/crates/oneiros-engine/src/domains/experience/features/state.rs
@@ -6,17 +6,23 @@ impl ExperienceState {
     pub fn reduce(mut canon: BrainCanon, event: &Events) -> BrainCanon {
         if let Events::Experience(experience_event) = event {
             match experience_event {
-                ExperienceEvents::ExperienceCreated(experience) => {
-                    canon.experiences.set(experience);
-                }
-                ExperienceEvents::ExperienceDescriptionUpdated(update) => {
-                    if let Some(exp) = canon.experiences.get_mut(update.id) {
-                        exp.description = update.description.clone();
+                ExperienceEvents::ExperienceCreated(created) => {
+                    if let Ok(current) = created.current() {
+                        canon.experiences.set(&current.experience);
                     }
                 }
-                ExperienceEvents::ExperienceSensationUpdated(update) => {
-                    if let Some(exp) = canon.experiences.get_mut(update.id) {
-                        exp.sensation = update.sensation.clone();
+                ExperienceEvents::ExperienceDescriptionUpdated(updated) => {
+                    if let Ok(current) = updated.current()
+                        && let Some(experience) = canon.experiences.get_mut(current.id)
+                    {
+                        experience.description = current.description;
+                    }
+                }
+                ExperienceEvents::ExperienceSensationUpdated(updated) => {
+                    if let Ok(current) = updated.current()
+                        && let Some(experience) = canon.experiences.get_mut(current.id)
+                    {
+                        experience.sensation = current.sensation;
                     }
                 }
             };
@@ -45,10 +51,11 @@ mod tests {
         canon.experiences.set(&experience);
 
         let event = Events::Experience(ExperienceEvents::ExperienceDescriptionUpdated(
-            ExperienceDescriptionUpdate {
-                id: experience.id,
-                description: Description::new("Updated description"),
-            },
+            ExperienceDescriptionUpdated::builder_v1()
+                .id(experience.id)
+                .description(Description::new("Updated description"))
+                .build()
+                .into(),
         ));
         let next = ExperienceState::reduce(canon, &event);
 

--- a/crates/oneiros-engine/src/domains/experience/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/experience/protocol/events.rs
@@ -7,14 +7,48 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = ExperienceEventsType, display = "kebab-case")]
 pub enum ExperienceEvents {
-    ExperienceCreated(Experience),
-    ExperienceDescriptionUpdated(ExperienceDescriptionUpdate),
-    ExperienceSensationUpdated(ExperienceSensationUpdate),
+    ExperienceCreated(ExperienceCreated),
+    ExperienceDescriptionUpdated(ExperienceDescriptionUpdated),
+    ExperienceSensationUpdated(ExperienceSensationUpdated),
+}
+
+versioned! {
+    pub enum ExperienceCreated {
+        V1 => {
+            #[serde(flatten)] pub experience: Experience,
+        }
+    }
+}
+
+versioned! {
+    pub enum ExperienceDescriptionUpdated {
+        V1 => {
+            pub id: ExperienceId,
+            #[builder(into)] pub description: Description,
+        }
+    }
+}
+
+versioned! {
+    pub enum ExperienceSensationUpdated {
+        V1 => {
+            pub id: ExperienceId,
+            #[builder(into)] pub sensation: SensationName,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_experience() -> Experience {
+        Experience::builder()
+            .agent_id(AgentId::new())
+            .sensation("echoes")
+            .description("Resonance noticed")
+            .build()
+    }
 
     #[test]
     fn event_types_are_kebab_cased() {
@@ -36,16 +70,26 @@ mod tests {
             assert_eq!(&event_type.to_string(), expectation);
         }
     }
-}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExperienceDescriptionUpdate {
-    pub id: ExperienceId,
-    pub description: Description,
-}
+    #[test]
+    fn experience_created_wire_format_is_flat() {
+        let event =
+            ExperienceEvents::ExperienceCreated(ExperienceCreated::V1(ExperienceCreatedV1 {
+                experience: sample_experience(),
+            }));
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExperienceSensationUpdate {
-    pub id: ExperienceId,
-    pub sensation: SensationName,
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "experience-created");
+        assert!(
+            json["data"].get("experience").is_none(),
+            "flatten must elide the experience envelope on the wire"
+        );
+        assert_eq!(json["data"]["sensation"], "echoes");
+        assert_eq!(json["data"]["description"], "Resonance noticed");
+        assert!(json["data"].get("id").is_some());
+        assert!(
+            json["data"].get("V1").is_none(),
+            "V1 layer must not appear on the wire"
+        );
+    }
 }

--- a/crates/oneiros-engine/src/domains/experience/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/experience/protocol/requests.rs
@@ -1,51 +1,66 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct CreateExperience {
-    #[builder(into)]
-    pub agent: AgentName,
-    #[builder(into)]
-    pub sensation: SensationName,
-    #[builder(into)]
-    pub description: Description,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum CreateExperience {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+            #[builder(into)] pub sensation: SensationName,
+            #[builder(into)] pub description: Description,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetExperience {
-    #[builder(into)]
-    pub key: ResourceKey<ExperienceId>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetExperience {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<ExperienceId>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListExperiences {
-    #[arg(long)]
-    pub agent: Option<AgentName>,
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListExperiences {
+        #[derive(clap::Args)]
+        V1 => {
+            #[arg(long)]
+            pub agent: Option<AgentName>,
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct UpdateExperienceDescription {
-    #[builder(into)]
-    pub id: ExperienceId,
-    #[builder(into)]
-    pub description: Description,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum UpdateExperienceDescription {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub id: ExperienceId,
+            #[builder(into)] pub description: Description,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct UpdateExperienceSensation {
-    #[builder(into)]
-    pub id: ExperienceId,
-    #[builder(into)]
-    pub sensation: SensationName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum UpdateExperienceSensation {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub id: ExperienceId,
+            #[builder(into)] pub sensation: SensationName,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/experience/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/experience/protocol/responses.rs
@@ -1,15 +1,47 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = ExperienceResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ExperienceResponse {
-    ExperienceCreated(Response<Experience>),
-    ExperienceDetails(Response<Experience>),
-    Experiences(Listed<Response<Experience>>),
+    ExperienceCreated(ExperienceCreatedResponse),
+    ExperienceDetails(ExperienceDetailsResponse),
+    Experiences(ExperiencesResponse),
     NoExperiences,
-    ExperienceUpdated(Response<Experience>),
+    ExperienceUpdated(ExperienceUpdatedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ExperienceCreatedResponse {
+        V1 => { #[serde(flatten)] pub experience: Experience }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ExperienceDetailsResponse {
+        V1 => { #[serde(flatten)] pub experience: Experience }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ExperiencesResponse {
+        V1 => {
+            pub items: Vec<Experience>,
+            pub total: usize,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ExperienceUpdatedResponse {
+        V1 => { #[serde(flatten)] pub experience: Experience }
+    }
 }

--- a/crates/oneiros-engine/src/domains/experience/service.rs
+++ b/crates/oneiros-engine/src/domains/experience/service.rs
@@ -5,52 +5,61 @@ pub struct ExperienceService;
 impl ExperienceService {
     pub async fn create(
         context: &ProjectContext,
-        CreateExperience {
-            agent,
-            sensation,
-            description,
-        }: &CreateExperience,
+        request: &CreateExperience,
     ) -> Result<ExperienceResponse, ExperienceError> {
+        let CreateExperience::V1(creation) = request;
         let agent_record = AgentRepo::new(context)
-            .get(agent)
+            .get(&creation.agent)
             .await?
-            .ok_or_else(|| ExperienceError::AgentNotFound(agent.clone()))?;
+            .ok_or_else(|| ExperienceError::AgentNotFound(creation.agent.clone()))?;
 
         let experience = Experience::builder()
             .agent_id(agent_record.id)
-            .sensation(sensation.clone())
-            .description(description.clone())
+            .sensation(creation.sensation.clone())
+            .description(creation.description.clone())
             .build();
 
         context
-            .emit(ExperienceEvents::ExperienceCreated(experience.clone()))
+            .emit(ExperienceEvents::ExperienceCreated(
+                ExperienceCreated::builder_v1()
+                    .experience(experience.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        let ref_token = RefToken::new(Ref::experience(experience.id));
+
         Ok(ExperienceResponse::ExperienceCreated(
-            Response::new(experience).with_ref_token(ref_token),
+            ExperienceCreatedResponse::builder_v1()
+                .experience(experience)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn get(
         context: &ProjectContext,
-        selector: &GetExperience,
+        request: &GetExperience,
     ) -> Result<ExperienceResponse, ExperienceError> {
-        let id = selector.key.resolve()?;
+        let GetExperience::V1(lookup) = request;
+        let id = lookup.key.resolve()?;
         let experience = ExperienceRepo::new(context)
             .get(&id)
             .await?
             .ok_or(ExperienceError::NotFound(id))?;
-        let ref_token = RefToken::new(Ref::experience(experience.id));
         Ok(ExperienceResponse::ExperienceDetails(
-            Response::new(experience).with_ref_token(ref_token),
+            ExperienceDetailsResponse::builder_v1()
+                .experience(experience)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn list(
         context: &ProjectContext,
-        ListExperiences { agent, filters }: &ListExperiences,
+        request: &ListExperiences,
     ) -> Result<ExperienceResponse, ExperienceError> {
-        let agent_id = match agent {
+        let ListExperiences::V1(listing) = request;
+        let agent_id = match &listing.agent {
             Some(name) => {
                 let record = AgentRepo::new(context)
                     .get(name)
@@ -62,65 +71,78 @@ impl ExperienceService {
         };
 
         let listed = ExperienceRepo::new(context)
-            .list(agent_id.as_deref(), filters)
+            .list(agent_id.as_deref(), &listing.filters)
             .await?;
         Ok(if listed.total == 0 {
             ExperienceResponse::NoExperiences
         } else {
-            ExperienceResponse::Experiences(listed.map(|e| {
-                let ref_token = RefToken::new(Ref::experience(e.id));
-                Response::new(e).with_ref_token(ref_token)
-            }))
+            ExperienceResponse::Experiences(
+                ExperiencesResponse::builder_v1()
+                    .items(listed.items)
+                    .total(listed.total)
+                    .build()
+                    .into(),
+            )
         })
     }
 
     pub async fn update_description(
         context: &ProjectContext,
-        UpdateExperienceDescription { id, description }: &UpdateExperienceDescription,
+        request: &UpdateExperienceDescription,
     ) -> Result<ExperienceResponse, ExperienceError> {
+        let UpdateExperienceDescription::V1(update) = request;
         let mut experience = ExperienceRepo::new(context)
-            .get(id)
+            .get(&update.id)
             .await?
-            .ok_or_else(|| ExperienceError::NotFound(*id))?;
+            .ok_or_else(|| ExperienceError::NotFound(update.id))?;
 
-        experience.description = description.clone();
+        experience.description = update.description.clone();
 
         context
             .emit(ExperienceEvents::ExperienceDescriptionUpdated(
-                ExperienceDescriptionUpdate {
-                    id: *id,
-                    description: description.clone(),
-                },
+                ExperienceDescriptionUpdated::builder_v1()
+                    .id(update.id)
+                    .description(update.description.clone())
+                    .build()
+                    .into(),
             ))
             .await?;
-        let ref_token = RefToken::new(Ref::experience(experience.id));
+
         Ok(ExperienceResponse::ExperienceUpdated(
-            Response::new(experience).with_ref_token(ref_token),
+            ExperienceUpdatedResponse::builder_v1()
+                .experience(experience)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn update_sensation(
         context: &ProjectContext,
-        UpdateExperienceSensation { id, sensation }: &UpdateExperienceSensation,
+        request: &UpdateExperienceSensation,
     ) -> Result<ExperienceResponse, ExperienceError> {
+        let UpdateExperienceSensation::V1(update) = request;
         let mut experience = ExperienceRepo::new(context)
-            .get(id)
+            .get(&update.id)
             .await?
-            .ok_or_else(|| ExperienceError::NotFound(*id))?;
+            .ok_or_else(|| ExperienceError::NotFound(update.id))?;
 
-        experience.sensation = sensation.clone();
+        experience.sensation = update.sensation.clone();
 
         context
             .emit(ExperienceEvents::ExperienceSensationUpdated(
-                ExperienceSensationUpdate {
-                    id: *id,
-                    sensation: sensation.clone(),
-                },
+                ExperienceSensationUpdated::builder_v1()
+                    .id(update.id)
+                    .sensation(update.sensation.clone())
+                    .build()
+                    .into(),
             ))
             .await?;
-        let ref_token = RefToken::new(Ref::experience(experience.id));
+
         Ok(ExperienceResponse::ExperienceUpdated(
-            Response::new(experience).with_ref_token(ref_token),
+            ExperienceUpdatedResponse::builder_v1()
+                .experience(experience)
+                .build()
+                .into(),
         ))
     }
 }

--- a/crates/oneiros-engine/src/domains/experience/store.rs
+++ b/crates/oneiros-engine/src/domains/experience/store.rs
@@ -15,12 +15,17 @@ impl<'a> ExperienceStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Experience(experience_event)) = &event.data {
             match experience_event {
-                ExperienceEvents::ExperienceCreated(experience) => self.insert(experience)?,
-                ExperienceEvents::ExperienceDescriptionUpdated(update) => {
-                    self.update_description(&update.id, &update.description)?
+                ExperienceEvents::ExperienceCreated(created) => {
+                    let experience = created.current()?.experience;
+                    self.write_experience(&experience)?
                 }
-                ExperienceEvents::ExperienceSensationUpdated(update) => {
-                    self.update_sensation(&update.id, &update.sensation)?
+                ExperienceEvents::ExperienceDescriptionUpdated(updated) => {
+                    let current = updated.current()?;
+                    self.update_description(&current.id, &current.description)?
+                }
+                ExperienceEvents::ExperienceSensationUpdated(updated) => {
+                    let current = updated.current()?;
+                    self.update_sensation(&current.id, &current.sensation)?
                 }
             }
         }
@@ -160,7 +165,7 @@ impl<'a> ExperienceStore<'a> {
         Ok(experiences)
     }
 
-    fn insert(&self, experience: &Experience) -> Result<(), EventError> {
+    fn write_experience(&self, experience: &Experience) -> Result<(), EventError> {
         self.conn.execute(
             "INSERT OR REPLACE INTO experiences (id, agent_id, sensation, description, created_at)
              VALUES (?1, ?2, ?3, ?4, ?5)",

--- a/crates/oneiros-engine/src/domains/experience/view.rs
+++ b/crates/oneiros-engine/src/domains/experience/view.rs
@@ -14,24 +14,24 @@ impl<'a> ExperienceView<'a> {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            ExperienceResponse::ExperienceCreated(wrapped) => {
-                let ref_token = RefToken::from(Ref::experience(wrapped.data.id));
+            ExperienceResponse::ExperienceCreated(ExperienceCreatedResponse::V1(created)) => {
+                let ref_token = RefToken::from(Ref::experience(created.experience.id));
                 McpResponse::new(format!(
                     "Experience created ({}).\n\n**sensation:** {}\n**ref:** {}",
-                    wrapped.data.sensation, wrapped.data.sensation, ref_token
+                    created.experience.sensation, created.experience.sensation, ref_token
                 ))
                 .hint_set(HintSet::mutation(
                     MutationHints::builder().ref_token(ref_token).build(),
                 ))
             }
-            ExperienceResponse::ExperienceDetails(wrapped) => {
-                let ref_token = RefToken::from(Ref::experience(wrapped.data.id));
+            ExperienceResponse::ExperienceDetails(ExperienceDetailsResponse::V1(details)) => {
+                let ref_token = RefToken::from(Ref::experience(details.experience.id));
                 McpResponse::new(format!(
                     "# Experience\n\n**sensation:** {}\n**agent:** {}\n**created:** {}\n\n{}\n",
-                    wrapped.data.sensation,
-                    wrapped.data.agent_id,
-                    wrapped.data.created_at,
-                    wrapped.data.description
+                    details.experience.sensation,
+                    details.experience.agent_id,
+                    details.experience.created_at,
+                    details.experience.description
                 ))
                 .hint(Hint::suggest(
                     format!("create-connection <nature> {ref_token} <target>"),
@@ -39,26 +39,33 @@ impl<'a> ExperienceView<'a> {
                 ))
                 .hint(Hint::suggest("search-query", "Search for related entities"))
             }
-            ExperienceResponse::Experiences(listed) => {
+            ExperienceResponse::Experiences(ExperiencesResponse::V1(listed)) => {
                 let title = match self.request {
-                    ExperienceRequest::ListExperiences(listing) => match &listing.agent {
-                        Some(agent) => format!("# Experiences — {agent}\n\n"),
-                        None => "# Experiences\n\n".to_string(),
-                    },
+                    ExperienceRequest::ListExperiences(ListExperiences::V1(listing)) => {
+                        match &listing.agent {
+                            Some(agent) => format!("# Experiences — {agent}\n\n"),
+                            None => "# Experiences\n\n".to_string(),
+                        }
+                    }
                     _ => "# Experiences\n\n".to_string(),
                 };
-                let mut md = format!("{title}{} of {} total\n\n", listed.len(), listed.total);
-                for wrapped in &listed.items {
+                let mut md = format!(
+                    "{title}{} of {} total\n\n",
+                    listed.items.len(),
+                    listed.total
+                );
+                for item in &listed.items {
                     md.push_str(&format!(
                         "### {} — {}\n{}\n\n",
-                        wrapped.data.sensation, wrapped.data.created_at, wrapped.data.description
+                        item.sensation, item.created_at, item.description
                     ));
                 }
                 let mut response = McpResponse::new(md).hint(Hint::suggest(
                     "create-experience",
                     "Mark a meaningful moment",
                 ));
-                if let ExperienceRequest::ListExperiences(listing) = self.request
+                if let ExperienceRequest::ListExperiences(ListExperiences::V1(listing)) =
+                    self.request
                     && let Some(agent) = &listing.agent
                 {
                     response = response.hint(Hint::inspect(
@@ -69,11 +76,11 @@ impl<'a> ExperienceView<'a> {
                 response
             }
             ExperienceResponse::NoExperiences => McpResponse::new("No experiences yet."),
-            ExperienceResponse::ExperienceUpdated(wrapped) => {
-                let ref_token = RefToken::from(Ref::experience(wrapped.data.id));
+            ExperienceResponse::ExperienceUpdated(ExperienceUpdatedResponse::V1(updated)) => {
+                let ref_token = RefToken::from(Ref::experience(updated.experience.id));
                 McpResponse::new(format!(
                     "Experience updated ({}).\n\n**sensation:** {}\n**ref:** {}",
-                    wrapped.data.sensation, wrapped.data.sensation, ref_token
+                    updated.experience.sensation, updated.experience.sensation, ref_token
                 ))
                 .hint_set(HintSet::mutation(
                     MutationHints::builder().ref_token(ref_token).build(),
@@ -84,72 +91,56 @@ impl<'a> ExperienceView<'a> {
 
     pub fn render(self) -> Rendered<ExperienceResponse> {
         match self.response {
-            ExperienceResponse::ExperienceCreated(wrapped) => {
-                let subject = wrapped
-                    .meta()
-                    .ref_token()
-                    .map(|ref_token| {
-                        format!(
-                            "{} Experience recorded: {}",
-                            "✓".success(),
-                            ref_token.muted()
-                        )
-                    })
-                    .unwrap_or_default();
-                let hints = match wrapped.meta().ref_token() {
-                    Some(ref_token) => {
-                        HintSet::mutation(MutationHints::builder().ref_token(ref_token).build())
-                    }
-                    None => HintSet::None,
-                };
+            ExperienceResponse::ExperienceCreated(ExperienceCreatedResponse::V1(created)) => {
+                let ref_token = RefToken::from(Ref::experience(created.experience.id));
+                let subject = format!(
+                    "{} Experience recorded: {}",
+                    "✓".success(),
+                    ref_token.clone().muted()
+                );
+                let hints =
+                    HintSet::mutation(MutationHints::builder().ref_token(ref_token).build());
                 Rendered::new(
-                    ExperienceResponse::ExperienceCreated(wrapped),
+                    ExperienceResponse::ExperienceCreated(ExperienceCreatedResponse::V1(created)),
                     subject,
                     String::new(),
                 )
                 .with_hints(hints)
             }
-            ExperienceResponse::ExperienceDetails(wrapped) => {
-                let prompt = Detail::new(wrapped.data.sensation.to_string())
-                    .field("description:", wrapped.data.description.to_string())
+            ExperienceResponse::ExperienceDetails(ExperienceDetailsResponse::V1(details)) => {
+                let prompt = Detail::new(details.experience.sensation.to_string())
+                    .field("description:", details.experience.description.to_string())
                     .to_string();
-                let hints = match wrapped.meta().ref_token() {
-                    Some(ref_token) => {
-                        HintSet::mutation(MutationHints::builder().ref_token(ref_token).build())
-                    }
-                    None => HintSet::None,
-                };
+                let ref_token = RefToken::from(Ref::experience(details.experience.id));
+                let hints =
+                    HintSet::mutation(MutationHints::builder().ref_token(ref_token).build());
                 Rendered::new(
-                    ExperienceResponse::ExperienceDetails(wrapped),
+                    ExperienceResponse::ExperienceDetails(ExperienceDetailsResponse::V1(details)),
                     prompt,
                     String::new(),
                 )
                 .with_hints(hints)
             }
-            ExperienceResponse::Experiences(listed) => {
+            ExperienceResponse::Experiences(ExperiencesResponse::V1(listed)) => {
                 let mut table = Table::new(vec![
                     Column::key("sensation", "Sensation"),
                     Column::key("description", "Description").max(60),
                     Column::key("ref_token", "Ref"),
                 ]);
-                for wrapped in &listed.items {
-                    let ref_token = wrapped
-                        .meta()
-                        .ref_token()
-                        .map(|t| t.to_string())
-                        .unwrap_or_default();
+                for item in &listed.items {
+                    let ref_token = RefToken::from(Ref::experience(item.id));
                     table.push_row(vec![
-                        wrapped.data.sensation.to_string(),
-                        wrapped.data.description.to_string(),
-                        ref_token,
+                        item.sensation.to_string(),
+                        item.description.to_string(),
+                        ref_token.to_string(),
                     ]);
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
                 Rendered::new(
-                    ExperienceResponse::Experiences(listed),
+                    ExperienceResponse::Experiences(ExperiencesResponse::V1(listed)),
                     prompt,
                     String::new(),
                 )
@@ -159,26 +150,17 @@ impl<'a> ExperienceView<'a> {
                 format!("{}", "No experiences.".muted()),
                 String::new(),
             ),
-            ExperienceResponse::ExperienceUpdated(wrapped) => {
-                let subject = wrapped
-                    .meta()
-                    .ref_token()
-                    .map(|ref_token| {
-                        format!(
-                            "{} Experience updated: {}",
-                            "✓".success(),
-                            ref_token.muted()
-                        )
-                    })
-                    .unwrap_or_default();
-                let hints = match wrapped.meta().ref_token() {
-                    Some(ref_token) => {
-                        HintSet::mutation(MutationHints::builder().ref_token(ref_token).build())
-                    }
-                    None => HintSet::None,
-                };
+            ExperienceResponse::ExperienceUpdated(ExperienceUpdatedResponse::V1(updated)) => {
+                let ref_token = RefToken::from(Ref::experience(updated.experience.id));
+                let subject = format!(
+                    "{} Experience updated: {}",
+                    "✓".success(),
+                    ref_token.clone().muted()
+                );
+                let hints =
+                    HintSet::mutation(MutationHints::builder().ref_token(ref_token).build());
                 Rendered::new(
-                    ExperienceResponse::ExperienceUpdated(wrapped),
+                    ExperienceResponse::ExperienceUpdated(ExperienceUpdatedResponse::V1(updated)),
                     subject,
                     String::new(),
                 )

--- a/crates/oneiros-engine/src/domains/follow/features/state.rs
+++ b/crates/oneiros-engine/src/domains/follow/features/state.rs
@@ -6,11 +6,23 @@ impl FollowState {
     pub fn reduce(mut canon: SystemCanon, event: &Events) -> SystemCanon {
         if let Events::Bookmark(bookmark_event) = event {
             match bookmark_event {
-                BookmarkEvents::BookmarkFollowed(follow) => {
-                    canon.follows.set(follow);
+                BookmarkEvents::BookmarkFollowed(followed) => {
+                    if let Ok(current) = followed.current() {
+                        let follow = Follow::builder()
+                            .id(current.id)
+                            .brain(current.brain)
+                            .bookmark(current.bookmark)
+                            .source(current.source)
+                            .checkpoint(current.checkpoint)
+                            .created_at(current.created_at)
+                            .build();
+                        canon.follows.set(&follow);
+                    }
                 }
                 BookmarkEvents::BookmarkUnfollowed(unfollowed) => {
-                    canon.follows.remove(unfollowed.follow_id);
+                    if let Ok(current) = unfollowed.current() {
+                        canon.follows.remove(current.follow_id);
+                    }
                 }
                 BookmarkEvents::BookmarkCreated(_)
                 | BookmarkEvents::BookmarkForked(_)

--- a/crates/oneiros-engine/src/domains/follow/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/follow/protocol/requests.rs
@@ -1,23 +1,27 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetFollow {
-    #[builder(into)]
-    pub key: ResourceKey<FollowId>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetFollow {
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<FollowId>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Default, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListFollows {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListFollows {
+        V1 => {
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/follow/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/follow/protocol/responses.rs
@@ -1,9 +1,10 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = FollowResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 #[expect(
@@ -11,6 +12,30 @@ use crate::*;
     reason = "We can reduce the size of the Follow later"
 )]
 pub enum FollowResponse {
-    Found(Response<Follow>),
-    Listed(Listed<Response<Follow>>),
+    Found(FollowFoundResponse),
+    Listed(FollowsResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum FollowFoundResponse {
+        V1 => {
+            #[builder(default)] pub id: FollowId,
+            pub brain: BrainName,
+            pub bookmark: BookmarkName,
+            pub source: FollowSource,
+            pub checkpoint: Checkpoint,
+            pub created_at: Timestamp,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum FollowsResponse {
+        V1 => {
+            pub items: Vec<FollowFoundResponseV1>,
+            pub total: usize,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/follow/service.rs
+++ b/crates/oneiros-engine/src/domains/follow/service.rs
@@ -18,8 +18,17 @@ impl FollowService {
             .source(source)
             .build();
 
+        let event = BookmarkFollowed::builder_v1()
+            .id(follow.id)
+            .brain(follow.brain.clone())
+            .bookmark(follow.bookmark.clone())
+            .source(follow.source.clone())
+            .checkpoint(follow.checkpoint.clone())
+            .created_at(follow.created_at)
+            .build();
+
         context
-            .emit(BookmarkEvents::BookmarkFollowed(follow.clone()))
+            .emit(BookmarkEvents::BookmarkFollowed(event.into()))
             .await?;
 
         Ok(follow)
@@ -61,11 +70,14 @@ impl FollowService {
         events_received: u64,
     ) -> Result<(), FollowError> {
         context
-            .emit(BookmarkEvents::BookmarkCollected(BookmarkCollected {
-                follow_id,
-                checkpoint,
-                events_received,
-            }))
+            .emit(BookmarkEvents::BookmarkCollected(
+                BookmarkCollected::builder_v1()
+                    .follow_id(follow_id)
+                    .checkpoint(checkpoint)
+                    .events_received(events_received)
+                    .build()
+                    .into(),
+            ))
             .await?;
         Ok(())
     }
@@ -79,11 +91,14 @@ impl FollowService {
             .ok_or(FollowError::NotFound(id))?;
 
         context
-            .emit(BookmarkEvents::BookmarkUnfollowed(BookmarkUnfollowed {
-                follow_id: existing.id,
-                brain: existing.brain,
-                bookmark: existing.bookmark,
-            }))
+            .emit(BookmarkEvents::BookmarkUnfollowed(
+                BookmarkUnfollowed::builder_v1()
+                    .follow_id(existing.id)
+                    .brain(existing.brain)
+                    .bookmark(existing.bookmark)
+                    .build()
+                    .into(),
+            ))
             .await?;
 
         Ok(())

--- a/crates/oneiros-engine/src/domains/follow/store.rs
+++ b/crates/oneiros-engine/src/domains/follow/store.rs
@@ -18,14 +18,17 @@ impl<'a> FollowStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Bookmark(bookmark_event)) = &event.data {
             match bookmark_event {
-                BookmarkEvents::BookmarkFollowed(follow) => {
-                    self.create_record(follow)?;
+                BookmarkEvents::BookmarkFollowed(followed) => {
+                    let current = followed.current()?;
+                    self.create_record(&current)?;
                 }
                 BookmarkEvents::BookmarkCollected(collected) => {
-                    self.advance_checkpoint(collected)?;
+                    let current = collected.current()?;
+                    self.advance_checkpoint(&current)?;
                 }
                 BookmarkEvents::BookmarkUnfollowed(unfollowed) => {
-                    self.delete_record(unfollowed.follow_id)?;
+                    let current = unfollowed.current()?;
+                    self.delete_record(current.follow_id)?;
                 }
                 BookmarkEvents::BookmarkCreated(_)
                 | BookmarkEvents::BookmarkForked(_)
@@ -57,7 +60,7 @@ impl<'a> FollowStore<'a> {
         Ok(())
     }
 
-    fn create_record(&self, follow: &Follow) -> Result<(), EventError> {
+    fn create_record(&self, follow: &BookmarkFollowedV1) -> Result<(), EventError> {
         let source_json = serde_json::to_string(&follow.source)?;
         let checkpoint_json = serde_json::to_string(&follow.checkpoint)?;
 
@@ -78,7 +81,7 @@ impl<'a> FollowStore<'a> {
         Ok(())
     }
 
-    fn advance_checkpoint(&self, collected: &BookmarkCollected) -> Result<(), EventError> {
+    fn advance_checkpoint(&self, collected: &BookmarkCollectedV1) -> Result<(), EventError> {
         let checkpoint_json = serde_json::to_string(&collected.checkpoint)?;
         self.conn.execute(
             "update follows set checkpoint = ?1 where id = ?2",

--- a/crates/oneiros-engine/src/domains/level/client.rs
+++ b/crates/oneiros-engine/src/domains/level/client.rs
@@ -9,23 +9,31 @@ impl<'a> LevelClient<'a> {
         Self { client }
     }
 
-    pub async fn set(&self, set: &SetLevel) -> Result<LevelResponse, ClientError> {
-        self.client.put(&format!("/levels/{}", set.name), set).await
+    pub async fn set(&self, setting: &SetLevel) -> Result<LevelResponse, ClientError> {
+        let SetLevel::V1(body) = setting;
+        self.client
+            .put(&format!("/levels/{}", body.name), setting)
+            .await
     }
 
-    pub async fn get(&self, request: &GetLevel) -> Result<LevelResponse, ClientError> {
-        self.client.get(&format!("/levels/{}", request.key)).await
+    pub async fn get(&self, lookup: &GetLevel) -> Result<LevelResponse, ClientError> {
+        let GetLevel::V1(lookup) = lookup;
+        self.client.get(&format!("/levels/{}", lookup.key)).await
     }
 
-    pub async fn list(&self, request: &ListLevels) -> Result<LevelResponse, ClientError> {
+    pub async fn list(&self, listing: &ListLevels) -> Result<LevelResponse, ClientError> {
+        let ListLevels::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset,
+            listing.filters.limit, listing.filters.offset,
         );
         self.client.get(&format!("/levels?{query}")).await
     }
 
-    pub async fn remove(&self, name: &LevelName) -> Result<LevelResponse, ClientError> {
-        self.client.delete(&format!("/levels/{name}")).await
+    pub async fn remove(&self, removal: &RemoveLevel) -> Result<LevelResponse, ClientError> {
+        let RemoveLevel::V1(removal) = removal;
+        self.client
+            .delete(&format!("/levels/{}", removal.name))
+            .await
     }
 }

--- a/crates/oneiros-engine/src/domains/level/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/level/features/cli.rs
@@ -2,6 +2,11 @@ use clap::Subcommand;
 
 use crate::*;
 
+/// CLI subcommands for the level domain. Each variant carries a versioned
+/// protocol request directly — clap derives parsing through the wrapper's
+/// `Args` impl, which delegates to the latest version's struct. The
+/// dispatcher passes the wrapper through to the client without rebuilding,
+/// since the operation type *is* the domain command.
 #[derive(Debug, Subcommand)]
 pub enum LevelCommands {
     Set(SetLevel),
@@ -19,10 +24,10 @@ impl LevelCommands {
         let level_client = LevelClient::new(&client);
 
         let response = match self {
-            LevelCommands::Set(set) => level_client.set(set).await?,
-            LevelCommands::Show(get) => level_client.get(get).await?,
-            LevelCommands::List(list) => level_client.list(list).await?,
-            LevelCommands::Remove(removal) => level_client.remove(&removal.name).await?,
+            Self::Set(setting) => level_client.set(setting).await?,
+            Self::Show(lookup) => level_client.get(lookup).await?,
+            Self::List(listing) => level_client.list(listing).await?,
+            Self::Remove(removal) => level_client.remove(removal).await?,
         };
 
         Ok(LevelView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/level/features/http.rs
+++ b/crates/oneiros-engine/src/domains/level/features/http.rs
@@ -41,12 +41,14 @@ impl LevelRouter {
 async fn set(
     context: ProjectContext,
     Path(name): Path<LevelName>,
-    Json(mut body): Json<SetLevel>,
+    Json(body): Json<SetLevel>,
 ) -> Result<(StatusCode, Json<LevelResponse>), LevelError> {
-    body.name = name;
+    let SetLevel::V1(mut setting) = body;
+    setting.name = name;
+    let request = SetLevel::V1(setting);
     Ok((
         StatusCode::OK,
-        Json(LevelService::set(&context, &body).await?),
+        Json(LevelService::set(&context, &request).await?),
     ))
 }
 
@@ -62,7 +64,7 @@ async fn show(
     Path(key): Path<ResourceKey<LevelName>>,
 ) -> Result<Json<LevelResponse>, LevelError> {
     Ok(Json(
-        LevelService::get(&context, &GetLevel::builder().key(key).build()).await?,
+        LevelService::get(&context, &GetLevel::builder_v1().key(key).build().into()).await?,
     ))
 }
 
@@ -71,6 +73,10 @@ async fn remove(
     Path(name): Path<LevelName>,
 ) -> Result<Json<LevelResponse>, LevelError> {
     Ok(Json(
-        LevelService::remove(&context, &RemoveLevel::builder().name(name).build()).await?,
+        LevelService::remove(
+            &context,
+            &RemoveLevel::builder_v1().name(name).build().into(),
+        )
+        .await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/level/features/state.rs
+++ b/crates/oneiros-engine/src/domains/level/features/state.rs
@@ -6,11 +6,15 @@ impl LevelState {
     pub fn reduce(mut canon: BrainCanon, event: &Events) -> BrainCanon {
         if let Events::Level(level_event) = event {
             match level_event {
-                LevelEvents::LevelSet(level) => {
-                    canon.levels.set(level);
+                LevelEvents::LevelSet(setting) => {
+                    if let Ok(current) = setting.current() {
+                        canon.levels.set(&current.level);
+                    }
                 }
-                LevelEvents::LevelRemoved(removed) => {
-                    canon.levels.remove(&removed.name);
+                LevelEvents::LevelRemoved(removal) => {
+                    if let Ok(current) = removal.current() {
+                        canon.levels.remove(&current.name);
+                    }
                 }
             };
         }
@@ -30,19 +34,22 @@ mod tests {
     #[test]
     fn sets_and_removes_level() {
         let canon = BrainCanon::default();
+        let name = LevelName::new("working");
         let level = Level::builder()
-            .name("working")
+            .name(name.clone())
             .description("Short-term")
             .prompt("")
             .build();
-        let event = Events::Level(LevelEvents::LevelSet(level.clone()));
+        let event = Events::Level(LevelEvents::LevelSet(
+            LevelSet::builder_v1().level(level).build().into(),
+        ));
 
         let next = LevelState::reduce(canon, &event);
         assert_eq!(next.levels.len(), 1);
 
-        let event = Events::Level(LevelEvents::LevelRemoved(LevelRemoved {
-            name: level.name.clone(),
-        }));
+        let event = Events::Level(LevelEvents::LevelRemoved(
+            LevelRemoved::builder_v1().name(name).build().into(),
+        ));
         let next = LevelState::reduce(next, &event);
         assert_eq!(next.levels.len(), 0);
     }

--- a/crates/oneiros-engine/src/domains/level/model.rs
+++ b/crates/oneiros-engine/src/domains/level/model.rs
@@ -1,20 +1,17 @@
 use bon::Builder;
-use clap::Args;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::*;
 
-#[derive(Args, Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct Level {
     #[builder(into)]
     pub name: LevelName,
     #[builder(into)]
-    #[arg(long, default_value = "")]
     pub description: Description,
     #[builder(into)]
-    #[arg(long, default_value = "")]
     pub prompt: Prompt,
 }
 

--- a/crates/oneiros-engine/src/domains/level/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/level/protocol/events.rs
@@ -7,13 +7,37 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = LevelEventsType, display = "kebab-case")]
 pub enum LevelEvents {
-    LevelSet(Level),
+    LevelSet(LevelSet),
     LevelRemoved(LevelRemoved),
+}
+
+versioned! {
+    pub enum LevelSet {
+        V1 => {
+            #[serde(flatten)] pub level: Level,
+        }
+    }
+}
+
+versioned! {
+    pub enum LevelRemoved {
+        V1 => {
+            #[builder(into)] pub name: LevelName,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_level() -> Level {
+        Level::builder()
+            .name("working")
+            .description("Short-term")
+            .prompt("")
+            .build()
+    }
 
     #[test]
     fn event_types_are_kebab_cased() {
@@ -25,9 +49,44 @@ mod tests {
             assert_eq!(&event_type.to_string(), expectation);
         }
     }
-}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LevelRemoved {
-    pub name: LevelName,
+    #[test]
+    fn level_set_wire_format_is_flat() {
+        // V1 embeds `Level` with `#[serde(flatten)]`, so the wire shape stays
+        // at the model fields and never gains a `level` envelope.
+        let event = LevelEvents::LevelSet(LevelSet::V1(LevelSetV1 {
+            level: sample_level(),
+        }));
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "level-set");
+        assert!(
+            json["data"].get("level").is_none(),
+            "flatten must elide the level envelope on the wire"
+        );
+        assert_eq!(json["data"]["name"], "working");
+        assert_eq!(json["data"]["description"], "Short-term");
+        assert!(
+            json["data"].get("V1").is_none(),
+            "V1 layer must not appear on the wire"
+        );
+    }
+
+    #[test]
+    fn level_removed_round_trips_through_v1_layer() {
+        let original = LevelEvents::LevelRemoved(LevelRemoved::V1(LevelRemovedV1 {
+            name: LevelName::new("working"),
+        }));
+
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: LevelEvents = serde_json::from_str(&json).unwrap();
+
+        match decoded {
+            LevelEvents::LevelRemoved(removed) => {
+                let v1 = removed.current().unwrap();
+                assert_eq!(v1.name.to_string(), "working");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/level/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/level/protocol/requests.rs
@@ -1,41 +1,56 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct SetLevel {
-    #[builder(into)]
-    pub name: LevelName,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub description: Description,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub prompt: Prompt,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SetLevel {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: LevelName,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub description: Description,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub prompt: Prompt,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetLevel {
-    #[builder(into)]
-    pub key: ResourceKey<LevelName>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetLevel {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<LevelName>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct RemoveLevel {
-    #[builder(into)]
-    pub name: LevelName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum RemoveLevel {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: LevelName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListLevels {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListLevels {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/level/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/level/protocol/responses.rs
@@ -1,15 +1,49 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = LevelResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum LevelResponse {
-    LevelSet(LevelName),
-    LevelDetails(Response<Level>),
-    Levels(Listed<Response<Level>>),
+    LevelSet(LevelSetResponse),
+    LevelDetails(LevelDetailsResponse),
+    Levels(LevelsResponse),
     NoLevels,
-    LevelRemoved(LevelName),
+    LevelRemoved(LevelRemovedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum LevelSetResponse {
+        V1 => { #[serde(flatten)] pub level: Level }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum LevelDetailsResponse {
+        V1 => { #[serde(flatten)] pub level: Level }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum LevelsResponse {
+        V1 => {
+            pub items: Vec<Level>,
+            pub total: usize,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum LevelRemovedResponse {
+        V1 => {
+            #[builder(into)] pub name: LevelName,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/level/service.rs
+++ b/crates/oneiros-engine/src/domains/level/service.rs
@@ -5,60 +5,81 @@ pub struct LevelService;
 impl LevelService {
     pub async fn set(
         context: &ProjectContext,
-        SetLevel {
-            name,
-            description,
-            prompt,
-        }: &SetLevel,
+        request: &SetLevel,
     ) -> Result<LevelResponse, LevelError> {
+        let SetLevel::V1(set) = request;
         let level = Level::builder()
-            .name(name.clone())
-            .description(description.clone())
-            .prompt(prompt.clone())
+            .name(set.name.clone())
+            .description(set.description.clone())
+            .prompt(set.prompt.clone())
             .build();
-        context.emit(LevelEvents::LevelSet(level)).await?;
-        Ok(LevelResponse::LevelSet(name.clone()))
+
+        context
+            .emit(LevelEvents::LevelSet(
+                LevelSet::builder_v1().level(level.clone()).build().into(),
+            ))
+            .await?;
+
+        Ok(LevelResponse::LevelSet(
+            LevelSetResponse::builder_v1().level(level).build().into(),
+        ))
     }
 
     pub async fn get(
         context: &ProjectContext,
-        selector: &GetLevel,
+        request: &GetLevel,
     ) -> Result<LevelResponse, LevelError> {
-        let name = selector.key.resolve()?;
+        let GetLevel::V1(lookup) = request;
+        let name = lookup.key.resolve()?;
         let level = LevelRepo::new(context)
             .get(&name)
             .await?
             .ok_or(LevelError::NotFound(name))?;
-        let ref_token = RefToken::new(Ref::level(level.name.clone()));
         Ok(LevelResponse::LevelDetails(
-            Response::new(level).with_ref_token(ref_token),
+            LevelDetailsResponse::builder_v1()
+                .level(level)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn list(
         context: &ProjectContext,
-        ListLevels { filters }: &ListLevels,
+        request: &ListLevels,
     ) -> Result<LevelResponse, LevelError> {
-        let listed = LevelRepo::new(context).list(filters).await?;
+        let ListLevels::V1(listing) = request;
+        let listed = LevelRepo::new(context).list(&listing.filters).await?;
         if listed.total == 0 {
             Ok(LevelResponse::NoLevels)
         } else {
-            Ok(LevelResponse::Levels(listed.map(|e| {
-                let ref_token = RefToken::new(Ref::level(e.name.clone()));
-                Response::new(e).with_ref_token(ref_token)
-            })))
+            Ok(LevelResponse::Levels(
+                LevelsResponse::builder_v1()
+                    .items(listed.items)
+                    .total(listed.total)
+                    .build()
+                    .into(),
+            ))
         }
     }
 
     pub async fn remove(
         context: &ProjectContext,
-        selector: &RemoveLevel,
+        request: &RemoveLevel,
     ) -> Result<LevelResponse, LevelError> {
+        let RemoveLevel::V1(removal) = request;
         context
-            .emit(LevelEvents::LevelRemoved(LevelRemoved {
-                name: selector.name.clone(),
-            }))
+            .emit(LevelEvents::LevelRemoved(
+                LevelRemoved::builder_v1()
+                    .name(removal.name.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        Ok(LevelResponse::LevelRemoved(selector.name.clone()))
+        Ok(LevelResponse::LevelRemoved(
+            LevelRemovedResponse::builder_v1()
+                .name(removal.name.clone())
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/level/store.rs
+++ b/crates/oneiros-engine/src/domains/level/store.rs
@@ -14,8 +14,8 @@ impl<'a> LevelStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Level(level_event)) = &event.data {
             match level_event {
-                LevelEvents::LevelSet(level) => self.set(level)?,
-                LevelEvents::LevelRemoved(removed) => self.remove(&removed.name)?,
+                LevelEvents::LevelSet(setting) => self.set(setting)?,
+                LevelEvents::LevelRemoved(removal) => self.remove(removal)?,
             }
         }
         Ok(())
@@ -64,7 +64,21 @@ impl<'a> LevelStore<'a> {
         Ok(levels)
     }
 
-    fn set(&self, level: &Level) -> Result<(), EventError> {
+    fn set(&self, setting: &LevelSet) -> Result<(), EventError> {
+        let level = setting.current()?.level;
+        self.write_level(&level)
+    }
+
+    fn remove(&self, removal: &LevelRemoved) -> Result<(), EventError> {
+        let name = removal.current()?.name;
+        self.conn.execute(
+            "DELETE FROM levels WHERE name = ?1",
+            params![name.to_string()],
+        )?;
+        Ok(())
+    }
+
+    fn write_level(&self, level: &Level) -> Result<(), EventError> {
         self.conn.execute(
             "INSERT OR REPLACE INTO levels (name, description, prompt) VALUES (?1, ?2, ?3)",
             params![
@@ -72,14 +86,6 @@ impl<'a> LevelStore<'a> {
                 level.description.to_string(),
                 level.prompt.to_string()
             ],
-        )?;
-        Ok(())
-    }
-
-    fn remove(&self, name: &LevelName) -> Result<(), EventError> {
-        self.conn.execute(
-            "DELETE FROM levels WHERE name = ?1",
-            params![name.to_string()],
         )?;
         Ok(())
     }

--- a/crates/oneiros-engine/src/domains/level/view.rs
+++ b/crates/oneiros-engine/src/domains/level/view.rs
@@ -11,24 +11,28 @@ impl LevelView {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            LevelResponse::Levels(listed) => {
+            LevelResponse::Levels(LevelsResponse::V1(listed)) => {
                 let items: Vec<_> = listed
                     .items
                     .iter()
-                    .map(|w| (w.data.name.to_string(), w.data.description.to_string()))
+                    .map(|item| (item.name.to_string(), item.description.to_string()))
                     .collect();
                 Self::vocabulary_table("Levels", &items)
             }
-            LevelResponse::LevelDetails(wrapped) => {
+            LevelResponse::LevelDetails(LevelDetailsResponse::V1(details)) => {
                 let items = vec![(
-                    wrapped.data.name.to_string(),
-                    wrapped.data.description.to_string(),
+                    details.level.name.to_string(),
+                    details.level.description.to_string(),
                 )];
                 Self::vocabulary_table("Level", &items)
             }
             LevelResponse::NoLevels => Self::vocabulary_table("Levels", &[]),
-            LevelResponse::LevelSet(name) => McpResponse::new(format!("Level set: {name}")),
-            LevelResponse::LevelRemoved(name) => McpResponse::new(format!("Level removed: {name}")),
+            LevelResponse::LevelSet(LevelSetResponse::V1(set)) => {
+                McpResponse::new(format!("Level set: {}", set.level.name))
+            }
+            LevelResponse::LevelRemoved(LevelRemovedResponse::V1(removed)) => {
+                McpResponse::new(format!("Level removed: {}", removed.name))
+            }
         }
     }
 
@@ -48,50 +52,65 @@ impl LevelView {
 
     pub fn render(self) -> Rendered<LevelResponse> {
         match self.response {
-            LevelResponse::LevelSet(name) => {
-                let prompt = Confirmation::new("Level", name.to_string(), "set").to_string();
+            LevelResponse::LevelSet(LevelSetResponse::V1(set)) => {
+                let prompt =
+                    Confirmation::new("Level", set.level.name.to_string(), "set").to_string();
                 let hints = HintSet::vocabulary(
                     VocabularyHints::builder().kind("level".to_string()).build(),
                 );
-                Rendered::new(LevelResponse::LevelSet(name), prompt, String::new())
-                    .with_hints(hints)
+                Rendered::new(
+                    LevelResponse::LevelSet(LevelSetResponse::V1(set)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
-            LevelResponse::LevelDetails(wrapped) => {
-                let prompt = Detail::new(wrapped.data.name.to_string())
-                    .field("description:", wrapped.data.description.to_string())
-                    .field("prompt:", wrapped.data.prompt.to_string())
+            LevelResponse::LevelDetails(LevelDetailsResponse::V1(details)) => {
+                let prompt = Detail::new(details.level.name.to_string())
+                    .field("description:", details.level.description.to_string())
+                    .field("prompt:", details.level.prompt.to_string())
                     .to_string();
-                Rendered::new(LevelResponse::LevelDetails(wrapped), prompt, String::new())
+                Rendered::new(
+                    LevelResponse::LevelDetails(LevelDetailsResponse::V1(details)),
+                    prompt,
+                    String::new(),
+                )
             }
-            LevelResponse::Levels(listed) => {
+            LevelResponse::Levels(LevelsResponse::V1(listed)) => {
                 let mut table = Table::new(vec![
                     Column::key("name", "Name"),
                     Column::key("description", "Description").max(60),
                 ]);
-                for wrapped in &listed.items {
-                    table.push_row(vec![
-                        wrapped.data.name.to_string(),
-                        wrapped.data.description.to_string(),
-                    ]);
+                for item in &listed.items {
+                    table.push_row(vec![item.name.to_string(), item.description.to_string()]);
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
-                Rendered::new(LevelResponse::Levels(listed), prompt, String::new())
+                Rendered::new(
+                    LevelResponse::Levels(LevelsResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
             LevelResponse::NoLevels => Rendered::new(
                 LevelResponse::NoLevels,
                 format!("{}", "No levels configured.".muted()),
                 String::new(),
             ),
-            LevelResponse::LevelRemoved(name) => {
-                let prompt = Confirmation::new("Level", name.to_string(), "removed").to_string();
+            LevelResponse::LevelRemoved(LevelRemovedResponse::V1(removed)) => {
+                let prompt =
+                    Confirmation::new("Level", removed.name.to_string(), "removed").to_string();
                 let hints = HintSet::vocabulary(
                     VocabularyHints::builder().kind("level".to_string()).build(),
                 );
-                Rendered::new(LevelResponse::LevelRemoved(name), prompt, String::new())
-                    .with_hints(hints)
+                Rendered::new(
+                    LevelResponse::LevelRemoved(LevelRemovedResponse::V1(removed)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/mcp/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/mcp/features/cli.rs
@@ -11,11 +11,18 @@ pub enum McpCommands {
 impl McpCommands {
     pub fn execute(&self, config: &Config) -> Result<Rendered<Responses>, McpConfigError> {
         let response = match self {
-            McpCommands::Init(init) => {
-                let result = McpConfigService::init(config, init)?;
+            McpCommands::Init(initialization) => {
+                let InitMcp::V1(init) = initialization;
+                let result = McpConfigService::init(config, initialization)?;
 
-                if let McpConfigResponse::McpConfigExists(ref path) = result {
+                if let McpConfigResponse::McpConfigExists(_) = &result {
                     if !init.yes {
+                        let path = match &result {
+                            McpConfigResponse::McpConfigExists(McpConfigExistsResponse::V1(d)) => {
+                                d.path.clone()
+                            }
+                            _ => unreachable!(),
+                        };
                         let overwrite = inquire::Confirm::new(&format!(
                             "{} already exists. Overwrite?",
                             path.display()
@@ -25,7 +32,7 @@ impl McpCommands {
                         .unwrap_or(false);
 
                         if overwrite {
-                            McpConfigService::write(config, init)?
+                            McpConfigService::write(config, initialization)?
                         } else {
                             result
                         }

--- a/crates/oneiros-engine/src/domains/mcp/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/mcp/protocol/errors.rs
@@ -4,7 +4,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 
-use crate::ErrorResponse;
+use crate::{ErrorResponse, UpcastError};
 
 #[derive(Debug, thiserror::Error)]
 pub enum McpConfigError {
@@ -16,13 +16,16 @@ pub enum McpConfigError {
 
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Upcast(#[from] UpcastError),
 }
 
 impl IntoResponse for McpConfigError {
     fn into_response(self) -> Response {
         let (status, message) = match &self {
             McpConfigError::NoToken => (StatusCode::PRECONDITION_FAILED, self.to_string()),
-            McpConfigError::Io(_) | McpConfigError::Json(_) => {
+            McpConfigError::Io(_) | McpConfigError::Json(_) | McpConfigError::Upcast(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
             }
         };

--- a/crates/oneiros-engine/src/domains/mcp/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/mcp/protocol/requests.rs
@@ -1,23 +1,26 @@
 use std::net::SocketAddr;
 
-use bon::Builder;
-use clap::Args;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct InitMcp {
-    /// Bearer token for MCP authentication. Read from disk if not provided.
-    #[arg(long)]
-    #[builder(into)]
-    pub token: Option<Token>,
-    /// Service address. Uses config default if not provided.
-    #[arg(long)]
-    pub address: Option<SocketAddr>,
-    /// Skip confirmation prompts.
-    #[arg(long, short)]
-    #[builder(default)]
-    pub yes: bool,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum InitMcp {
+        #[derive(clap::Args)]
+        V1 => {
+            /// Bearer token for MCP authentication. Read from disk if not provided.
+            #[arg(long)]
+            #[builder(into)]
+            pub token: Option<Token>,
+            /// Service address. Uses config default if not provided.
+            #[arg(long)]
+            pub address: Option<SocketAddr>,
+            /// Skip confirmation prompts.
+            #[arg(long, short)]
+            #[serde(default)]
+            #[builder(default)]
+            pub yes: bool,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/mcp/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/mcp/protocol/responses.rs
@@ -1,12 +1,33 @@
 use std::path::PathBuf;
 
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+use crate::*;
+
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = McpConfigResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum McpConfigResponse {
-    McpConfigWritten(PathBuf),
-    McpConfigExists(PathBuf),
+    McpConfigWritten(McpConfigWrittenResponse),
+    McpConfigExists(McpConfigExistsResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum McpConfigWrittenResponse {
+        V1 => {
+            pub path: PathBuf,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum McpConfigExistsResponse {
+        V1 => {
+            pub path: PathBuf,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/mcp/service.rs
+++ b/crates/oneiros-engine/src/domains/mcp/service.rs
@@ -6,13 +6,14 @@ pub struct McpConfigService;
 
 impl McpConfigService {
     pub fn init(config: &Config, request: &InitMcp) -> Result<McpConfigResponse, McpConfigError> {
-        let token = request
+        let details = request.current()?;
+        let token = details
             .token
             .clone()
             .or_else(|| config.token())
             .ok_or(McpConfigError::NoToken)?;
 
-        let address = request.address.unwrap_or(config.service_addr());
+        let address = details.address.unwrap_or(config.service_addr());
 
         let mcp_json = serde_json::json!({
             "mcpServers": {
@@ -28,23 +29,38 @@ impl McpConfigService {
 
         let path = Self::mcp_json_path();
 
-        if path.exists() && !request.yes {
+        if path.exists() && !details.yes {
             // In non-interactive contexts (like setup), the caller handles
             // the prompt. Here we just report the file exists.
-            return Ok(McpConfigResponse::McpConfigExists(path));
+            return Ok(McpConfigResponse::McpConfigExists(
+                McpConfigExistsResponse::builder_v1()
+                    .path(path)
+                    .build()
+                    .into(),
+            ));
         }
 
         let content = serde_json::to_string_pretty(&mcp_json)?;
         std::fs::write(&path, content)?;
 
-        Ok(McpConfigResponse::McpConfigWritten(path))
+        Ok(McpConfigResponse::McpConfigWritten(
+            McpConfigWrittenResponse::builder_v1()
+                .path(path)
+                .build()
+                .into(),
+        ))
     }
 
     /// Write the .mcp.json regardless of whether it exists.
     /// Used by setup after the user confirms.
     pub fn write(config: &Config, request: &InitMcp) -> Result<McpConfigResponse, McpConfigError> {
-        let mut forced = request.clone();
-        forced.yes = true;
+        let details = request.current()?;
+        let forced: InitMcp = InitMcp::builder_v1()
+            .maybe_token(details.token.clone())
+            .maybe_address(details.address)
+            .yes(true)
+            .build()
+            .into();
         Self::init(config, &forced)
     }
 

--- a/crates/oneiros-engine/src/domains/mcp/view.rs
+++ b/crates/oneiros-engine/src/domains/mcp/view.rs
@@ -16,25 +16,37 @@ impl McpView {
 
     pub fn render(self) -> Rendered<McpConfigResponse> {
         match self.response {
-            McpConfigResponse::McpConfigWritten(path) => {
+            McpConfigResponse::McpConfigWritten(McpConfigWrittenResponse::V1(details)) => {
+                let path = details.path;
                 let prompt = format!(
                     "{} MCP config written to {}.",
                     "✓".success(),
                     path.display()
                 );
                 Rendered::new(
-                    McpConfigResponse::McpConfigWritten(path),
+                    McpConfigResponse::McpConfigWritten(
+                        McpConfigWrittenResponse::builder_v1()
+                            .path(path)
+                            .build()
+                            .into(),
+                    ),
                     prompt,
                     String::new(),
                 )
             }
-            McpConfigResponse::McpConfigExists(path) => {
+            McpConfigResponse::McpConfigExists(McpConfigExistsResponse::V1(details)) => {
+                let path = details.path;
                 let prompt = format!(
                     "{}",
                     format!("MCP config already exists at {}. Skipped.", path.display()).muted()
                 );
                 Rendered::new(
-                    McpConfigResponse::McpConfigExists(path),
+                    McpConfigResponse::McpConfigExists(
+                        McpConfigExistsResponse::builder_v1()
+                            .path(path)
+                            .build()
+                            .into(),
+                    ),
                     prompt,
                     String::new(),
                 )

--- a/crates/oneiros-engine/src/domains/memory/client.rs
+++ b/crates/oneiros-engine/src/domains/memory/client.rs
@@ -9,30 +9,32 @@ impl<'a> MemoryClient<'a> {
         Self { client }
     }
 
-    pub async fn add(&self, request: &AddMemory) -> Result<MemoryResponse, ClientError> {
-        self.client.post("/memories", request).await
+    pub async fn add(&self, addition: &AddMemory) -> Result<MemoryResponse, ClientError> {
+        self.client.post("/memories", addition).await
     }
 
-    pub async fn list(&self, request: &ListMemories) -> Result<MemoryResponse, ClientError> {
+    pub async fn list(&self, listing: &ListMemories) -> Result<MemoryResponse, ClientError> {
+        let ListMemories::V1(listing) = listing;
         let mut params: Vec<(&str, String)> = Vec::new();
 
-        if let Some(a) = &request.agent {
-            params.push(("agent", a.to_string()));
+        if let Some(agent_name) = &listing.agent {
+            params.push(("agent", agent_name.to_string()));
         }
 
-        params.push(("limit", request.filters.limit.to_string()));
-        params.push(("offset", request.filters.offset.to_string()));
+        params.push(("limit", listing.filters.limit.to_string()));
+        params.push(("offset", listing.filters.offset.to_string()));
 
         let query = params
             .iter()
-            .map(|(k, v)| format!("{k}={v}"))
+            .map(|(key, value)| format!("{key}={value}"))
             .collect::<Vec<_>>()
             .join("&");
 
         self.client.get(&format!("/memories?{query}")).await
     }
 
-    pub async fn get(&self, request: &GetMemory) -> Result<MemoryResponse, ClientError> {
-        self.client.get(&format!("/memories/{}", request.key)).await
+    pub async fn get(&self, lookup: &GetMemory) -> Result<MemoryResponse, ClientError> {
+        let GetMemory::V1(lookup) = lookup;
+        self.client.get(&format!("/memories/{}", lookup.key)).await
     }
 }

--- a/crates/oneiros-engine/src/domains/memory/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/memory/features/cli.rs
@@ -18,18 +18,18 @@ impl MemoryCommands {
         let memory_client = MemoryClient::new(&client);
 
         let (response, request) = match self {
-            MemoryCommands::Add(addition) => {
-                let response = memory_client.add(addition).await?;
-                (response, MemoryRequest::AddMemory(addition.clone()))
-            }
-            MemoryCommands::Show(get) => {
-                let response = memory_client.get(get).await?;
-                (response, MemoryRequest::GetMemory(get.clone()))
-            }
-            MemoryCommands::List(listing) => {
-                let response = memory_client.list(listing).await?;
-                (response, MemoryRequest::ListMemories(listing.clone()))
-            }
+            Self::Add(addition) => (
+                memory_client.add(addition).await?,
+                MemoryRequest::AddMemory(addition.clone()),
+            ),
+            Self::Show(lookup) => (
+                memory_client.get(lookup).await?,
+                MemoryRequest::GetMemory(lookup.clone()),
+            ),
+            Self::List(listing) => (
+                memory_client.list(listing).await?,
+                MemoryRequest::ListMemories(listing.clone()),
+            ),
         };
 
         Ok(MemoryView::new(response, &request).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/memory/features/http.rs
+++ b/crates/oneiros-engine/src/domains/memory/features/http.rs
@@ -55,6 +55,6 @@ async fn show(
     Path(key): Path<ResourceKey<MemoryId>>,
 ) -> Result<Json<MemoryResponse>, MemoryError> {
     Ok(Json(
-        MemoryService::get(&context, &GetMemory::builder().key(key).build()).await?,
+        MemoryService::get(&context, &GetMemory::builder_v1().key(key).build().into()).await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/memory/features/state.rs
+++ b/crates/oneiros-engine/src/domains/memory/features/state.rs
@@ -4,8 +4,10 @@ pub struct MemoryState;
 
 impl MemoryState {
     pub fn reduce(mut canon: BrainCanon, event: &Events) -> BrainCanon {
-        if let Events::Memory(MemoryEvents::MemoryAdded(memory)) = event {
-            canon.memories.set(memory);
+        if let Events::Memory(MemoryEvents::MemoryAdded(added)) = event
+            && let Ok(current) = added.current()
+        {
+            canon.memories.set(&current.memory);
         }
 
         canon

--- a/crates/oneiros-engine/src/domains/memory/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/memory/protocol/events.rs
@@ -7,15 +7,52 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = MemoryEventsType, display = "kebab-case")]
 pub enum MemoryEvents {
-    MemoryAdded(Memory),
+    MemoryAdded(MemoryAdded),
+}
+
+versioned! {
+    pub enum MemoryAdded {
+        V1 => {
+            #[serde(flatten)] pub memory: Memory,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn sample_memory() -> Memory {
+        Memory::builder()
+            .agent_id(AgentId::new())
+            .level("project")
+            .content("A consolidated insight")
+            .build()
+    }
+
     #[test]
     fn event_types_are_kebab_cased() {
         assert_eq!(&MemoryEventsType::MemoryAdded.to_string(), "memory-added");
+    }
+
+    #[test]
+    fn memory_added_wire_format_is_flat() {
+        let event = MemoryEvents::MemoryAdded(MemoryAdded::V1(MemoryAddedV1 {
+            memory: sample_memory(),
+        }));
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "memory-added");
+        assert!(
+            json["data"].get("memory").is_none(),
+            "flatten must elide the memory envelope on the wire"
+        );
+        assert_eq!(json["data"]["level"], "project");
+        assert_eq!(json["data"]["content"], "A consolidated insight");
+        assert!(json["data"].get("id").is_some());
+        assert!(
+            json["data"].get("V1").is_none(),
+            "V1 layer must not appear on the wire"
+        );
     }
 }

--- a/crates/oneiros-engine/src/domains/memory/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/memory/protocol/requests.rs
@@ -1,35 +1,44 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct AddMemory {
-    #[builder(into)]
-    pub agent: AgentName,
-    #[builder(into)]
-    pub level: LevelName,
-    #[builder(into)]
-    pub content: Content,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum AddMemory {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+            #[builder(into)] pub level: LevelName,
+            #[builder(into)] pub content: Content,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetMemory {
-    #[builder(into)]
-    pub key: ResourceKey<MemoryId>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetMemory {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<MemoryId>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListMemories {
-    #[arg(long)]
-    pub agent: Option<AgentName>,
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListMemories {
+        #[derive(clap::Args)]
+        V1 => {
+            #[arg(long)]
+            pub agent: Option<AgentName>,
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/memory/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/memory/protocol/responses.rs
@@ -1,14 +1,39 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = MemoryResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum MemoryResponse {
-    MemoryAdded(Response<Memory>),
-    MemoryDetails(Response<Memory>),
-    Memories(Listed<Response<Memory>>),
+    MemoryAdded(MemoryAddedResponse),
+    MemoryDetails(MemoryDetailsResponse),
+    Memories(MemoriesResponse),
     NoMemories,
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum MemoryAddedResponse {
+        V1 => { #[serde(flatten)] pub memory: Memory }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum MemoryDetailsResponse {
+        V1 => { #[serde(flatten)] pub memory: Memory }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum MemoriesResponse {
+        V1 => {
+            pub items: Vec<Memory>,
+            pub total: usize,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/memory/service.rs
+++ b/crates/oneiros-engine/src/domains/memory/service.rs
@@ -5,52 +5,61 @@ pub struct MemoryService;
 impl MemoryService {
     pub async fn add(
         context: &ProjectContext,
-        AddMemory {
-            agent,
-            level,
-            content,
-        }: &AddMemory,
+        request: &AddMemory,
     ) -> Result<MemoryResponse, MemoryError> {
+        let AddMemory::V1(addition) = request;
         let agent_record = AgentRepo::new(context)
-            .get(agent)
+            .get(&addition.agent)
             .await?
-            .ok_or_else(|| MemoryError::AgentNotFound(agent.clone()))?;
+            .ok_or_else(|| MemoryError::AgentNotFound(addition.agent.clone()))?;
 
         let memory = Memory::builder()
             .agent_id(agent_record.id)
-            .level(level.clone())
-            .content(content.clone())
+            .level(addition.level.clone())
+            .content(addition.content.clone())
             .build();
 
         context
-            .emit(MemoryEvents::MemoryAdded(memory.clone()))
+            .emit(MemoryEvents::MemoryAdded(
+                MemoryAdded::builder_v1()
+                    .memory(memory.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        let ref_token = RefToken::new(Ref::memory(memory.id));
+
         Ok(MemoryResponse::MemoryAdded(
-            Response::new(memory).with_ref_token(ref_token),
+            MemoryAddedResponse::builder_v1()
+                .memory(memory)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn get(
         context: &ProjectContext,
-        selector: &GetMemory,
+        request: &GetMemory,
     ) -> Result<MemoryResponse, MemoryError> {
-        let id = selector.key.resolve()?;
+        let GetMemory::V1(lookup) = request;
+        let id = lookup.key.resolve()?;
         let memory = MemoryRepo::new(context)
             .get(&id)
             .await?
             .ok_or(MemoryError::NotFound(id))?;
-        let ref_token = RefToken::new(Ref::memory(memory.id));
         Ok(MemoryResponse::MemoryDetails(
-            Response::new(memory).with_ref_token(ref_token),
+            MemoryDetailsResponse::builder_v1()
+                .memory(memory)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn list(
         context: &ProjectContext,
-        ListMemories { agent, filters }: &ListMemories,
+        request: &ListMemories,
     ) -> Result<MemoryResponse, MemoryError> {
-        let agent_id = match agent {
+        let ListMemories::V1(listing) = request;
+        let agent_id = match &listing.agent {
             Some(name) => {
                 let record = AgentRepo::new(context)
                     .get(name)
@@ -62,15 +71,18 @@ impl MemoryService {
         };
 
         let listed = MemoryRepo::new(context)
-            .list(agent_id.as_deref(), filters)
+            .list(agent_id.as_deref(), &listing.filters)
             .await?;
         Ok(if listed.total == 0 {
             MemoryResponse::NoMemories
         } else {
-            MemoryResponse::Memories(listed.map(|m| {
-                let ref_token = RefToken::new(Ref::memory(m.id));
-                Response::new(m).with_ref_token(ref_token)
-            }))
+            MemoryResponse::Memories(
+                MemoriesResponse::builder_v1()
+                    .items(listed.items)
+                    .total(listed.total)
+                    .build()
+                    .into(),
+            )
         })
     }
 }

--- a/crates/oneiros-engine/src/domains/memory/store.rs
+++ b/crates/oneiros-engine/src/domains/memory/store.rs
@@ -15,7 +15,10 @@ impl<'a> MemoryStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Memory(memory_event)) = &event.data {
             match memory_event {
-                MemoryEvents::MemoryAdded(memory) => self.insert(memory)?,
+                MemoryEvents::MemoryAdded(added) => {
+                    let memory = added.current()?.memory;
+                    self.write_memory(&memory)?
+                }
             }
         }
         Ok(())
@@ -114,7 +117,7 @@ impl<'a> MemoryStore<'a> {
         Ok(memories)
     }
 
-    fn insert(&self, memory: &Memory) -> Result<(), EventError> {
+    fn write_memory(&self, memory: &Memory) -> Result<(), EventError> {
         self.conn.execute(
             "INSERT OR REPLACE INTO memories (id, agent_id, level, content, created_at)
              VALUES (?1, ?2, ?3, ?4, ?5)",

--- a/crates/oneiros-engine/src/domains/memory/view.rs
+++ b/crates/oneiros-engine/src/domains/memory/view.rs
@@ -17,24 +17,24 @@ impl<'a> MemoryView<'a> {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            MemoryResponse::MemoryAdded(wrapped) => {
-                let ref_token = wrapped.data.ref_token();
+            MemoryResponse::MemoryAdded(MemoryAddedResponse::V1(added)) => {
+                let ref_token = RefToken::new(Ref::memory(added.memory.id));
                 McpResponse::new(format!(
                     "Memory consolidated ({}).\n\n**level:** {}\n**ref:** {}",
-                    wrapped.data.level, wrapped.data.level, ref_token
+                    added.memory.level, added.memory.level, ref_token
                 ))
                 .hint_set(HintSet::mutation(
                     MutationHints::builder().ref_token(ref_token).build(),
                 ))
             }
-            MemoryResponse::MemoryDetails(wrapped) => {
-                let ref_token = wrapped.data.ref_token();
+            MemoryResponse::MemoryDetails(MemoryDetailsResponse::V1(details)) => {
+                let ref_token = RefToken::new(Ref::memory(details.memory.id));
                 McpResponse::new(format!(
                     "# Memory\n\n**level:** {}\n**agent:** {}\n**created:** {}\n\n{}\n",
-                    wrapped.data.level,
-                    wrapped.data.agent_id,
-                    wrapped.data.created_at,
-                    wrapped.data.content
+                    details.memory.level,
+                    details.memory.agent_id,
+                    details.memory.created_at,
+                    details.memory.content
                 ))
                 .hint(Hint::suggest(
                     format!("create-connection <nature> {ref_token} <target>"),
@@ -42,24 +42,30 @@ impl<'a> MemoryView<'a> {
                 ))
                 .hint(Hint::suggest("search-query", "Search for related entities"))
             }
-            MemoryResponse::Memories(listed) => {
+            MemoryResponse::Memories(MemoriesResponse::V1(listed)) => {
                 let title = match self.request {
-                    MemoryRequest::ListMemories(listing) => match &listing.agent {
-                        Some(agent) => format!("# Memories — {agent}\n\n"),
-                        None => "# Memories\n\n".to_string(),
-                    },
+                    MemoryRequest::ListMemories(ListMemories::V1(listing)) => {
+                        match &listing.agent {
+                            Some(agent) => format!("# Memories — {agent}\n\n"),
+                            None => "# Memories\n\n".to_string(),
+                        }
+                    }
                     _ => "# Memories\n\n".to_string(),
                 };
-                let mut md = format!("{title}{} of {} total\n\n", listed.len(), listed.total);
-                for wrapped in &listed.items {
+                let mut md = format!(
+                    "{title}{} of {} total\n\n",
+                    listed.items.len(),
+                    listed.total
+                );
+                for item in &listed.items {
                     md.push_str(&format!(
                         "### {} — {}\n{}\n\n",
-                        wrapped.data.level, wrapped.data.created_at, wrapped.data.content
+                        item.level, item.created_at, item.content
                     ));
                 }
                 let mut response = McpResponse::new(md)
                     .hint(Hint::suggest("add-memory", "Consolidate what matters"));
-                if let MemoryRequest::ListMemories(listing) = self.request
+                if let MemoryRequest::ListMemories(ListMemories::V1(listing)) = self.request
                     && let Some(agent) = &listing.agent
                 {
                     response = response.hint(Hint::inspect(
@@ -76,81 +82,78 @@ impl<'a> MemoryView<'a> {
 
     pub fn render(self) -> Rendered<MemoryResponse> {
         match (self.response, self.request) {
-            (MemoryResponse::MemoryAdded(wrapped), _) => {
-                let subject = wrapped
-                    .meta()
-                    .ref_token()
-                    .map(|ref_token| {
-                        format!("{} Memory recorded: {}", "✓".success(), ref_token.muted())
-                    })
-                    .unwrap_or_default();
-
-                let hints = match wrapped.meta().ref_token() {
-                    Some(ref_token) => {
-                        HintSet::mutation(MutationHints::builder().ref_token(ref_token).build())
-                    }
-                    None => HintSet::None,
-                };
-
-                Rendered::new(MemoryResponse::MemoryAdded(wrapped), subject, String::new())
-                    .with_hints(hints)
-            }
-            (MemoryResponse::MemoryDetails(wrapped), _) => {
-                let prompt = Detail::new(wrapped.data.level.to_string())
-                    .field("content:", wrapped.data.content.to_string())
-                    .to_string();
-
-                let hints = match wrapped.meta().ref_token() {
-                    Some(ref_token) => {
-                        HintSet::mutation(MutationHints::builder().ref_token(ref_token).build())
-                    }
-                    None => HintSet::None,
-                };
+            (MemoryResponse::MemoryAdded(MemoryAddedResponse::V1(added)), _) => {
+                let ref_token = RefToken::new(Ref::memory(added.memory.id));
+                let subject = format!(
+                    "{} Memory recorded: {}",
+                    "✓".success(),
+                    ref_token.clone().muted()
+                );
+                let hints =
+                    HintSet::mutation(MutationHints::builder().ref_token(ref_token).build());
 
                 Rendered::new(
-                    MemoryResponse::MemoryDetails(wrapped),
+                    MemoryResponse::MemoryAdded(MemoryAddedResponse::V1(added)),
+                    subject,
+                    String::new(),
+                )
+                .with_hints(hints)
+            }
+            (MemoryResponse::MemoryDetails(MemoryDetailsResponse::V1(details)), _) => {
+                let prompt = Detail::new(details.memory.level.to_string())
+                    .field("content:", details.memory.content.to_string())
+                    .to_string();
+                let ref_token = RefToken::new(Ref::memory(details.memory.id));
+                let hints =
+                    HintSet::mutation(MutationHints::builder().ref_token(ref_token).build());
+
+                Rendered::new(
+                    MemoryResponse::MemoryDetails(MemoryDetailsResponse::V1(details)),
                     prompt,
                     String::new(),
                 )
                 .with_hints(hints)
             }
-            (MemoryResponse::Memories(listed), MemoryRequest::ListMemories(listing)) => {
+            (
+                MemoryResponse::Memories(MemoriesResponse::V1(listed)),
+                MemoryRequest::ListMemories(ListMemories::V1(listing)),
+            ) => {
                 let mut table = Table::new(vec![
                     Column::key("level", "Level"),
                     Column::key("content", "Content").max(60),
                     Column::key("ref_token", "Ref"),
                 ]);
 
-                for wrapped in &listed.items {
-                    let ref_token = wrapped
-                        .meta()
-                        .ref_token()
-                        .map(|t| t.to_string())
-                        .unwrap_or_default();
+                for item in &listed.items {
+                    let ref_token = RefToken::new(Ref::memory(item.id));
                     table.push_row(vec![
-                        wrapped.data.level.to_string(),
-                        wrapped.data.content.to_string(),
-                        ref_token,
+                        item.level.to_string(),
+                        item.content.to_string(),
+                        ref_token.to_string(),
                     ]);
                 }
 
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
 
                 let hints = match &listing.agent {
                     Some(agent) => HintSet::listing(
                         ListingHints::builder()
                             .agent(agent.clone())
-                            .has_more(listed.len() < listed.total)
+                            .has_more(listed.items.len() < listed.total)
                             .build(),
                     ),
                     None => HintSet::None,
                 };
 
-                Rendered::new(MemoryResponse::Memories(listed), prompt, String::new())
-                    .with_hints(hints)
+                Rendered::new(
+                    MemoryResponse::Memories(MemoriesResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
             (MemoryResponse::NoMemories, _) => Rendered::new(
                 MemoryResponse::NoMemories,

--- a/crates/oneiros-engine/src/domains/nature/client.rs
+++ b/crates/oneiros-engine/src/domains/nature/client.rs
@@ -9,25 +9,31 @@ impl<'a> NatureClient<'a> {
         Self { client }
     }
 
-    pub async fn set(&self, set: &SetNature) -> Result<NatureResponse, ClientError> {
+    pub async fn set(&self, setting: &SetNature) -> Result<NatureResponse, ClientError> {
+        let SetNature::V1(body) = setting;
         self.client
-            .put(&format!("/natures/{}", set.name), set)
+            .put(&format!("/natures/{}", body.name), setting)
             .await
     }
 
-    pub async fn get(&self, request: &GetNature) -> Result<NatureResponse, ClientError> {
-        self.client.get(&format!("/natures/{}", request.key)).await
+    pub async fn get(&self, lookup: &GetNature) -> Result<NatureResponse, ClientError> {
+        let GetNature::V1(lookup) = lookup;
+        self.client.get(&format!("/natures/{}", lookup.key)).await
     }
 
-    pub async fn list(&self, request: &ListNatures) -> Result<NatureResponse, ClientError> {
+    pub async fn list(&self, listing: &ListNatures) -> Result<NatureResponse, ClientError> {
+        let ListNatures::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset,
+            listing.filters.limit, listing.filters.offset,
         );
         self.client.get(&format!("/natures?{query}")).await
     }
 
-    pub async fn remove(&self, name: &NatureName) -> Result<NatureResponse, ClientError> {
-        self.client.delete(&format!("/natures/{name}")).await
+    pub async fn remove(&self, removal: &RemoveNature) -> Result<NatureResponse, ClientError> {
+        let RemoveNature::V1(removal) = removal;
+        self.client
+            .delete(&format!("/natures/{}", removal.name))
+            .await
     }
 }

--- a/crates/oneiros-engine/src/domains/nature/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/nature/features/cli.rs
@@ -2,6 +2,11 @@ use clap::Subcommand;
 
 use crate::*;
 
+/// CLI subcommands for the nature domain. Each variant carries a versioned
+/// protocol request directly — clap derives parsing through the wrapper's
+/// `Args` impl, which delegates to the latest version's struct. The
+/// dispatcher passes the wrapper through to the client without rebuilding,
+/// since the operation type *is* the domain command.
 #[derive(Debug, Subcommand)]
 pub enum NatureCommands {
     Set(SetNature),
@@ -19,10 +24,10 @@ impl NatureCommands {
         let nature_client = NatureClient::new(&client);
 
         let response = match self {
-            NatureCommands::Set(set) => nature_client.set(set).await?,
-            NatureCommands::Show(get) => nature_client.get(get).await?,
-            NatureCommands::List(list) => nature_client.list(list).await?,
-            NatureCommands::Remove(removal) => nature_client.remove(&removal.name).await?,
+            Self::Set(setting) => nature_client.set(setting).await?,
+            Self::Show(lookup) => nature_client.get(lookup).await?,
+            Self::List(listing) => nature_client.list(listing).await?,
+            Self::Remove(removal) => nature_client.remove(removal).await?,
         };
 
         Ok(NatureView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/nature/features/http.rs
+++ b/crates/oneiros-engine/src/domains/nature/features/http.rs
@@ -41,12 +41,14 @@ impl NatureRouter {
 async fn set(
     context: ProjectContext,
     Path(name): Path<NatureName>,
-    Json(mut body): Json<SetNature>,
+    Json(body): Json<SetNature>,
 ) -> Result<(StatusCode, Json<NatureResponse>), NatureError> {
-    body.name = name;
+    let SetNature::V1(mut setting) = body;
+    setting.name = name;
+    let request = SetNature::V1(setting);
     Ok((
         StatusCode::OK,
-        Json(NatureService::set(&context, &body).await?),
+        Json(NatureService::set(&context, &request).await?),
     ))
 }
 
@@ -62,7 +64,7 @@ async fn show(
     Path(key): Path<ResourceKey<NatureName>>,
 ) -> Result<Json<NatureResponse>, NatureError> {
     Ok(Json(
-        NatureService::get(&context, &GetNature::builder().key(key).build()).await?,
+        NatureService::get(&context, &GetNature::builder_v1().key(key).build().into()).await?,
     ))
 }
 
@@ -71,6 +73,10 @@ async fn remove(
     Path(name): Path<NatureName>,
 ) -> Result<Json<NatureResponse>, NatureError> {
     Ok(Json(
-        NatureService::remove(&context, &RemoveNature::builder().name(name).build()).await?,
+        NatureService::remove(
+            &context,
+            &RemoveNature::builder_v1().name(name).build().into(),
+        )
+        .await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/nature/features/state.rs
+++ b/crates/oneiros-engine/src/domains/nature/features/state.rs
@@ -6,11 +6,15 @@ impl NatureState {
     pub fn reduce(mut canon: BrainCanon, event: &Events) -> BrainCanon {
         if let Events::Nature(nature_event) = event {
             match nature_event {
-                NatureEvents::NatureSet(nature) => {
-                    canon.natures.set(nature);
+                NatureEvents::NatureSet(setting) => {
+                    if let Ok(current) = setting.current() {
+                        canon.natures.set(&current.nature);
+                    }
                 }
-                NatureEvents::NatureRemoved(removed) => {
-                    canon.natures.remove(&removed.name);
+                NatureEvents::NatureRemoved(removal) => {
+                    if let Ok(current) = removal.current() {
+                        canon.natures.remove(&current.name);
+                    }
                 }
             };
         }

--- a/crates/oneiros-engine/src/domains/nature/model.rs
+++ b/crates/oneiros-engine/src/domains/nature/model.rs
@@ -1,20 +1,17 @@
 use bon::Builder;
-use clap::Args;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::*;
 
-#[derive(Args, Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct Nature {
     #[builder(into)]
     pub name: NatureName,
     #[builder(into)]
-    #[arg(long, default_value = "")]
     pub description: Description,
     #[builder(into)]
-    #[arg(long, default_value = "")]
     pub prompt: Prompt,
 }
 

--- a/crates/oneiros-engine/src/domains/nature/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/nature/protocol/events.rs
@@ -7,13 +7,37 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = NatureEventsType, display = "kebab-case")]
 pub enum NatureEvents {
-    NatureSet(Nature),
+    NatureSet(NatureSet),
     NatureRemoved(NatureRemoved),
+}
+
+versioned! {
+    pub enum NatureSet {
+        V1 => {
+            #[serde(flatten)] pub nature: Nature,
+        }
+    }
+}
+
+versioned! {
+    pub enum NatureRemoved {
+        V1 => {
+            #[builder(into)] pub name: NatureName,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_nature() -> Nature {
+        Nature::builder()
+            .name("context")
+            .description("Provides background")
+            .prompt("Use when one thing frames another.")
+            .build()
+    }
 
     #[test]
     fn event_types_are_kebab_cased() {
@@ -25,9 +49,42 @@ mod tests {
             assert_eq!(&event_type.to_string(), expectation);
         }
     }
-}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NatureRemoved {
-    pub name: NatureName,
+    #[test]
+    fn nature_set_wire_format_is_flat() {
+        let event = NatureEvents::NatureSet(NatureSet::V1(NatureSetV1 {
+            nature: sample_nature(),
+        }));
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "nature-set");
+        assert!(
+            json["data"].get("nature").is_none(),
+            "flatten must elide the nature envelope on the wire"
+        );
+        assert_eq!(json["data"]["name"], "context");
+        assert_eq!(json["data"]["description"], "Provides background");
+        assert!(
+            json["data"].get("V1").is_none(),
+            "V1 layer must not appear on the wire"
+        );
+    }
+
+    #[test]
+    fn nature_removed_round_trips_through_v1_layer() {
+        let original = NatureEvents::NatureRemoved(NatureRemoved::V1(NatureRemovedV1 {
+            name: NatureName::new("context"),
+        }));
+
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: NatureEvents = serde_json::from_str(&json).unwrap();
+
+        match decoded {
+            NatureEvents::NatureRemoved(removed) => {
+                let v1 = removed.current().unwrap();
+                assert_eq!(v1.name.to_string(), "context");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/nature/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/nature/protocol/requests.rs
@@ -1,41 +1,56 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct SetNature {
-    #[builder(into)]
-    pub name: NatureName,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub description: Description,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub prompt: Prompt,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SetNature {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: NatureName,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub description: Description,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub prompt: Prompt,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetNature {
-    #[builder(into)]
-    pub key: ResourceKey<NatureName>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetNature {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<NatureName>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct RemoveNature {
-    #[builder(into)]
-    pub name: NatureName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum RemoveNature {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: NatureName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListNatures {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListNatures {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/nature/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/nature/protocol/responses.rs
@@ -1,15 +1,49 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = NatureResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum NatureResponse {
-    NatureSet(NatureName),
-    NatureDetails(Response<Nature>),
-    Natures(Listed<Response<Nature>>),
+    NatureSet(NatureSetResponse),
+    NatureDetails(NatureDetailsResponse),
+    Natures(NaturesResponse),
     NoNatures,
-    NatureRemoved(NatureName),
+    NatureRemoved(NatureRemovedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum NatureSetResponse {
+        V1 => { #[serde(flatten)] pub nature: Nature }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum NatureDetailsResponse {
+        V1 => { #[serde(flatten)] pub nature: Nature }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum NaturesResponse {
+        V1 => {
+            pub items: Vec<Nature>,
+            pub total: usize,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum NatureRemovedResponse {
+        V1 => {
+            #[builder(into)] pub name: NatureName,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/nature/service.rs
+++ b/crates/oneiros-engine/src/domains/nature/service.rs
@@ -5,60 +5,87 @@ pub struct NatureService;
 impl NatureService {
     pub async fn set(
         context: &ProjectContext,
-        SetNature {
-            name,
-            description,
-            prompt,
-        }: &SetNature,
+        request: &SetNature,
     ) -> Result<NatureResponse, NatureError> {
+        let SetNature::V1(set) = request;
         let nature = Nature::builder()
-            .name(name.clone())
-            .description(description.clone())
-            .prompt(prompt.clone())
+            .name(set.name.clone())
+            .description(set.description.clone())
+            .prompt(set.prompt.clone())
             .build();
-        context.emit(NatureEvents::NatureSet(nature)).await?;
-        Ok(NatureResponse::NatureSet(name.clone()))
+
+        context
+            .emit(NatureEvents::NatureSet(
+                NatureSet::builder_v1()
+                    .nature(nature.clone())
+                    .build()
+                    .into(),
+            ))
+            .await?;
+
+        Ok(NatureResponse::NatureSet(
+            NatureSetResponse::builder_v1()
+                .nature(nature)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn get(
         context: &ProjectContext,
-        selector: &GetNature,
+        request: &GetNature,
     ) -> Result<NatureResponse, NatureError> {
-        let name = selector.key.resolve()?;
+        let GetNature::V1(lookup) = request;
+        let name = lookup.key.resolve()?;
         let nature = NatureRepo::new(context)
             .get(&name)
             .await?
             .ok_or(NatureError::NotFound(name))?;
-        let ref_token = RefToken::new(Ref::nature(nature.name.clone()));
         Ok(NatureResponse::NatureDetails(
-            Response::new(nature).with_ref_token(ref_token),
+            NatureDetailsResponse::builder_v1()
+                .nature(nature)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn list(
         context: &ProjectContext,
-        ListNatures { filters }: &ListNatures,
+        request: &ListNatures,
     ) -> Result<NatureResponse, NatureError> {
-        let listed = NatureRepo::new(context).list(filters).await?;
+        let ListNatures::V1(listing) = request;
+        let listed = NatureRepo::new(context).list(&listing.filters).await?;
         if listed.total == 0 {
             Ok(NatureResponse::NoNatures)
         } else {
-            Ok(NatureResponse::Natures(listed.map(|e| {
-                let ref_token = RefToken::new(Ref::nature(e.name.clone()));
-                Response::new(e).with_ref_token(ref_token)
-            })))
+            Ok(NatureResponse::Natures(
+                NaturesResponse::builder_v1()
+                    .items(listed.items)
+                    .total(listed.total)
+                    .build()
+                    .into(),
+            ))
         }
     }
 
     pub async fn remove(
         context: &ProjectContext,
-        selector: &RemoveNature,
+        request: &RemoveNature,
     ) -> Result<NatureResponse, NatureError> {
+        let RemoveNature::V1(removal) = request;
         context
-            .emit(NatureEvents::NatureRemoved(NatureRemoved {
-                name: selector.name.clone(),
-            }))
+            .emit(NatureEvents::NatureRemoved(
+                NatureRemoved::builder_v1()
+                    .name(removal.name.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        Ok(NatureResponse::NatureRemoved(selector.name.clone()))
+        Ok(NatureResponse::NatureRemoved(
+            NatureRemovedResponse::builder_v1()
+                .name(removal.name.clone())
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/nature/store.rs
+++ b/crates/oneiros-engine/src/domains/nature/store.rs
@@ -14,8 +14,8 @@ impl<'a> NatureStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Nature(nature_event)) = &event.data {
             match nature_event {
-                NatureEvents::NatureSet(nature) => self.set(nature)?,
-                NatureEvents::NatureRemoved(removed) => self.remove(&removed.name)?,
+                NatureEvents::NatureSet(setting) => self.set(setting)?,
+                NatureEvents::NatureRemoved(removal) => self.remove(removal)?,
             }
         }
         Ok(())
@@ -64,7 +64,21 @@ impl<'a> NatureStore<'a> {
         Ok(natures)
     }
 
-    fn set(&self, nature: &Nature) -> Result<(), EventError> {
+    fn set(&self, setting: &NatureSet) -> Result<(), EventError> {
+        let nature = setting.current()?.nature;
+        self.write_nature(&nature)
+    }
+
+    fn remove(&self, removal: &NatureRemoved) -> Result<(), EventError> {
+        let name = removal.current()?.name;
+        self.conn.execute(
+            "DELETE FROM natures WHERE name = ?1",
+            params![name.to_string()],
+        )?;
+        Ok(())
+    }
+
+    fn write_nature(&self, nature: &Nature) -> Result<(), EventError> {
         self.conn.execute(
             "INSERT OR REPLACE INTO natures (name, description, prompt) VALUES (?1, ?2, ?3)",
             params![
@@ -72,14 +86,6 @@ impl<'a> NatureStore<'a> {
                 nature.description.to_string(),
                 nature.prompt.to_string()
             ],
-        )?;
-        Ok(())
-    }
-
-    fn remove(&self, name: &NatureName) -> Result<(), EventError> {
-        self.conn.execute(
-            "DELETE FROM natures WHERE name = ?1",
-            params![name.to_string()],
         )?;
         Ok(())
     }

--- a/crates/oneiros-engine/src/domains/nature/view.rs
+++ b/crates/oneiros-engine/src/domains/nature/view.rs
@@ -11,25 +11,27 @@ impl NatureView {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            NatureResponse::Natures(listed) => {
+            NatureResponse::Natures(NaturesResponse::V1(listed)) => {
                 let items: Vec<_> = listed
                     .items
                     .iter()
-                    .map(|w| (w.data.name.to_string(), w.data.description.to_string()))
+                    .map(|item| (item.name.to_string(), item.description.to_string()))
                     .collect();
                 Self::vocabulary_table("Natures", &items)
             }
-            NatureResponse::NatureDetails(wrapped) => {
+            NatureResponse::NatureDetails(NatureDetailsResponse::V1(details)) => {
                 let items = vec![(
-                    wrapped.data.name.to_string(),
-                    wrapped.data.description.to_string(),
+                    details.nature.name.to_string(),
+                    details.nature.description.to_string(),
                 )];
                 Self::vocabulary_table("Nature", &items)
             }
             NatureResponse::NoNatures => Self::vocabulary_table("Natures", &[]),
-            NatureResponse::NatureSet(name) => McpResponse::new(format!("Nature set: {name}")),
-            NatureResponse::NatureRemoved(name) => {
-                McpResponse::new(format!("Nature removed: {name}"))
+            NatureResponse::NatureSet(NatureSetResponse::V1(set)) => {
+                McpResponse::new(format!("Nature set: {}", set.nature.name))
+            }
+            NatureResponse::NatureRemoved(NatureRemovedResponse::V1(removed)) => {
+                McpResponse::new(format!("Nature removed: {}", removed.name))
             }
         }
     }
@@ -50,58 +52,69 @@ impl NatureView {
 
     pub fn render(self) -> Rendered<NatureResponse> {
         match self.response {
-            NatureResponse::NatureSet(name) => {
-                let prompt = Confirmation::new("Nature", name.to_string(), "set").to_string();
+            NatureResponse::NatureSet(NatureSetResponse::V1(set)) => {
+                let prompt =
+                    Confirmation::new("Nature", set.nature.name.to_string(), "set").to_string();
                 let hints = HintSet::vocabulary(
                     VocabularyHints::builder()
                         .kind("nature".to_string())
                         .build(),
                 );
-                Rendered::new(NatureResponse::NatureSet(name), prompt, String::new())
-                    .with_hints(hints)
+                Rendered::new(
+                    NatureResponse::NatureSet(NatureSetResponse::V1(set)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
-            NatureResponse::NatureDetails(wrapped) => {
-                let prompt = Detail::new(wrapped.data.name.to_string())
-                    .field("description:", wrapped.data.description.to_string())
-                    .field("prompt:", wrapped.data.prompt.to_string())
+            NatureResponse::NatureDetails(NatureDetailsResponse::V1(details)) => {
+                let prompt = Detail::new(details.nature.name.to_string())
+                    .field("description:", details.nature.description.to_string())
+                    .field("prompt:", details.nature.prompt.to_string())
                     .to_string();
                 Rendered::new(
-                    NatureResponse::NatureDetails(wrapped),
+                    NatureResponse::NatureDetails(NatureDetailsResponse::V1(details)),
                     prompt,
                     String::new(),
                 )
             }
-            NatureResponse::Natures(listed) => {
+            NatureResponse::Natures(NaturesResponse::V1(listed)) => {
                 let mut table = Table::new(vec![
                     Column::key("name", "Name"),
                     Column::key("description", "Description").max(60),
                 ]);
-                for wrapped in &listed.items {
-                    table.push_row(vec![
-                        wrapped.data.name.to_string(),
-                        wrapped.data.description.to_string(),
-                    ]);
+                for item in &listed.items {
+                    table.push_row(vec![item.name.to_string(), item.description.to_string()]);
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
-                Rendered::new(NatureResponse::Natures(listed), prompt, String::new())
+                Rendered::new(
+                    NatureResponse::Natures(NaturesResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
             NatureResponse::NoNatures => Rendered::new(
                 NatureResponse::NoNatures,
                 format!("{}", "No natures configured.".muted()),
                 String::new(),
             ),
-            NatureResponse::NatureRemoved(name) => {
-                let prompt = Confirmation::new("Nature", name.to_string(), "removed").to_string();
+            NatureResponse::NatureRemoved(NatureRemovedResponse::V1(removed)) => {
+                let prompt =
+                    Confirmation::new("Nature", removed.name.to_string(), "removed").to_string();
                 let hints = HintSet::vocabulary(
                     VocabularyHints::builder()
                         .kind("nature".to_string())
                         .build(),
                 );
-                Rendered::new(NatureResponse::NatureRemoved(name), prompt, String::new())
-                    .with_hints(hints)
+                Rendered::new(
+                    NatureResponse::NatureRemoved(NatureRemovedResponse::V1(removed)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/peer/client.rs
+++ b/crates/oneiros-engine/src/domains/peer/client.rs
@@ -15,19 +15,22 @@ impl<'a> PeerClient<'a> {
         self.client.post("/peers", add).await
     }
 
-    pub async fn get(&self, request: &GetPeer) -> Result<PeerResponse, ClientError> {
-        self.client.get(&format!("/peers/{}", request.key)).await
+    pub async fn get(&self, lookup: &GetPeer) -> Result<PeerResponse, ClientError> {
+        let GetPeer::V1(lookup) = lookup;
+        self.client.get(&format!("/peers/{}", lookup.key)).await
     }
 
-    pub async fn list(&self, request: &ListPeers) -> Result<PeerResponse, ClientError> {
+    pub async fn list(&self, listing: &ListPeers) -> Result<PeerResponse, ClientError> {
+        let ListPeers::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset,
+            listing.filters.limit, listing.filters.offset,
         );
         self.client.get(&format!("/peers?{query}")).await
     }
 
-    pub async fn remove(&self, id: &PeerId) -> Result<PeerResponse, ClientError> {
-        self.client.delete(&format!("/peers/{}", id)).await
+    pub async fn remove(&self, removal: &RemovePeer) -> Result<PeerResponse, ClientError> {
+        let RemovePeer::V1(removal) = removal;
+        self.client.delete(&format!("/peers/{}", removal.id)).await
     }
 }

--- a/crates/oneiros-engine/src/domains/peer/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/peer/features/cli.rs
@@ -16,10 +16,10 @@ impl PeerCommands {
         let peer_client = PeerClient::new(&client);
 
         let response = match self {
-            PeerCommands::Add(add) => peer_client.add(add).await?,
-            PeerCommands::Get(get) => peer_client.get(get).await?,
-            PeerCommands::List(list) => peer_client.list(list).await?,
-            PeerCommands::Remove(remove) => peer_client.remove(&remove.id).await?,
+            Self::Add(addition) => peer_client.add(addition).await?,
+            Self::Get(lookup) => peer_client.get(lookup).await?,
+            Self::List(listing) => peer_client.list(listing).await?,
+            Self::Remove(removal) => peer_client.remove(removal).await?,
         };
 
         Ok(PeerView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/peer/features/http.rs
+++ b/crates/oneiros-engine/src/domains/peer/features/http.rs
@@ -50,7 +50,7 @@ async fn show(
     Path(key): Path<ResourceKey<PeerId>>,
 ) -> Result<Json<PeerResponse>, PeerError> {
     Ok(Json(
-        PeerService::get(&context, &GetPeer::builder().key(key).build()).await?,
+        PeerService::get(&context, &GetPeer::builder_v1().key(key).build().into()).await?,
     ))
 }
 
@@ -59,6 +59,6 @@ async fn remove(
     Path(id): Path<PeerId>,
 ) -> Result<Json<PeerResponse>, PeerError> {
     Ok(Json(
-        PeerService::remove(&context, &RemovePeer::builder().id(id).build()).await?,
+        PeerService::remove(&context, &RemovePeer::builder_v1().id(id).build().into()).await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/peer/features/state.rs
+++ b/crates/oneiros-engine/src/domains/peer/features/state.rs
@@ -6,14 +6,34 @@ impl PeerState {
     pub fn reduce(mut canon: SystemCanon, event: &Events) -> SystemCanon {
         if let Events::Peer(peer_event) = event {
             match peer_event {
-                PeerEvents::PeerAdded(peer) => {
-                    canon.peers.set(peer);
+                PeerEvents::PeerAdded(added) => {
+                    if let Ok(current) = added.current() {
+                        let peer = Peer::builder()
+                            .id(current.id)
+                            .key(current.key)
+                            .address(current.address)
+                            .name(current.name)
+                            .created_at(current.created_at)
+                            .build();
+                        canon.peers.set(&peer);
+                    }
                 }
-                PeerEvents::PeerUpdated(peer) => {
-                    canon.peers.set(peer);
+                PeerEvents::PeerUpdated(updated) => {
+                    if let Ok(current) = updated.current() {
+                        let peer = Peer::builder()
+                            .id(current.id)
+                            .key(current.key)
+                            .address(current.address)
+                            .name(current.name)
+                            .created_at(current.created_at)
+                            .build();
+                        canon.peers.set(&peer);
+                    }
                 }
                 PeerEvents::PeerRemoved(removed) => {
-                    canon.peers.remove(removed.id);
+                    if let Ok(current) = removed.current() {
+                        canon.peers.remove(current.id);
+                    }
                 }
             };
         }

--- a/crates/oneiros-engine/src/domains/peer/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/peer/protocol/events.rs
@@ -7,17 +7,41 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = PeerEventsType, display = "kebab-case")]
 pub enum PeerEvents {
-    /// A peer was added to this host's known-peers table.
-    PeerAdded(Peer),
-    /// A peer's address (or other mutable field) was refreshed.
-    PeerUpdated(Peer),
-    /// A peer was explicitly removed from this host's known-peers table.
+    PeerAdded(PeerAdded),
+    PeerUpdated(PeerUpdated),
     PeerRemoved(PeerRemoved),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PeerRemoved {
-    pub id: PeerId,
+versioned! {
+    pub enum PeerAdded {
+        V1 => {
+            #[builder(default)] pub id: PeerId,
+            pub key: PeerKey,
+            pub address: PeerAddress,
+            #[builder(into)] pub name: PeerName,
+            #[builder(default = Timestamp::now())] pub created_at: Timestamp,
+        }
+    }
+}
+
+versioned! {
+    pub enum PeerUpdated {
+        V1 => {
+            #[builder(default)] pub id: PeerId,
+            pub key: PeerKey,
+            pub address: PeerAddress,
+            #[builder(into)] pub name: PeerName,
+            #[builder(default = Timestamp::now())] pub created_at: Timestamp,
+        }
+    }
+}
+
+versioned! {
+    pub enum PeerRemoved {
+        V1 => {
+            pub id: PeerId,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/oneiros-engine/src/domains/peer/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/peer/protocol/requests.rs
@@ -1,46 +1,52 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-/// Add a new peer by supplying its address in base64url-encoded form.
-///
-/// The address carries the cryptographic identity (endpoint id = ed25519
-/// public key) plus reachability info (relay URLs, direct sockets).
-/// The service extracts the key from the address and stores the full peer
-/// record.
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct AddPeer {
-    /// The peer's address — a base64url-encoded PeerAddress, as produced
-    /// by `bookmark share` or extracted from an `oneiros://` URI.
-    pub address: String,
-    /// Optional human-readable label. Defaults to a short hex prefix of
-    /// the key (e.g. `peer-a3f2b1`).
-    #[arg(long)]
-    pub name: Option<String>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum AddPeer {
+        #[derive(clap::Args)]
+        V1 => {
+            pub address: String,
+            #[arg(long)]
+            pub name: Option<String>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetPeer {
-    #[builder(into)]
-    pub key: ResourceKey<PeerId>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetPeer {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<PeerId>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct RemovePeer {
-    #[builder(into)]
-    pub id: PeerId,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum RemovePeer {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub id: PeerId,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Default, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListPeers {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListPeers {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/peer/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/peer/protocol/responses.rs
@@ -1,14 +1,60 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = PeerResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum PeerResponse {
-    Added(Response<Peer>),
-    Found(Response<Peer>),
-    Listed(Listed<Response<Peer>>),
-    Removed(PeerId),
+    Added(PeerAddedResponse),
+    Found(PeerFoundResponse),
+    Listed(PeersResponse),
+    Removed(PeerRemovedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum PeerAddedResponse {
+        V1 => {
+            #[builder(default)] pub id: PeerId,
+            pub key: PeerKey,
+            pub address: PeerAddress,
+            #[builder(into)] pub name: PeerName,
+            pub created_at: Timestamp,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum PeerFoundResponse {
+        V1 => {
+            #[builder(default)] pub id: PeerId,
+            pub key: PeerKey,
+            pub address: PeerAddress,
+            #[builder(into)] pub name: PeerName,
+            pub created_at: Timestamp,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum PeersResponse {
+        V1 => {
+            pub items: Vec<PeerFoundResponseV1>,
+            pub total: usize,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum PeerRemovedResponse {
+        V1 => {
+            pub id: PeerId,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/peer/service.rs
+++ b/crates/oneiros-engine/src/domains/peer/service.rs
@@ -2,21 +2,40 @@ use crate::*;
 
 pub struct PeerService;
 
+fn peer_to_added_v1(peer: Peer) -> PeerAddedResponseV1 {
+    PeerAddedResponseV1 {
+        id: peer.id,
+        key: peer.key,
+        address: peer.address,
+        name: peer.name,
+        created_at: peer.created_at,
+    }
+}
+
+fn peer_to_found_v1(peer: Peer) -> PeerFoundResponseV1 {
+    PeerFoundResponseV1 {
+        id: peer.id,
+        key: peer.key,
+        address: peer.address,
+        name: peer.name,
+        created_at: peer.created_at,
+    }
+}
+
 impl PeerService {
-    /// Add a peer by its base64url-encoded address. Extracts the key from
-    /// the address, generates a default name if none is supplied, and
-    /// emits `PeerAdded`.
     pub async fn add(
         context: &SystemContext,
-        AddPeer { address, name }: &AddPeer,
+        request: &AddPeer,
     ) -> Result<PeerResponse, PeerError> {
-        let parsed: PeerAddress = address
+        let AddPeer::V1(add) = request;
+        let parsed: PeerAddress = add
+            .address
             .parse()
             .map_err(|e: PeerAddressError| PeerError::InvalidAddress(e.to_string()))?;
         let endpoint_id = parsed.inner().id;
         let key = PeerKey::from_bytes(*endpoint_id.as_bytes());
 
-        let peer_name = match name {
+        let peer_name = match &add.name {
             Some(name) if !name.is_empty() => PeerName::new(name),
             _ => default_peer_name(&key),
         };
@@ -27,43 +46,56 @@ impl PeerService {
             .name(peer_name)
             .build();
 
-        context.emit(PeerEvents::PeerAdded(peer.clone())).await?;
-        let ref_token = RefToken::new(Ref::peer(peer.id));
-        Ok(PeerResponse::Added(
-            Response::new(peer).with_ref_token(ref_token),
-        ))
+        let event = PeerAdded::builder_v1()
+            .id(peer.id)
+            .key(peer.key)
+            .address(peer.address.clone())
+            .name(peer.name.clone())
+            .created_at(peer.created_at)
+            .build();
+
+        context.emit(PeerEvents::PeerAdded(event.into())).await?;
+        Ok(PeerResponse::Added(PeerAddedResponse::V1(
+            peer_to_added_v1(peer),
+        )))
     }
 
     pub async fn get(
         context: &SystemContext,
-        selector: &GetPeer,
+        request: &GetPeer,
     ) -> Result<PeerResponse, PeerError> {
-        let id = selector.key.resolve()?;
+        let GetPeer::V1(get) = request;
+        let id = get.key.resolve()?;
         let peer = PeerRepo::new(context)
             .get(id)
             .await?
             .ok_or(PeerError::NotFound(id))?;
-        let ref_token = RefToken::new(Ref::peer(peer.id));
-        Ok(PeerResponse::Found(
-            Response::new(peer).with_ref_token(ref_token),
-        ))
+        Ok(PeerResponse::Found(PeerFoundResponse::V1(
+            peer_to_found_v1(peer),
+        )))
     }
 
     pub async fn list(
         context: &SystemContext,
-        ListPeers { filters }: &ListPeers,
+        request: &ListPeers,
     ) -> Result<PeerResponse, PeerError> {
-        let listed = PeerRepo::new(context).list(filters).await?;
-        Ok(PeerResponse::Listed(listed.map(|peer| {
-            let ref_token = RefToken::new(Ref::peer(peer.id));
-            Response::new(peer).with_ref_token(ref_token)
-        })))
+        let ListPeers::V1(listing) = request;
+        let listed = PeerRepo::new(context).list(&listing.filters).await?;
+        let total = listed.total;
+        let items: Vec<PeerFoundResponseV1> =
+            listed.items.into_iter().map(peer_to_found_v1).collect();
+        Ok(PeerResponse::Listed(
+            PeersResponse::builder_v1()
+                .items(items)
+                .total(total)
+                .build()
+                .into(),
+        ))
     }
 
     /// Ensure a peer with the given key is known. If one already exists,
     /// return it without emitting an event. Otherwise add it and return
-    /// the newly-created record. Used by `bookmark follow` when a remote
-    /// URI arrives — the peer gets added transparently if it's new.
+    /// the newly-created record.
     pub async fn ensure(
         context: &SystemContext,
         key: PeerKey,
@@ -81,33 +113,45 @@ impl PeerService {
         let name = default_peer_name(&key);
         let peer = Peer::builder().key(key).address(address).name(name).build();
 
-        context.emit(PeerEvents::PeerAdded(peer.clone())).await?;
+        let event = PeerAdded::builder_v1()
+            .id(peer.id)
+            .key(peer.key)
+            .address(peer.address.clone())
+            .name(peer.name.clone())
+            .created_at(peer.created_at)
+            .build();
+
+        context.emit(PeerEvents::PeerAdded(event.into())).await?;
 
         Ok(peer)
     }
 
     pub async fn remove(
         context: &SystemContext,
-        RemovePeer { id }: &RemovePeer,
+        request: &RemovePeer,
     ) -> Result<PeerResponse, PeerError> {
-        // Verify the peer exists before emitting — keeps the event stream
-        // consistent with reality.
+        let RemovePeer::V1(remove) = request;
         let existing = PeerRepo::new(context)
-            .get(*id)
+            .get(remove.id)
             .await?
-            .ok_or(PeerError::NotFound(*id))?;
+            .ok_or(PeerError::NotFound(remove.id))?;
 
         context
-            .emit(PeerEvents::PeerRemoved(PeerRemoved { id: existing.id }))
+            .emit(PeerEvents::PeerRemoved(
+                PeerRemoved::builder_v1().id(existing.id).build().into(),
+            ))
             .await?;
 
-        Ok(PeerResponse::Removed(*id))
+        Ok(PeerResponse::Removed(
+            PeerRemovedResponse::builder_v1()
+                .id(remove.id)
+                .build()
+                .into(),
+        ))
     }
 }
 
 /// Default peer name derived from the first 6 hex digits of the key.
-/// Gives human-legible output for `peer list` without requiring users to
-/// pick a label for every peer they follow.
 fn default_peer_name(key: &PeerKey) -> PeerName {
     let hex = key.to_string();
     let prefix: String = hex.chars().take(6).collect();

--- a/crates/oneiros-engine/src/domains/peer/store.rs
+++ b/crates/oneiros-engine/src/domains/peer/store.rs
@@ -14,14 +14,29 @@ impl<'a> PeerStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Peer(peer_event)) = &event.data {
             match peer_event {
-                PeerEvents::PeerAdded(peer) => {
-                    self.create_record(peer)?;
+                PeerEvents::PeerAdded(added) => {
+                    let current = added.current()?;
+                    self.create_record(
+                        &current.id,
+                        &current.key,
+                        &current.address,
+                        &current.name,
+                        &current.created_at,
+                    )?;
                 }
-                PeerEvents::PeerUpdated(peer) => {
-                    self.create_record(peer)?;
+                PeerEvents::PeerUpdated(updated) => {
+                    let current = updated.current()?;
+                    self.create_record(
+                        &current.id,
+                        &current.key,
+                        &current.address,
+                        &current.name,
+                        &current.created_at,
+                    )?;
                 }
                 PeerEvents::PeerRemoved(removed) => {
-                    self.delete_record(removed.id)?;
+                    let current = removed.current()?;
+                    self.delete_record(current.id)?;
                 }
             }
         }
@@ -46,16 +61,23 @@ impl<'a> PeerStore<'a> {
         Ok(())
     }
 
-    fn create_record(&self, peer: &Peer) -> Result<(), EventError> {
+    fn create_record(
+        &self,
+        id: &PeerId,
+        key: &PeerKey,
+        address: &PeerAddress,
+        name: &PeerName,
+        created_at: &Timestamp,
+    ) -> Result<(), EventError> {
         self.conn.execute(
             "insert or replace into peers (id, key, address, name, created_at)
              values (?1, ?2, ?3, ?4, ?5)",
             params![
-                peer.id.to_string(),
-                peer.key.to_string(),
-                peer.address.to_string(),
-                peer.name.to_string(),
-                peer.created_at.as_string(),
+                id.to_string(),
+                key.to_string(),
+                address.to_string(),
+                name.to_string(),
+                created_at.as_string(),
             ],
         )?;
         Ok(())

--- a/crates/oneiros-engine/src/domains/peer/view.rs
+++ b/crates/oneiros-engine/src/domains/peer/view.rs
@@ -11,28 +11,34 @@ impl PeerView {
 
     pub fn render(self) -> Rendered<PeerResponse> {
         match self.response {
-            PeerResponse::Added(wrapped) => {
-                let prompt =
-                    Confirmation::new("Peer", wrapped.data.name.to_string(), "added").to_string();
-                Rendered::new(PeerResponse::Added(wrapped), prompt, String::new())
+            PeerResponse::Added(PeerAddedResponse::V1(added)) => {
+                let prompt = Confirmation::new("Peer", added.name.to_string(), "added").to_string();
+                Rendered::new(
+                    PeerResponse::Added(PeerAddedResponse::V1(added)),
+                    prompt,
+                    String::new(),
+                )
             }
-            PeerResponse::Found(wrapped) => {
-                let prompt = Detail::new(wrapped.data.name.to_string())
-                    .field("id:", wrapped.data.id.to_string())
-                    .field("key:", wrapped.data.key.to_string())
-                    .field("address:", wrapped.data.address.to_string())
-                    .field("created_at:", wrapped.data.created_at.as_string())
+            PeerResponse::Found(PeerFoundResponse::V1(found)) => {
+                let prompt = Detail::new(found.name.to_string())
+                    .field("id:", found.id.to_string())
+                    .field("key:", found.key.to_string())
+                    .field("address:", found.address.to_string())
+                    .field("created_at:", found.created_at.as_string())
                     .to_string();
-                Rendered::new(PeerResponse::Found(wrapped), prompt, String::new())
+                Rendered::new(
+                    PeerResponse::Found(PeerFoundResponse::V1(found)),
+                    prompt,
+                    String::new(),
+                )
             }
-            PeerResponse::Listed(listed) => {
+            PeerResponse::Listed(PeersResponse::V1(listed)) => {
                 let mut table = Table::new(vec![
                     Column::key("name", "Name"),
                     Column::key("key", "Key"),
                     Column::key("id", "ID"),
                 ]);
-                for wrapped in &listed.items {
-                    let peer = &wrapped.data;
+                for peer in &listed.items {
                     let key_display = peer.key.to_string();
                     let short_key: String = key_display.chars().take(12).collect();
                     table.push_row(vec![
@@ -43,13 +49,21 @@ impl PeerView {
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
-                Rendered::new(PeerResponse::Listed(listed), prompt, String::new())
+                Rendered::new(
+                    PeerResponse::Listed(PeersResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
-            PeerResponse::Removed(id) => {
-                let prompt = format!("Removed peer {id}");
-                Rendered::new(PeerResponse::Removed(id), prompt, String::new())
+            PeerResponse::Removed(PeerRemovedResponse::V1(removed)) => {
+                let prompt = format!("Removed peer {}", removed.id);
+                Rendered::new(
+                    PeerResponse::Removed(PeerRemovedResponse::V1(removed)),
+                    prompt,
+                    String::new(),
+                )
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/persona/client.rs
+++ b/crates/oneiros-engine/src/domains/persona/client.rs
@@ -9,25 +9,31 @@ impl<'a> PersonaClient<'a> {
         Self { client }
     }
 
-    pub async fn set(&self, set: &SetPersona) -> Result<PersonaResponse, ClientError> {
+    pub async fn set(&self, setting: &SetPersona) -> Result<PersonaResponse, ClientError> {
+        let SetPersona::V1(body) = setting;
         self.client
-            .put(&format!("/personas/{}", set.name), set)
+            .put(&format!("/personas/{}", body.name), setting)
             .await
     }
 
-    pub async fn get(&self, request: &GetPersona) -> Result<PersonaResponse, ClientError> {
-        self.client.get(&format!("/personas/{}", request.key)).await
+    pub async fn get(&self, lookup: &GetPersona) -> Result<PersonaResponse, ClientError> {
+        let GetPersona::V1(lookup) = lookup;
+        self.client.get(&format!("/personas/{}", lookup.key)).await
     }
 
-    pub async fn list(&self, request: &ListPersonas) -> Result<PersonaResponse, ClientError> {
+    pub async fn list(&self, listing: &ListPersonas) -> Result<PersonaResponse, ClientError> {
+        let ListPersonas::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset,
+            listing.filters.limit, listing.filters.offset,
         );
         self.client.get(&format!("/personas?{query}")).await
     }
 
-    pub async fn remove(&self, name: &PersonaName) -> Result<PersonaResponse, ClientError> {
-        self.client.delete(&format!("/personas/{name}")).await
+    pub async fn remove(&self, removal: &RemovePersona) -> Result<PersonaResponse, ClientError> {
+        let RemovePersona::V1(removal) = removal;
+        self.client
+            .delete(&format!("/personas/{}", removal.name))
+            .await
     }
 }

--- a/crates/oneiros-engine/src/domains/persona/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/persona/features/cli.rs
@@ -2,6 +2,11 @@ use clap::Subcommand;
 
 use crate::*;
 
+/// CLI subcommands for the persona domain. Each variant carries a versioned
+/// protocol request directly — clap derives parsing through the wrapper's
+/// `Args` impl, which delegates to the latest version's struct. The
+/// dispatcher passes the wrapper through to the client without rebuilding,
+/// since the operation type *is* the domain command.
 #[derive(Debug, Subcommand)]
 pub enum PersonaCommands {
     Set(SetPersona),
@@ -19,10 +24,10 @@ impl PersonaCommands {
         let persona_client = PersonaClient::new(&client);
 
         let response = match self {
-            PersonaCommands::Set(set) => persona_client.set(set).await?,
-            PersonaCommands::Show(get) => persona_client.get(get).await?,
-            PersonaCommands::List(list) => persona_client.list(list).await?,
-            PersonaCommands::Remove(removal) => persona_client.remove(&removal.name).await?,
+            Self::Set(setting) => persona_client.set(setting).await?,
+            Self::Show(lookup) => persona_client.get(lookup).await?,
+            Self::List(listing) => persona_client.list(listing).await?,
+            Self::Remove(removal) => persona_client.remove(removal).await?,
         };
 
         Ok(PersonaView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/persona/features/http.rs
+++ b/crates/oneiros-engine/src/domains/persona/features/http.rs
@@ -41,12 +41,14 @@ impl PersonaRouter {
 async fn set(
     context: ProjectContext,
     Path(name): Path<PersonaName>,
-    Json(mut body): Json<SetPersona>,
+    Json(body): Json<SetPersona>,
 ) -> Result<(StatusCode, Json<PersonaResponse>), PersonaError> {
-    body.name = name;
+    let SetPersona::V1(mut setting) = body;
+    setting.name = name;
+    let request = SetPersona::V1(setting);
     Ok((
         StatusCode::OK,
-        Json(PersonaService::set(&context, &body).await?),
+        Json(PersonaService::set(&context, &request).await?),
     ))
 }
 
@@ -62,7 +64,7 @@ async fn show(
     Path(key): Path<ResourceKey<PersonaName>>,
 ) -> Result<Json<PersonaResponse>, PersonaError> {
     Ok(Json(
-        PersonaService::get(&context, &GetPersona::builder().key(key).build()).await?,
+        PersonaService::get(&context, &GetPersona::builder_v1().key(key).build().into()).await?,
     ))
 }
 
@@ -71,6 +73,10 @@ async fn remove(
     Path(name): Path<PersonaName>,
 ) -> Result<Json<PersonaResponse>, PersonaError> {
     Ok(Json(
-        PersonaService::remove(&context, &RemovePersona::builder().name(name).build()).await?,
+        PersonaService::remove(
+            &context,
+            &RemovePersona::builder_v1().name(name).build().into(),
+        )
+        .await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/persona/features/state.rs
+++ b/crates/oneiros-engine/src/domains/persona/features/state.rs
@@ -6,11 +6,15 @@ impl PersonaState {
     pub fn reduce(mut canon: BrainCanon, event: &Events) -> BrainCanon {
         if let Events::Persona(persona_event) = event {
             match persona_event {
-                PersonaEvents::PersonaSet(persona) => {
-                    canon.personas.set(persona);
+                PersonaEvents::PersonaSet(setting) => {
+                    if let Ok(current) = setting.current() {
+                        canon.personas.set(&current.persona);
+                    }
                 }
-                PersonaEvents::PersonaRemoved(removed) => {
-                    canon.personas.remove(&removed.name);
+                PersonaEvents::PersonaRemoved(removal) => {
+                    if let Ok(current) = removal.current() {
+                        canon.personas.remove(&current.name);
+                    }
                 }
             };
         }

--- a/crates/oneiros-engine/src/domains/persona/model.rs
+++ b/crates/oneiros-engine/src/domains/persona/model.rs
@@ -1,20 +1,17 @@
 use bon::Builder;
-use clap::Args;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::*;
 
-#[derive(Args, Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct Persona {
     #[builder(into)]
     pub name: PersonaName,
     #[builder(into)]
-    #[arg(long, default_value = "")]
     pub description: Description,
     #[builder(into)]
-    #[arg(long, default_value = "")]
     pub prompt: Prompt,
 }
 

--- a/crates/oneiros-engine/src/domains/persona/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/persona/protocol/events.rs
@@ -7,13 +7,37 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = PersonaEventsType, display = "kebab-case")]
 pub enum PersonaEvents {
-    PersonaSet(Persona),
+    PersonaSet(PersonaSet),
     PersonaRemoved(PersonaRemoved),
+}
+
+versioned! {
+    pub enum PersonaSet {
+        V1 => {
+            #[serde(flatten)] pub persona: Persona,
+        }
+    }
+}
+
+versioned! {
+    pub enum PersonaRemoved {
+        V1 => {
+            #[builder(into)] pub name: PersonaName,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_persona() -> Persona {
+        Persona::builder()
+            .name("process")
+            .description("Process agents")
+            .prompt("Manages internal lifecycle.")
+            .build()
+    }
 
     #[test]
     fn event_types_are_kebab_cased() {
@@ -25,9 +49,42 @@ mod tests {
             assert_eq!(&event_type.to_string(), expectation);
         }
     }
-}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PersonaRemoved {
-    pub name: PersonaName,
+    #[test]
+    fn persona_set_wire_format_is_flat() {
+        let event = PersonaEvents::PersonaSet(PersonaSet::V1(PersonaSetV1 {
+            persona: sample_persona(),
+        }));
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "persona-set");
+        assert!(
+            json["data"].get("persona").is_none(),
+            "flatten must elide the persona envelope on the wire"
+        );
+        assert_eq!(json["data"]["name"], "process");
+        assert_eq!(json["data"]["description"], "Process agents");
+        assert!(
+            json["data"].get("V1").is_none(),
+            "V1 layer must not appear on the wire"
+        );
+    }
+
+    #[test]
+    fn persona_removed_round_trips_through_v1_layer() {
+        let original = PersonaEvents::PersonaRemoved(PersonaRemoved::V1(PersonaRemovedV1 {
+            name: PersonaName::new("process"),
+        }));
+
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: PersonaEvents = serde_json::from_str(&json).unwrap();
+
+        match decoded {
+            PersonaEvents::PersonaRemoved(removed) => {
+                let v1 = removed.current().unwrap();
+                assert_eq!(v1.name.to_string(), "process");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/persona/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/persona/protocol/requests.rs
@@ -1,41 +1,56 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct SetPersona {
-    #[builder(into)]
-    pub name: PersonaName,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub description: Description,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub prompt: Prompt,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SetPersona {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: PersonaName,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub description: Description,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub prompt: Prompt,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetPersona {
-    #[builder(into)]
-    pub key: ResourceKey<PersonaName>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetPersona {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<PersonaName>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct RemovePersona {
-    #[builder(into)]
-    pub name: PersonaName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum RemovePersona {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: PersonaName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListPersonas {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListPersonas {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/persona/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/persona/protocol/responses.rs
@@ -1,15 +1,49 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = PersonaResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum PersonaResponse {
-    PersonaSet(PersonaName),
-    PersonaDetails(Response<Persona>),
-    Personas(Listed<Response<Persona>>),
+    PersonaSet(PersonaSetResponse),
+    PersonaDetails(PersonaDetailsResponse),
+    Personas(PersonasResponse),
     NoPersonas,
-    PersonaRemoved(PersonaName),
+    PersonaRemoved(PersonaRemovedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum PersonaSetResponse {
+        V1 => { #[serde(flatten)] pub persona: Persona }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum PersonaDetailsResponse {
+        V1 => { #[serde(flatten)] pub persona: Persona }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum PersonasResponse {
+        V1 => {
+            pub items: Vec<Persona>,
+            pub total: usize,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum PersonaRemovedResponse {
+        V1 => {
+            #[builder(into)] pub name: PersonaName,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/persona/service.rs
+++ b/crates/oneiros-engine/src/domains/persona/service.rs
@@ -5,60 +5,87 @@ pub struct PersonaService;
 impl PersonaService {
     pub async fn set(
         context: &ProjectContext,
-        SetPersona {
-            name,
-            description,
-            prompt,
-        }: &SetPersona,
+        request: &SetPersona,
     ) -> Result<PersonaResponse, PersonaError> {
+        let SetPersona::V1(set) = request;
         let persona = Persona::builder()
-            .name(name.clone())
-            .description(description.clone())
-            .prompt(prompt.clone())
+            .name(set.name.clone())
+            .description(set.description.clone())
+            .prompt(set.prompt.clone())
             .build();
-        context.emit(PersonaEvents::PersonaSet(persona)).await?;
-        Ok(PersonaResponse::PersonaSet(name.clone()))
+
+        context
+            .emit(PersonaEvents::PersonaSet(
+                PersonaSet::builder_v1()
+                    .persona(persona.clone())
+                    .build()
+                    .into(),
+            ))
+            .await?;
+
+        Ok(PersonaResponse::PersonaSet(
+            PersonaSetResponse::builder_v1()
+                .persona(persona)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn get(
         context: &ProjectContext,
-        selector: &GetPersona,
+        request: &GetPersona,
     ) -> Result<PersonaResponse, PersonaError> {
-        let name = selector.key.resolve()?;
+        let GetPersona::V1(lookup) = request;
+        let name = lookup.key.resolve()?;
         let persona = PersonaRepo::new(context)
             .get(&name)
             .await?
             .ok_or(PersonaError::NotFound(name))?;
-        let ref_token = RefToken::new(Ref::persona(persona.name.clone()));
         Ok(PersonaResponse::PersonaDetails(
-            Response::new(persona).with_ref_token(ref_token),
+            PersonaDetailsResponse::builder_v1()
+                .persona(persona)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn list(
         context: &ProjectContext,
-        ListPersonas { filters }: &ListPersonas,
+        request: &ListPersonas,
     ) -> Result<PersonaResponse, PersonaError> {
-        let listed = PersonaRepo::new(context).list(filters).await?;
+        let ListPersonas::V1(listing) = request;
+        let listed = PersonaRepo::new(context).list(&listing.filters).await?;
         if listed.total == 0 {
             Ok(PersonaResponse::NoPersonas)
         } else {
-            Ok(PersonaResponse::Personas(listed.map(|e| {
-                let ref_token = RefToken::new(Ref::persona(e.name.clone()));
-                Response::new(e).with_ref_token(ref_token)
-            })))
+            Ok(PersonaResponse::Personas(
+                PersonasResponse::builder_v1()
+                    .items(listed.items)
+                    .total(listed.total)
+                    .build()
+                    .into(),
+            ))
         }
     }
 
     pub async fn remove(
         context: &ProjectContext,
-        selector: &RemovePersona,
+        request: &RemovePersona,
     ) -> Result<PersonaResponse, PersonaError> {
+        let RemovePersona::V1(removal) = request;
         context
-            .emit(PersonaEvents::PersonaRemoved(PersonaRemoved {
-                name: selector.name.clone(),
-            }))
+            .emit(PersonaEvents::PersonaRemoved(
+                PersonaRemoved::builder_v1()
+                    .name(removal.name.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        Ok(PersonaResponse::PersonaRemoved(selector.name.clone()))
+        Ok(PersonaResponse::PersonaRemoved(
+            PersonaRemovedResponse::builder_v1()
+                .name(removal.name.clone())
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/persona/store.rs
+++ b/crates/oneiros-engine/src/domains/persona/store.rs
@@ -15,8 +15,8 @@ impl<'a> PersonaStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Persona(persona_event)) = &event.data {
             match persona_event {
-                PersonaEvents::PersonaSet(persona) => self.set(persona)?,
-                PersonaEvents::PersonaRemoved(removed) => self.remove(&removed.name)?,
+                PersonaEvents::PersonaSet(setting) => self.set(setting)?,
+                PersonaEvents::PersonaRemoved(removal) => self.remove(removal)?,
             }
         }
         Ok(())
@@ -64,7 +64,21 @@ impl<'a> PersonaStore<'a> {
         }
     }
 
-    fn set(&self, persona: &Persona) -> Result<(), EventError> {
+    fn set(&self, setting: &PersonaSet) -> Result<(), EventError> {
+        let persona = setting.current()?.persona;
+        self.write_persona(&persona)
+    }
+
+    fn remove(&self, removal: &PersonaRemoved) -> Result<(), EventError> {
+        let name = removal.current()?.name;
+        self.conn.execute(
+            "DELETE FROM personas WHERE name = ?1",
+            params![name.to_string()],
+        )?;
+        Ok(())
+    }
+
+    fn write_persona(&self, persona: &Persona) -> Result<(), EventError> {
         self.conn.execute(
             "INSERT OR REPLACE INTO personas (name, description, prompt) VALUES (?1, ?2, ?3)",
             params![
@@ -72,14 +86,6 @@ impl<'a> PersonaStore<'a> {
                 persona.description.to_string(),
                 persona.prompt.to_string()
             ],
-        )?;
-        Ok(())
-    }
-
-    fn remove(&self, name: &PersonaName) -> Result<(), EventError> {
-        self.conn.execute(
-            "DELETE FROM personas WHERE name = ?1",
-            params![name.to_string()],
         )?;
         Ok(())
     }

--- a/crates/oneiros-engine/src/domains/persona/view.rs
+++ b/crates/oneiros-engine/src/domains/persona/view.rs
@@ -11,25 +11,27 @@ impl PersonaView {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            PersonaResponse::Personas(listed) => {
+            PersonaResponse::Personas(PersonasResponse::V1(listed)) => {
                 let items: Vec<_> = listed
                     .items
                     .iter()
-                    .map(|w| (w.data.name.to_string(), w.data.description.to_string()))
+                    .map(|item| (item.name.to_string(), item.description.to_string()))
                     .collect();
                 Self::vocabulary_table("Personas", &items)
             }
-            PersonaResponse::PersonaDetails(wrapped) => {
+            PersonaResponse::PersonaDetails(PersonaDetailsResponse::V1(details)) => {
                 let items = vec![(
-                    wrapped.data.name.to_string(),
-                    wrapped.data.description.to_string(),
+                    details.persona.name.to_string(),
+                    details.persona.description.to_string(),
                 )];
                 Self::vocabulary_table("Persona", &items)
             }
             PersonaResponse::NoPersonas => Self::vocabulary_table("Personas", &[]),
-            PersonaResponse::PersonaSet(name) => McpResponse::new(format!("Persona set: {name}")),
-            PersonaResponse::PersonaRemoved(name) => {
-                McpResponse::new(format!("Persona removed: {name}"))
+            PersonaResponse::PersonaSet(PersonaSetResponse::V1(set)) => {
+                McpResponse::new(format!("Persona set: {}", set.persona.name))
+            }
+            PersonaResponse::PersonaRemoved(PersonaRemovedResponse::V1(removed)) => {
+                McpResponse::new(format!("Persona removed: {}", removed.name))
             }
         }
     }
@@ -50,58 +52,69 @@ impl PersonaView {
 
     pub fn render(self) -> Rendered<PersonaResponse> {
         match self.response {
-            PersonaResponse::PersonaSet(name) => {
-                let prompt = Confirmation::new("Persona", name.to_string(), "set").to_string();
+            PersonaResponse::PersonaSet(PersonaSetResponse::V1(set)) => {
+                let prompt =
+                    Confirmation::new("Persona", set.persona.name.to_string(), "set").to_string();
                 let hints = HintSet::vocabulary(
                     VocabularyHints::builder()
                         .kind("persona".to_string())
                         .build(),
                 );
-                Rendered::new(PersonaResponse::PersonaSet(name), prompt, String::new())
-                    .with_hints(hints)
+                Rendered::new(
+                    PersonaResponse::PersonaSet(PersonaSetResponse::V1(set)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
-            PersonaResponse::PersonaDetails(wrapped) => {
-                let prompt = Detail::new(wrapped.data.name.to_string())
-                    .field("description:", wrapped.data.description.to_string())
-                    .field("prompt:", wrapped.data.prompt.to_string())
+            PersonaResponse::PersonaDetails(PersonaDetailsResponse::V1(details)) => {
+                let prompt = Detail::new(details.persona.name.to_string())
+                    .field("description:", details.persona.description.to_string())
+                    .field("prompt:", details.persona.prompt.to_string())
                     .to_string();
                 Rendered::new(
-                    PersonaResponse::PersonaDetails(wrapped),
+                    PersonaResponse::PersonaDetails(PersonaDetailsResponse::V1(details)),
                     prompt,
                     String::new(),
                 )
             }
-            PersonaResponse::Personas(listed) => {
+            PersonaResponse::Personas(PersonasResponse::V1(listed)) => {
                 let mut table = Table::new(vec![
                     Column::key("name", "Name"),
                     Column::key("description", "Description").max(60),
                 ]);
-                for wrapped in &listed.items {
-                    table.push_row(vec![
-                        wrapped.data.name.to_string(),
-                        wrapped.data.description.to_string(),
-                    ]);
+                for item in &listed.items {
+                    table.push_row(vec![item.name.to_string(), item.description.to_string()]);
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
-                Rendered::new(PersonaResponse::Personas(listed), prompt, String::new())
+                Rendered::new(
+                    PersonaResponse::Personas(PersonasResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
             PersonaResponse::NoPersonas => Rendered::new(
                 PersonaResponse::NoPersonas,
                 format!("{}", "No personas configured.".muted()),
                 String::new(),
             ),
-            PersonaResponse::PersonaRemoved(name) => {
-                let prompt = Confirmation::new("Persona", name.to_string(), "removed").to_string();
+            PersonaResponse::PersonaRemoved(PersonaRemovedResponse::V1(removed)) => {
+                let prompt =
+                    Confirmation::new("Persona", removed.name.to_string(), "removed").to_string();
                 let hints = HintSet::vocabulary(
                     VocabularyHints::builder()
                         .kind("persona".to_string())
                         .build(),
                 );
-                Rendered::new(PersonaResponse::PersonaRemoved(name), prompt, String::new())
-                    .with_hints(hints)
+                Rendered::new(
+                    PersonaResponse::PersonaRemoved(PersonaRemovedResponse::V1(removed)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/pressure/client.rs
+++ b/crates/oneiros-engine/src/domains/pressure/client.rs
@@ -14,8 +14,9 @@ impl<'a> PressureClient<'a> {
 
     /// Retrieve pressure readings for a specific agent.
     pub async fn get(&self, request: &GetPressure) -> Result<PressureResponse, ClientError> {
+        let details = request.current()?;
         self.client
-            .get(&format!("/pressures/{}", request.agent))
+            .get(&format!("/pressures/{}", details.agent))
             .await
     }
 

--- a/crates/oneiros-engine/src/domains/pressure/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/pressure/features/cli.rs
@@ -5,7 +5,7 @@ use crate::*;
 #[derive(Debug, Args)]
 pub struct PressureCommands {
     #[command(flatten)]
-    pub request: GetPressure,
+    pub command: GetPressure,
 }
 
 impl PressureCommands {
@@ -16,9 +16,9 @@ impl PressureCommands {
         let client = context.client();
         let pressure_client = PressureClient::new(&client);
 
-        let request = PressureRequest::GetPressure(self.request.clone());
-        let response = pressure_client.get(&self.request).await?;
-        Ok(PressureView::new(response, &request)
+        let request = PressureRequest::GetPressure(self.command.clone());
+        let response = pressure_client.get(&self.command).await?;
+        Ok(PressurePresenter::new(response, &request)
             .render()
             .map(Into::into))
     }

--- a/crates/oneiros-engine/src/domains/pressure/features/http.rs
+++ b/crates/oneiros-engine/src/domains/pressure/features/http.rs
@@ -31,7 +31,11 @@ async fn get(
     Path(agent): Path<AgentName>,
 ) -> Result<Json<PressureResponse>, PressureError> {
     Ok(Json(
-        PressureService::get(&context, &GetPressure::builder().agent(agent).build()).await?,
+        PressureService::get(
+            &context,
+            &GetPressure::builder_v1().agent(agent).build().into(),
+        )
+        .await?,
     ))
 }
 

--- a/crates/oneiros-engine/src/domains/pressure/features/state.rs
+++ b/crates/oneiros-engine/src/domains/pressure/features/state.rs
@@ -69,25 +69,25 @@ impl PressureState {
     /// Update continuity timestamps when we see lifecycle events.
     fn track_continuity(canon: &mut BrainCanon, event: &Events) {
         match event {
-            Events::Continuity(ContinuityEvents::Introspected(e)) => {
+            Events::Continuity(ContinuityEvents::Introspected(Introspected::V1(e))) => {
                 canon
                     .continuity_timestamps
                     .get_or_default(&e.agent)
                     .last_introspect = Some(e.created_at);
             }
-            Events::Continuity(ContinuityEvents::Reflected(e)) => {
+            Events::Continuity(ContinuityEvents::Reflected(Reflected::V1(e))) => {
                 canon
                     .continuity_timestamps
                     .get_or_default(&e.agent)
                     .last_reflect = Some(e.created_at);
             }
-            Events::Continuity(ContinuityEvents::Dreamed(e)) => {
+            Events::Continuity(ContinuityEvents::Dreamed(Dreamed::V1(e))) => {
                 canon
                     .continuity_timestamps
                     .get_or_default(&e.agent)
                     .last_dream = Some(e.created_at);
             }
-            Events::Continuity(ContinuityEvents::Slept(e)) => {
+            Events::Continuity(ContinuityEvents::Slept(Slept::V1(e))) => {
                 canon
                     .continuity_timestamps
                     .get_or_default(&e.agent)
@@ -100,28 +100,38 @@ impl PressureState {
     /// Determine which agents need pressure recomputed for this event.
     fn resolve_agents<'a>(canon: &'a BrainCanon, event: &Events) -> Vec<&'a Agent> {
         match event {
-            Events::Cognition(CognitionEvents::CognitionAdded(c)) => {
-                canon.agents.get(c.agent_id).into_iter().collect()
+            Events::Cognition(CognitionEvents::CognitionAdded(CognitionAdded::V1(addition))) => {
+                canon
+                    .agents
+                    .get(addition.cognition.agent_id)
+                    .into_iter()
+                    .collect()
             }
-            Events::Memory(MemoryEvents::MemoryAdded(m)) => {
-                canon.agents.get(m.agent_id).into_iter().collect()
-            }
-            Events::Experience(ExperienceEvents::ExperienceCreated(e)) => {
-                canon.agents.get(e.agent_id).into_iter().collect()
-            }
-            Events::Continuity(ContinuityEvents::Introspected(e)) => {
+            Events::Memory(MemoryEvents::MemoryAdded(MemoryAdded::V1(addition))) => canon
+                .agents
+                .get(addition.memory.agent_id)
+                .into_iter()
+                .collect(),
+            Events::Experience(ExperienceEvents::ExperienceCreated(ExperienceCreated::V1(
+                creation,
+            ))) => canon
+                .agents
+                .get(creation.experience.agent_id)
+                .into_iter()
+                .collect(),
+            Events::Continuity(ContinuityEvents::Introspected(Introspected::V1(e))) => {
                 canon.agents.find_by_name(&e.agent).into_iter().collect()
             }
-            Events::Continuity(ContinuityEvents::Reflected(e)) => {
+            Events::Continuity(ContinuityEvents::Reflected(Reflected::V1(e))) => {
                 canon.agents.find_by_name(&e.agent).into_iter().collect()
             }
-            Events::Continuity(ContinuityEvents::Dreamed(e)) => {
+            Events::Continuity(ContinuityEvents::Dreamed(Dreamed::V1(e))) => {
                 canon.agents.find_by_name(&e.agent).into_iter().collect()
             }
-            Events::Continuity(ContinuityEvents::Slept(e)) => {
+            Events::Continuity(ContinuityEvents::Slept(Slept::V1(e))) => {
                 canon.agents.find_by_name(&e.agent).into_iter().collect()
             }
-            Events::Continuity(ContinuityEvents::Sensed(e)) => {
+            Events::Continuity(ContinuityEvents::Sensed(Sensed::V1(e))) => {
                 canon.agents.find_by_name(&e.agent).into_iter().collect()
             }
             // Connection events may affect orphaned/unconnected counts for any agent
@@ -421,11 +431,16 @@ mod tests {
     fn ignores_irrelevant_events() {
         let canon = seeded_canon();
         let event = Events::Level(LevelEvents::LevelSet(
-            Level::builder()
-                .name("working")
-                .description("Short-term")
-                .prompt("")
-                .build(),
+            LevelSet::builder_v1()
+                .level(
+                    Level::builder()
+                        .name("working")
+                        .description("Short-term")
+                        .prompt("")
+                        .build(),
+                )
+                .build()
+                .into(),
         ));
 
         let next = PressureState::reduce(canon, &event);
@@ -441,14 +456,19 @@ mod tests {
             .unwrap();
         let agent_id = agent.id;
 
-        let cognition = Cognition::builder()
-            .agent_id(agent_id)
-            .texture("observation")
-            .content("A thought")
-            .build();
+        let added: CognitionAdded = CognitionAdded::builder_v1()
+            .cognition(
+                Cognition::builder()
+                    .agent_id(agent_id)
+                    .texture("observation")
+                    .content("A thought")
+                    .build(),
+            )
+            .build()
+            .into();
 
         // Simulate the full pipeline: cognition reducer then pressure reducer
-        let event = Events::Cognition(CognitionEvents::CognitionAdded(cognition));
+        let event = Events::Cognition(CognitionEvents::CognitionAdded(added));
         canon = CognitionState::reduce(canon, &event);
         let next = PressureState::reduce(canon, &event);
 
@@ -479,7 +499,11 @@ mod tests {
         canon.cognitions.set(&working);
         canon.cognitions.set(&observation);
 
-        let event = Events::Cognition(CognitionEvents::CognitionAdded(observation));
+        let added: CognitionAdded = CognitionAdded::builder_v1()
+            .cognition(observation.clone())
+            .build()
+            .into();
+        let event = Events::Cognition(CognitionEvents::CognitionAdded(added));
         let next = PressureState::reduce(canon, &event);
 
         let introspect = next
@@ -514,7 +538,11 @@ mod tests {
         canon.cognitions.set(&cognition);
 
         // Before connection: cognition is orphaned
-        let event = Events::Cognition(CognitionEvents::CognitionAdded(cognition));
+        let added: CognitionAdded = CognitionAdded::builder_v1()
+            .cognition(cognition.clone())
+            .build()
+            .into();
+        let event = Events::Cognition(CognitionEvents::CognitionAdded(added));
         let after_cog = PressureState::reduce(canon, &event);
 
         let catharsis_before = after_cog
@@ -537,7 +565,11 @@ mod tests {
             .build();
         canon.connections.set(&connection);
 
-        let conn_event = Events::Connection(ConnectionEvents::ConnectionCreated(connection));
+        let conn_created: ConnectionCreated = ConnectionCreated::builder_v1()
+            .connection(connection.clone())
+            .build()
+            .into();
+        let conn_event = Events::Connection(ConnectionEvents::ConnectionCreated(conn_created));
         let after_conn = PressureState::reduce(canon, &conn_event);
 
         let catharsis_after = after_conn
@@ -556,10 +588,13 @@ mod tests {
     fn tracks_continuity_timestamps() {
         let mut canon = seeded_canon();
 
-        let event = Events::Continuity(ContinuityEvents::Introspected(ContinuityEvent {
-            agent: AgentName::new("gov.process"),
-            created_at: Timestamp::now(),
-        }));
+        let event = Events::Continuity(ContinuityEvents::Introspected(
+            Introspected::builder_v1()
+                .agent(AgentName::new("gov.process"))
+                .created_at(Timestamp::now())
+                .build()
+                .into(),
+        ));
 
         canon = PressureState::reduce(canon, &event);
 

--- a/crates/oneiros-engine/src/domains/pressure/presenter.rs
+++ b/crates/oneiros-engine/src/domains/pressure/presenter.rs
@@ -12,11 +12,12 @@ impl<'a> PressurePresenter<'a> {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            PressureResponse::Readings(result) => {
+            PressureResponse::Readings(ReadingsResponse::V1(result)) => {
                 let title = match self.request {
-                    PressureRequest::GetPressure(get) => {
-                        format!("# Pressure — {}\n\n", get.agent)
-                    }
+                    PressureRequest::GetPressure(get) => match get.current() {
+                        Ok(details) => format!("# Pressure — {}\n\n", details.agent),
+                        Err(_) => "# Pressure\n\n".to_string(),
+                    },
                     _ => "# Pressure\n\n".to_string(),
                 };
                 let mut md = title;
@@ -29,7 +30,7 @@ impl<'a> PressurePresenter<'a> {
                 }
                 McpResponse::new(md)
             }
-            PressureResponse::AllReadings(result) => {
+            PressureResponse::AllReadings(AllReadingsResponse::V1(result)) => {
                 let mut md = String::from("# Pressure — All Agents\n\n");
                 for pressure in &result.pressures {
                     md.push_str(&format!(
@@ -53,10 +54,10 @@ impl<'a> PressurePresenter<'a> {
 
     fn render_prompt(&self) -> String {
         match &self.response {
-            PressureResponse::Readings(result) => {
+            PressureResponse::Readings(ReadingsResponse::V1(result)) => {
                 RelevantPressures::from_pressures(result.pressures.clone()).to_string()
             }
-            PressureResponse::AllReadings(result) => {
+            PressureResponse::AllReadings(AllReadingsResponse::V1(result)) => {
                 RelevantPressures::from_pressures(result.pressures.clone()).to_string()
             }
         }
@@ -64,7 +65,7 @@ impl<'a> PressurePresenter<'a> {
 
     fn render_text(&self) -> String {
         match &self.response {
-            PressureResponse::Readings(result) => {
+            PressureResponse::Readings(ReadingsResponse::V1(result)) => {
                 format!("Pressure readings for {}.", result.agent)
             }
             PressureResponse::AllReadings(_) => "Pressure readings for all agents.".to_string(),

--- a/crates/oneiros-engine/src/domains/pressure/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/pressure/protocol/errors.rs
@@ -2,7 +2,7 @@ use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 
-use crate::{ErrorResponse, resource_op_error};
+use crate::{ErrorResponse, UpcastError, resource_op_error};
 
 #[derive(Debug, thiserror::Error)]
 pub enum PressureError {
@@ -14,6 +14,9 @@ pub enum PressureError {
 
     #[error(transparent)]
     Client(#[from] crate::ClientError),
+
+    #[error(transparent)]
+    Upcast(#[from] UpcastError),
 }
 
 resource_op_error!(PressureError);
@@ -21,7 +24,7 @@ resource_op_error!(PressureError);
 impl IntoResponse for PressureError {
     fn into_response(self) -> Response {
         let (status, message) = match &self {
-            PressureError::Database(_) | PressureError::Event(_) => {
+            PressureError::Database(_) | PressureError::Event(_) | PressureError::Upcast(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
             }
             PressureError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),

--- a/crates/oneiros-engine/src/domains/pressure/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/pressure/protocol/requests.rs
@@ -1,15 +1,17 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetPressure {
-    #[builder(into)]
-    pub agent: AgentName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetPressure {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/pressure/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/pressure/protocol/responses.rs
@@ -1,24 +1,32 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct PressureResult {
-    pub agent: AgentName,
-    pub pressures: Vec<Pressure>,
-}
-
-/// Pressure readings for all agents — returned by list queries.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct ListPressureResult {
-    pub pressures: Vec<Pressure>,
-}
-
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = PressureResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum PressureResponse {
-    Readings(PressureResult),
-    AllReadings(ListPressureResult),
+    Readings(ReadingsResponse),
+    AllReadings(AllReadingsResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ReadingsResponse {
+        V1 => {
+            #[builder(into)] pub agent: AgentName,
+            pub pressures: Vec<Pressure>,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum AllReadingsResponse {
+        V1 => {
+            pub pressures: Vec<Pressure>,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/pressure/service.rs
+++ b/crates/oneiros-engine/src/domains/pressure/service.rs
@@ -7,17 +7,24 @@ impl PressureService {
         context: &ProjectContext,
         selector: &GetPressure,
     ) -> Result<PressureResponse, PressureError> {
-        let pressures = PressureRepo::new(context).get(&selector.agent).await?;
-        Ok(PressureResponse::Readings(PressureResult {
-            agent: selector.agent.clone(),
-            pressures,
-        }))
+        let details = selector.current()?;
+        let pressures = PressureRepo::new(context).get(&details.agent).await?;
+        Ok(PressureResponse::Readings(
+            ReadingsResponse::builder_v1()
+                .agent(details.agent)
+                .pressures(pressures)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn list(context: &ProjectContext) -> Result<PressureResponse, PressureError> {
         let pressures = PressureRepo::new(context).list().await?;
-        Ok(PressureResponse::AllReadings(ListPressureResult {
-            pressures,
-        }))
+        Ok(PressureResponse::AllReadings(
+            AllReadingsResponse::builder_v1()
+                .pressures(pressures)
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/pressure/store.rs
+++ b/crates/oneiros-engine/src/domains/pressure/store.rs
@@ -137,28 +137,32 @@ impl<'a> PressureStore<'a> {
         // Try to resolve a single agent first
         let agent_name = match &event.data {
             Event::Known(known_event) => match known_event {
-                Events::Cognition(CognitionEvents::CognitionAdded(cognition)) => agent_store
-                    .get_name_by_id(&cognition.agent_id)?
+                Events::Cognition(CognitionEvents::CognitionAdded(CognitionAdded::V1(
+                    addition,
+                ))) => agent_store
+                    .get_name_by_id(&addition.cognition.agent_id)?
                     .map(|n| n.to_string()),
-                Events::Memory(MemoryEvents::MemoryAdded(memory)) => agent_store
-                    .get_name_by_id(&memory.agent_id)?
+                Events::Memory(MemoryEvents::MemoryAdded(MemoryAdded::V1(addition))) => agent_store
+                    .get_name_by_id(&addition.memory.agent_id)?
                     .map(|n| n.to_string()),
-                Events::Experience(ExperienceEvents::ExperienceCreated(experience)) => agent_store
-                    .get_name_by_id(&experience.agent_id)?
+                Events::Experience(ExperienceEvents::ExperienceCreated(ExperienceCreated::V1(
+                    creation,
+                ))) => agent_store
+                    .get_name_by_id(&creation.experience.agent_id)?
                     .map(|n| n.to_string()),
-                Events::Continuity(ContinuityEvents::Introspected(continuity)) => {
+                Events::Continuity(ContinuityEvents::Introspected(Introspected::V1(
+                    continuity,
+                ))) => Some(continuity.agent.to_string()),
+                Events::Continuity(ContinuityEvents::Reflected(Reflected::V1(continuity))) => {
                     Some(continuity.agent.to_string())
                 }
-                Events::Continuity(ContinuityEvents::Reflected(continuity)) => {
+                Events::Continuity(ContinuityEvents::Dreamed(Dreamed::V1(continuity))) => {
                     Some(continuity.agent.to_string())
                 }
-                Events::Continuity(ContinuityEvents::Dreamed(continuity)) => {
+                Events::Continuity(ContinuityEvents::Slept(Slept::V1(continuity))) => {
                     Some(continuity.agent.to_string())
                 }
-                Events::Continuity(ContinuityEvents::Slept(continuity)) => {
-                    Some(continuity.agent.to_string())
-                }
-                Events::Continuity(ContinuityEvents::Sensed(sensed)) => {
+                Events::Continuity(ContinuityEvents::Sensed(Sensed::V1(sensed))) => {
                     Some(sensed.agent.to_string())
                 }
                 // Connection events affect orphaned/unconnected counts for any agent

--- a/crates/oneiros-engine/src/domains/project/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/project/features/cli.rs
@@ -13,9 +13,15 @@ pub enum ProjectCommands {
 impl ProjectCommands {
     pub async fn execute(&self, config: &Config) -> Result<Rendered<Responses>, ProjectError> {
         let response: ProjectResponse = match self {
-            ProjectCommands::Init(init) => ProjectService::init(&config.system(), init).await?,
-            ProjectCommands::Export(export) => ProjectService::export(&config.project(), export)?,
-            ProjectCommands::Import(import) => ProjectService::import(&config.project(), import)?,
+            ProjectCommands::Init(initialization) => {
+                ProjectService::init(&config.system(), initialization).await?
+            }
+            ProjectCommands::Export(exporting) => {
+                ProjectService::export(&config.project(), exporting)?
+            }
+            ProjectCommands::Import(importing) => {
+                ProjectService::import(&config.project(), importing)?
+            }
             ProjectCommands::Replay => ProjectService::replay(&config.project())?,
         };
 

--- a/crates/oneiros-engine/src/domains/project/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/project/protocol/errors.rs
@@ -31,6 +31,9 @@ pub enum ProjectError {
 
     #[error(transparent)]
     Client(#[from] ClientError),
+
+    #[error(transparent)]
+    Upcast(#[from] UpcastError),
 }
 
 resource_op_error!(ProjectError);
@@ -44,7 +47,8 @@ impl IntoResponse for ProjectError {
             | ProjectError::Database(_)
             | ProjectError::Event(_)
             | ProjectError::Serde(_)
-            | ProjectError::Io(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            | ProjectError::Io(_)
+            | ProjectError::Upcast(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             ProjectError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
         };
         (status, Json(ErrorResponse::new(message))).into_response()

--- a/crates/oneiros-engine/src/domains/project/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/project/protocol/requests.rs
@@ -1,32 +1,46 @@
 use std::path::PathBuf;
 
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct InitProject {
-    #[arg(long)]
-    #[builder(into)]
-    pub name: Option<BrainName>,
-    #[arg(long, short)]
-    #[builder(default)]
-    pub yes: bool,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum InitProject {
+        #[derive(clap::Args)]
+        V1 => {
+            #[arg(long)]
+            #[builder(into)]
+            pub name: Option<BrainName>,
+            #[arg(long, short)]
+            #[serde(default)]
+            #[builder(default)]
+            pub yes: bool,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ExportProject {
-    #[arg(long, short)]
-    pub target: PathBuf,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ExportProject {
+        #[derive(clap::Args)]
+        V1 => {
+            #[arg(long, short)]
+            pub target: PathBuf,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ImportProject {
-    pub file: PathBuf,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ImportProject {
+        #[derive(clap::Args)]
+        V1 => {
+            pub file: PathBuf,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/project/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/project/protocol/responses.rs
@@ -1,83 +1,65 @@
 use std::path::PathBuf;
 
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-/// The filesystem path where the export file was written.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(transparent)]
-pub struct ExportPath(pub PathBuf);
-
-impl ExportPath {
-    pub fn new(path: impl Into<PathBuf>) -> Self {
-        Self(path.into())
-    }
-}
-
-impl AsRef<std::path::Path> for ExportPath {
-    fn as_ref(&self) -> &std::path::Path {
-        &self.0
-    }
-}
-
-impl core::ops::Deref for ExportPath {
-    type Target = PathBuf;
-    fn deref(&self) -> &PathBuf {
-        &self.0
-    }
-}
-
-impl core::fmt::Display for ExportPath {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", self.0.display())
-    }
-}
-
-/// A count of events processed (imported or replayed).
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(transparent)]
-pub struct EventCount(pub i64);
-
-impl EventCount {
-    pub fn new(value: impl Into<i64>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl core::fmt::Display for EventCount {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-/// The result of a successful project initialization — carries the
-/// token needed for all subsequent authenticated requests.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct InitResult {
-    pub brain_name: BrainName,
-    pub token: Token,
-}
-
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = ProjectResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ProjectResponse {
-    Initialized(InitResult),
-    BrainAlreadyExists(BrainName),
-    WroteExport(ExportPath),
-    Imported(ImportResult),
-    Replayed(ReplayResult),
+    Initialized(InitializedResponse),
+    BrainAlreadyExists(BrainAlreadyExistsResponse),
+    WroteExport(WroteExportResponse),
+    Imported(ImportedResponse),
+    Replayed(ReplayedResponse),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct ImportResult {
-    pub imported: EventCount,
-    pub replayed: EventCount,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum InitializedResponse {
+        V1 => {
+            #[builder(into)] pub brain_name: BrainName,
+            pub token: Token,
+        }
+    }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct ReplayResult {
-    pub replayed: EventCount,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum BrainAlreadyExistsResponse {
+        V1 => {
+            #[builder(into)] pub brain_name: BrainName,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum WroteExportResponse {
+        V1 => {
+            pub path: PathBuf,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ImportedResponse {
+        V1 => {
+            pub imported: i64,
+            pub replayed: i64,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ReplayedResponse {
+        V1 => {
+            pub replayed: i64,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/project/service.rs
+++ b/crates/oneiros-engine/src/domains/project/service.rs
@@ -9,31 +9,50 @@ impl ProjectService {
         context: &SystemContext,
         request: &InitProject,
     ) -> Result<ProjectResponse, ProjectError> {
-        let brain_name = request
+        let details = request.current()?;
+        let brain_name = details
             .name
             .clone()
             .unwrap_or_else(|| context.config.brain.clone());
 
         if let Ok(BrainResponse::Found(_)) = BrainService::get(
             context,
-            &GetBrain::builder().key(brain_name.clone()).build(),
+            &GetBrain::builder_v1()
+                .key(brain_name.clone())
+                .build()
+                .into(),
         )
         .await
         {
-            return Ok(ProjectResponse::BrainAlreadyExists(brain_name));
+            return Ok(ProjectResponse::BrainAlreadyExists(
+                BrainAlreadyExistsResponse::builder_v1()
+                    .brain_name(brain_name)
+                    .build()
+                    .into(),
+            ));
         }
 
         BrainService::create(
             context,
-            &CreateBrain::builder().name(brain_name.clone()).build(),
+            &CreateBrain::builder_v1()
+                .name(brain_name.clone())
+                .build()
+                .into(),
         )
         .await?;
 
+        let main_bookmark = Bookmark::builder()
+            .brain(brain_name.clone())
+            .name(BookmarkName::main())
+            .build();
+
         context
-            .emit(BookmarkEvents::BookmarkCreated(BookmarkCreated {
-                brain: brain_name.clone(),
-                name: BookmarkName::main(),
-            }))
+            .emit(BookmarkEvents::BookmarkCreated(
+                BookmarkCreated::builder_v1()
+                    .bookmark(main_bookmark)
+                    .build()
+                    .into(),
+            ))
             .await?;
 
         // Create the brain's database layout:
@@ -64,14 +83,17 @@ impl ProjectService {
         let token = if let Some(actor) = actors.items.first() {
             match TicketService::create(
                 context,
-                &CreateTicket::builder()
+                &CreateTicket::builder_v1()
                     .actor_id(actor.id)
                     .brain_name(brain_name.clone())
-                    .build(),
+                    .build()
+                    .into(),
             )
             .await?
             {
-                TicketResponse::Created(ticket) => ticket.link.token,
+                TicketResponse::Created(TicketCreatedResponse::V1(created)) => {
+                    created.ticket.link.token
+                }
                 _ => return Err(ProjectError::Missing),
             }
         } else {
@@ -86,10 +108,13 @@ impl ProjectService {
 
         std::fs::write(&token_path, format!("{token}"))?;
 
-        Ok(ProjectResponse::Initialized(InitResult {
-            brain_name,
-            token,
-        }))
+        Ok(ProjectResponse::Initialized(
+            InitializedResponse::builder_v1()
+                .brain_name(brain_name)
+                .token(token)
+                .build()
+                .into(),
+        ))
     }
 
     /// Export all events to a JSONL file in the target directory.
@@ -102,7 +127,8 @@ impl ProjectService {
         context: &ProjectContext,
         request: &ExportProject,
     ) -> Result<ProjectResponse, ProjectError> {
-        let target_dir = &request.target;
+        let details = request.current()?;
+        let target_dir = &details.target;
         let project_name = context.brain_name();
         let db = context.db()?;
         let events = EventLog::attached(&db).load_all()?;
@@ -111,8 +137,9 @@ impl ProjectService {
         let mut buffer = String::new();
         for event in &events {
             // Synthesize ephemeral BlobStored events for storage portability.
-            if let Event::Known(Events::Storage(StorageEvents::StorageSet(entry))) = &event.data
-                && let Ok(Some(blob)) = storage.get_blob(&entry.hash)
+            if let Event::Known(Events::Storage(StorageEvents::StorageSet(set))) = &event.data
+                && let Ok(current) = set.current()
+                && let Ok(Some(blob)) = storage.get_blob(&current.entry.hash)
             {
                 let synthetic = StoredEvent::builder()
                     .id(EventId::new())
@@ -138,7 +165,12 @@ impl ProjectService {
 
         std::fs::write(&file_path, buffer)?;
 
-        Ok(ProjectResponse::WroteExport(ExportPath::new(file_path)))
+        Ok(ProjectResponse::WroteExport(
+            WroteExportResponse::builder_v1()
+                .path(file_path)
+                .build()
+                .into(),
+        ))
     }
 
     /// Import events from a JSONL file and replay projections.
@@ -151,7 +183,8 @@ impl ProjectService {
         context: &ProjectContext,
         request: &ImportProject,
     ) -> Result<ProjectResponse, ProjectError> {
-        let file = std::fs::File::open(&request.file)?;
+        let details = request.current()?;
+        let file = std::fs::File::open(&details.file)?;
         let reader = std::io::BufReader::new(file);
         let mut imported = 0usize;
 
@@ -205,10 +238,13 @@ impl ProjectService {
         let log = EventLog::attached(&db);
         let replayed = context.projections.replay_brain(&db, &log)?;
 
-        Ok(ProjectResponse::Imported(ImportResult {
-            imported: EventCount::new(imported as i64),
-            replayed: EventCount::new(replayed as i64),
-        }))
+        Ok(ProjectResponse::Imported(
+            ImportedResponse::builder_v1()
+                .imported(imported as i64)
+                .replayed(replayed as i64)
+                .build()
+                .into(),
+        ))
     }
 
     /// Replay all events through projections, rebuilding read models.
@@ -217,8 +253,11 @@ impl ProjectService {
         let log = EventLog::attached(&db);
         let replayed = context.projections.replay_brain(&db, &log)?;
 
-        Ok(ProjectResponse::Replayed(ReplayResult {
-            replayed: EventCount::new(replayed as i64),
-        }))
+        Ok(ProjectResponse::Replayed(
+            ReplayedResponse::builder_v1()
+                .replayed(replayed as i64)
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/project/view.rs
+++ b/crates/oneiros-engine/src/domains/project/view.rs
@@ -16,35 +16,85 @@ impl ProjectView {
 
     pub fn render(self) -> Rendered<ProjectResponse> {
         match self.response {
-            ProjectResponse::Initialized(result) => {
-                let prompt = Confirmation::new("Brain", result.brain_name.to_string(), "created")
+            ProjectResponse::Initialized(InitializedResponse::V1(details)) => {
+                let prompt = Confirmation::new("Brain", details.brain_name.to_string(), "created")
                     .to_string();
-                Rendered::new(ProjectResponse::Initialized(result), prompt, String::new())
-            }
-            ProjectResponse::BrainAlreadyExists(name) => {
-                let prompt = format!("{}", format!("Brain '{name}' already exists.").muted());
                 Rendered::new(
-                    ProjectResponse::BrainAlreadyExists(name),
+                    ProjectResponse::Initialized(
+                        InitializedResponse::builder_v1()
+                            .brain_name(details.brain_name)
+                            .token(details.token)
+                            .build()
+                            .into(),
+                    ),
                     prompt,
                     String::new(),
                 )
             }
-            ProjectResponse::WroteExport(path) => {
-                let prompt = format!("{} Export written to '{path}'.", "✓".success());
-                Rendered::new(ProjectResponse::WroteExport(path), prompt, String::new())
+            ProjectResponse::BrainAlreadyExists(BrainAlreadyExistsResponse::V1(details)) => {
+                let prompt = format!(
+                    "{}",
+                    format!("Brain '{}' already exists.", details.brain_name).muted()
+                );
+                Rendered::new(
+                    ProjectResponse::BrainAlreadyExists(
+                        BrainAlreadyExistsResponse::builder_v1()
+                            .brain_name(details.brain_name)
+                            .build()
+                            .into(),
+                    ),
+                    prompt,
+                    String::new(),
+                )
             }
-            ProjectResponse::Imported(result) => {
+            ProjectResponse::WroteExport(WroteExportResponse::V1(details)) => {
+                let prompt = format!(
+                    "{} Export written to '{}'.",
+                    "✓".success(),
+                    details.path.display()
+                );
+                Rendered::new(
+                    ProjectResponse::WroteExport(
+                        WroteExportResponse::builder_v1()
+                            .path(details.path)
+                            .build()
+                            .into(),
+                    ),
+                    prompt,
+                    String::new(),
+                )
+            }
+            ProjectResponse::Imported(ImportedResponse::V1(details)) => {
                 let prompt = format!(
                     "{} Imported {} events, replayed {}.",
                     "✓".success(),
-                    result.imported,
-                    result.replayed,
+                    details.imported,
+                    details.replayed,
                 );
-                Rendered::new(ProjectResponse::Imported(result), prompt, String::new())
+                Rendered::new(
+                    ProjectResponse::Imported(
+                        ImportedResponse::builder_v1()
+                            .imported(details.imported)
+                            .replayed(details.replayed)
+                            .build()
+                            .into(),
+                    ),
+                    prompt,
+                    String::new(),
+                )
             }
-            ProjectResponse::Replayed(result) => {
-                let prompt = format!("{} Replayed {} events.", "✓".success(), result.replayed);
-                Rendered::new(ProjectResponse::Replayed(result), prompt, String::new())
+            ProjectResponse::Replayed(ReplayedResponse::V1(details)) => {
+                let prompt = format!("{} Replayed {} events.", "✓".success(), details.replayed);
+                Rendered::new(
+                    ProjectResponse::Replayed(
+                        ReplayedResponse::builder_v1()
+                            .replayed(details.replayed)
+                            .build()
+                            .into(),
+                    ),
+                    prompt,
+                    String::new(),
+                )
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/search/client.rs
+++ b/crates/oneiros-engine/src/domains/search/client.rs
@@ -10,9 +10,10 @@ impl<'a> SearchClient<'a> {
     }
 
     pub async fn search(&self, request: &SearchQuery) -> Result<SearchResponse, ClientError> {
-        let path = match &request.agent {
-            Some(a) => format!("/search?query={}&agent={a}", request.query),
-            None => format!("/search?query={}", request.query),
+        let details = request.current()?;
+        let path = match &details.agent {
+            Some(a) => format!("/search?query={}&agent={a}", details.query),
+            None => format!("/search?query={}", details.query),
         };
 
         self.client.get(&path).await

--- a/crates/oneiros-engine/src/domains/search/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/search/features/cli.rs
@@ -5,7 +5,7 @@ use crate::*;
 #[derive(Debug, Args)]
 pub struct SearchCommands {
     #[command(flatten)]
-    pub query: SearchQuery,
+    pub command: SearchQuery,
 }
 
 impl SearchCommands {
@@ -16,7 +16,7 @@ impl SearchCommands {
         let client = context.client();
         let search_client = SearchClient::new(&client);
 
-        let response = search_client.search(&self.query).await?;
+        let response = search_client.search(&self.command).await?;
         Ok(SearchView::new(response).render().map(Into::into))
     }
 }

--- a/crates/oneiros-engine/src/domains/search/presenter.rs
+++ b/crates/oneiros-engine/src/domains/search/presenter.rs
@@ -11,7 +11,7 @@ impl SearchPresenter {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            SearchResponse::Results(results) => {
+            SearchResponse::Results(ResultsResponse::V1(results)) => {
                 let mut md = format!(
                     "# Search: {}\n\n{} results\n\n",
                     results.query,
@@ -37,7 +37,7 @@ impl SearchPresenter {
 
     fn render_prompt(&self) -> String {
         match &self.response {
-            SearchResponse::Results(results) => {
+            SearchResponse::Results(ResultsResponse::V1(results)) => {
                 if results.results.is_empty() {
                     return format!("No results for '{}'.", results.query);
                 }
@@ -65,7 +65,7 @@ impl SearchPresenter {
 
     fn render_text(&self) -> String {
         match &self.response {
-            SearchResponse::Results(results) => {
+            SearchResponse::Results(ResultsResponse::V1(results)) => {
                 if results.results.is_empty() {
                     format!("No results for '{}'.", results.query)
                 } else {

--- a/crates/oneiros-engine/src/domains/search/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/search/protocol/errors.rs
@@ -2,7 +2,7 @@ use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 
-use crate::{ErrorResponse, resource_op_error};
+use crate::{ErrorResponse, UpcastError, resource_op_error};
 
 #[derive(Debug, thiserror::Error)]
 pub enum SearchError {
@@ -14,6 +14,9 @@ pub enum SearchError {
 
     #[error(transparent)]
     Client(#[from] crate::ClientError),
+
+    #[error(transparent)]
+    Upcast(#[from] UpcastError),
 }
 
 resource_op_error!(SearchError);
@@ -21,7 +24,7 @@ resource_op_error!(SearchError);
 impl IntoResponse for SearchError {
     fn into_response(self) -> Response {
         let (status, message) = match &self {
-            SearchError::Database(_) | SearchError::Event(_) => {
+            SearchError::Database(_) | SearchError::Event(_) | SearchError::Upcast(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
             }
             SearchError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),

--- a/crates/oneiros-engine/src/domains/search/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/search/protocol/requests.rs
@@ -1,17 +1,19 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct SearchQuery {
-    #[builder(into)]
-    pub query: String,
-    #[arg(long)]
-    pub agent: Option<AgentName>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SearchQuery {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub query: String,
+            #[arg(long)]
+            pub agent: Option<AgentName>,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/search/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/search/protocol/responses.rs
@@ -1,11 +1,22 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = SearchResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum SearchResponse {
-    Results(SearchResults),
+    Results(ResultsResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ResultsResponse {
+        V1 => {
+            pub query: QueryText,
+            pub results: Vec<Expression>,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/search/service.rs
+++ b/crates/oneiros-engine/src/domains/search/service.rs
@@ -5,19 +5,23 @@ pub struct SearchService;
 impl SearchService {
     pub async fn search(
         context: &ProjectContext,
-        SearchQuery { query, agent }: &SearchQuery,
+        request: &SearchQuery,
     ) -> Result<SearchResponse, SearchError> {
-        let agent_id = match agent {
+        let SearchQueryV1 { query, agent } = request.current()?;
+        let agent_id = match &agent {
             Some(name) => AgentRepo::new(context).get(name).await?.map(|a| a.id),
             None => None,
         };
 
         let results = SearchRepo::new(context)
-            .search(query, agent_id.as_ref())
+            .search(&query, agent_id.as_ref())
             .await?;
-        Ok(SearchResponse::Results(SearchResults {
-            query: QueryText::new(query),
-            results,
-        }))
+        Ok(SearchResponse::Results(
+            ResultsResponse::builder_v1()
+                .query(QueryText::new(query))
+                .results(results)
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/search/store.rs
+++ b/crates/oneiros-engine/src/domains/search/store.rs
@@ -22,7 +22,10 @@ impl<'a> SearchStore<'a> {
 
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         match &event.data {
-            Event::Known(Events::Cognition(CognitionEvents::CognitionAdded(cognition))) => {
+            Event::Known(Events::Cognition(CognitionEvents::CognitionAdded(
+                CognitionAdded::V1(addition),
+            ))) => {
+                let cognition = &addition.cognition;
                 self.index(
                     Ref::cognition(cognition.id),
                     "cognition-content",
@@ -30,7 +33,8 @@ impl<'a> SearchStore<'a> {
                     cognition.agent_id,
                 )?;
             }
-            Event::Known(Events::Memory(MemoryEvents::MemoryAdded(memory))) => {
+            Event::Known(Events::Memory(MemoryEvents::MemoryAdded(MemoryAdded::V1(addition)))) => {
+                let memory = &addition.memory;
                 self.index(
                     Ref::memory(memory.id),
                     "memory-content",
@@ -38,7 +42,8 @@ impl<'a> SearchStore<'a> {
                     memory.agent_id,
                 )?;
             }
-            Event::Known(Events::Agent(AgentEvents::AgentCreated(agent))) => {
+            Event::Known(Events::Agent(AgentEvents::AgentCreated(AgentCreated::V1(creation)))) => {
+                let agent = &creation.agent;
                 let content = format!("{} {}", agent.name, agent.description);
                 self.index(
                     Ref::agent(agent.id),
@@ -47,7 +52,8 @@ impl<'a> SearchStore<'a> {
                     &agent.name,
                 )?;
             }
-            Event::Known(Events::Agent(AgentEvents::AgentUpdated(agent))) => {
+            Event::Known(Events::Agent(AgentEvents::AgentUpdated(AgentUpdated::V1(update)))) => {
+                let agent = &update.agent;
                 self.remove_by_ref(&Ref::agent(agent.id))?;
                 let content = format!("{} {}", agent.name, agent.description);
                 self.index(
@@ -57,10 +63,13 @@ impl<'a> SearchStore<'a> {
                     &agent.name,
                 )?;
             }
-            Event::Known(Events::Agent(AgentEvents::AgentRemoved(removed))) => {
-                self.remove_by_agent(&removed.name)?;
+            Event::Known(Events::Agent(AgentEvents::AgentRemoved(AgentRemoved::V1(v)))) => {
+                self.remove_by_agent(&v.name)?;
             }
-            Event::Known(Events::Experience(ExperienceEvents::ExperienceCreated(experience))) => {
+            Event::Known(Events::Experience(ExperienceEvents::ExperienceCreated(
+                ExperienceCreated::V1(creation),
+            ))) => {
+                let experience = &creation.experience;
                 self.index(
                     Ref::experience(experience.id),
                     "experience-description",
@@ -69,7 +78,7 @@ impl<'a> SearchStore<'a> {
                 )?;
             }
             Event::Known(Events::Experience(ExperienceEvents::ExperienceDescriptionUpdated(
-                update,
+                ExperienceDescriptionUpdated::V1(update),
             ))) => {
                 self.remove_by_ref(&Ref::experience(update.id))?;
                 if let Ok(Some(exp)) = ExperienceStore::new(self.conn).get(&update.id) {

--- a/crates/oneiros-engine/src/domains/seed/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/seed/protocol/requests.rs
@@ -2,11 +2,21 @@ use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
-pub struct SeedCore;
+use crate::*;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
-pub struct SeedAgents;
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SeedCore {
+        V1 => {}
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SeedAgents {
+        V1 => {}
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]

--- a/crates/oneiros-engine/src/domains/seed/service.rs
+++ b/crates/oneiros-engine/src/domains/seed/service.rs
@@ -33,11 +33,12 @@ impl SeedService {
         ] {
             LevelService::set(
                 context,
-                &SetLevel::builder()
+                &SetLevel::builder_v1()
                     .name(LevelName::new(name))
                     .description(Description::from(description))
                     .prompt(Prompt::from(prompt))
-                    .build(),
+                    .build()
+                    .into(),
             )
             .await?;
         }
@@ -71,10 +72,11 @@ impl SeedService {
         ] {
             TextureService::set(
                 context,
-                &SetTexture::builder()
+                &SetTexture::builder_v1()
                     .name(TextureName::new(name))
                     .description(Description::from(description))
-                    .build(),
+                    .build()
+                    .into(),
             )
             .await?;
         }
@@ -104,10 +106,11 @@ impl SeedService {
         ] {
             SensationService::set(
                 context,
-                &SetSensation::builder()
+                &SetSensation::builder_v1()
                     .name(name)
                     .description(description)
-                    .build(),
+                    .build()
+                    .into(),
             )
             .await?;
         }
@@ -134,10 +137,11 @@ impl SeedService {
         ] {
             NatureService::set(
                 context,
-                &SetNature::builder()
+                &SetNature::builder_v1()
                     .name(name)
                     .description(description)
-                    .build(),
+                    .build()
+                    .into(),
             )
             .await?;
         }
@@ -155,10 +159,11 @@ impl SeedService {
         ] {
             PersonaService::set(
                 context,
-                &SetPersona::builder()
+                &SetPersona::builder_v1()
                     .name(name)
                     .description(description)
-                    .build(),
+                    .build()
+                    .into(),
             )
             .await?;
         }
@@ -187,11 +192,12 @@ impl SeedService {
         ] {
             UrgeService::set(
                 context,
-                &SetUrge::builder()
+                &SetUrge::builder_v1()
                     .name(name)
                     .description(description)
                     .prompt(prompt)
-                    .build(),
+                    .build()
+                    .into(),
             )
             .await?;
         }
@@ -246,12 +252,14 @@ impl SeedService {
 
             AgentService::create(
                 context,
-                &CreateAgent::builder()
-                    .name(agent_name)
-                    .persona(PersonaName::new(persona))
-                    .description(Description::from(description))
-                    .prompt(Prompt::from(prompt))
-                    .build(),
+                &CreateAgent::V1(
+                    CreateAgentV1::builder()
+                        .name(agent_name)
+                        .persona(PersonaName::new(persona))
+                        .description(Description::from(description))
+                        .prompt(Prompt::from(prompt))
+                        .build(),
+                ),
             )
             .await?;
         }

--- a/crates/oneiros-engine/src/domains/sensation/client.rs
+++ b/crates/oneiros-engine/src/domains/sensation/client.rs
@@ -9,27 +9,36 @@ impl<'a> SensationClient<'a> {
         Self { client }
     }
 
-    pub async fn set(&self, set: &SetSensation) -> Result<SensationResponse, ClientError> {
+    pub async fn set(&self, setting: &SetSensation) -> Result<SensationResponse, ClientError> {
+        let SetSensation::V1(body) = setting;
         self.client
-            .put(&format!("/sensations/{}", set.name), set)
+            .put(&format!("/sensations/{}", body.name), setting)
             .await
     }
 
-    pub async fn get(&self, request: &GetSensation) -> Result<SensationResponse, ClientError> {
+    pub async fn get(&self, lookup: &GetSensation) -> Result<SensationResponse, ClientError> {
+        let GetSensation::V1(lookup) = lookup;
         self.client
-            .get(&format!("/sensations/{}", request.key))
+            .get(&format!("/sensations/{}", lookup.key))
             .await
     }
 
-    pub async fn list(&self, request: &ListSensations) -> Result<SensationResponse, ClientError> {
+    pub async fn list(&self, listing: &ListSensations) -> Result<SensationResponse, ClientError> {
+        let ListSensations::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset,
+            listing.filters.limit, listing.filters.offset,
         );
         self.client.get(&format!("/sensations?{query}")).await
     }
 
-    pub async fn remove(&self, name: &SensationName) -> Result<SensationResponse, ClientError> {
-        self.client.delete(&format!("/sensations/{name}")).await
+    pub async fn remove(
+        &self,
+        removal: &RemoveSensation,
+    ) -> Result<SensationResponse, ClientError> {
+        let RemoveSensation::V1(removal) = removal;
+        self.client
+            .delete(&format!("/sensations/{}", removal.name))
+            .await
     }
 }

--- a/crates/oneiros-engine/src/domains/sensation/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/sensation/features/cli.rs
@@ -2,6 +2,11 @@ use clap::Subcommand;
 
 use crate::*;
 
+/// CLI subcommands for the sensation domain. Each variant carries a versioned
+/// protocol request directly — clap derives parsing through the wrapper's
+/// `Args` impl, which delegates to the latest version's struct. The
+/// dispatcher passes the wrapper through to the client without rebuilding,
+/// since the operation type *is* the domain command.
 #[derive(Debug, Subcommand)]
 pub enum SensationCommands {
     Set(SetSensation),
@@ -19,10 +24,10 @@ impl SensationCommands {
         let sensation_client = SensationClient::new(&client);
 
         let response = match self {
-            SensationCommands::Set(set) => sensation_client.set(set).await?,
-            SensationCommands::Show(get) => sensation_client.get(get).await?,
-            SensationCommands::List(list) => sensation_client.list(list).await?,
-            SensationCommands::Remove(removal) => sensation_client.remove(&removal.name).await?,
+            Self::Set(setting) => sensation_client.set(setting).await?,
+            Self::Show(lookup) => sensation_client.get(lookup).await?,
+            Self::List(listing) => sensation_client.list(listing).await?,
+            Self::Remove(removal) => sensation_client.remove(removal).await?,
         };
 
         Ok(SensationView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/sensation/features/http.rs
+++ b/crates/oneiros-engine/src/domains/sensation/features/http.rs
@@ -41,12 +41,14 @@ impl SensationRouter {
 async fn set(
     context: ProjectContext,
     Path(name): Path<SensationName>,
-    Json(mut body): Json<SetSensation>,
+    Json(body): Json<SetSensation>,
 ) -> Result<(StatusCode, Json<SensationResponse>), SensationError> {
-    body.name = name;
+    let SetSensation::V1(mut setting) = body;
+    setting.name = name;
+    let request = SetSensation::V1(setting);
     Ok((
         StatusCode::OK,
-        Json(SensationService::set(&context, &body).await?),
+        Json(SensationService::set(&context, &request).await?),
     ))
 }
 
@@ -62,7 +64,11 @@ async fn show(
     Path(key): Path<ResourceKey<SensationName>>,
 ) -> Result<Json<SensationResponse>, SensationError> {
     Ok(Json(
-        SensationService::get(&context, &GetSensation::builder().key(key).build()).await?,
+        SensationService::get(
+            &context,
+            &GetSensation::builder_v1().key(key).build().into(),
+        )
+        .await?,
     ))
 }
 
@@ -71,6 +77,10 @@ async fn remove(
     Path(name): Path<SensationName>,
 ) -> Result<Json<SensationResponse>, SensationError> {
     Ok(Json(
-        SensationService::remove(&context, &RemoveSensation::builder().name(name).build()).await?,
+        SensationService::remove(
+            &context,
+            &RemoveSensation::builder_v1().name(name).build().into(),
+        )
+        .await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/sensation/features/state.rs
+++ b/crates/oneiros-engine/src/domains/sensation/features/state.rs
@@ -6,11 +6,15 @@ impl SensationState {
     pub fn reduce(mut canon: BrainCanon, event: &Events) -> BrainCanon {
         if let Events::Sensation(sensation_event) = event {
             match sensation_event {
-                SensationEvents::SensationSet(sensation) => {
-                    canon.sensations.set(sensation);
+                SensationEvents::SensationSet(setting) => {
+                    if let Ok(current) = setting.current() {
+                        canon.sensations.set(&current.sensation);
+                    }
                 }
-                SensationEvents::SensationRemoved(removed) => {
-                    canon.sensations.remove(&removed.name);
+                SensationEvents::SensationRemoved(removal) => {
+                    if let Ok(current) = removal.current() {
+                        canon.sensations.remove(&current.name);
+                    }
                 }
             };
         }

--- a/crates/oneiros-engine/src/domains/sensation/model.rs
+++ b/crates/oneiros-engine/src/domains/sensation/model.rs
@@ -1,20 +1,17 @@
 use bon::Builder;
-use clap::Args;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::*;
 
-#[derive(Args, Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct Sensation {
     #[builder(into)]
     pub name: SensationName,
     #[builder(into)]
-    #[arg(long, default_value = "")]
     pub description: Description,
     #[builder(into)]
-    #[arg(long, default_value = "")]
     pub prompt: Prompt,
 }
 

--- a/crates/oneiros-engine/src/domains/sensation/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/sensation/protocol/events.rs
@@ -7,13 +7,37 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = SensationEventsType, display = "kebab-case")]
 pub enum SensationEvents {
-    SensationSet(Sensation),
+    SensationSet(SensationSet),
     SensationRemoved(SensationRemoved),
+}
+
+versioned! {
+    pub enum SensationSet {
+        V1 => {
+            #[serde(flatten)] pub sensation: Sensation,
+        }
+    }
+}
+
+versioned! {
+    pub enum SensationRemoved {
+        V1 => {
+            #[builder(into)] pub name: SensationName,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_sensation() -> Sensation {
+        Sensation::builder()
+            .name("echoes")
+            .description("Resonance between thoughts")
+            .prompt("Use when things rhyme.")
+            .build()
+    }
 
     #[test]
     fn event_types_are_kebab_cased() {
@@ -25,9 +49,43 @@ mod tests {
             assert_eq!(&event_type.to_string(), expectation);
         }
     }
-}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SensationRemoved {
-    pub name: SensationName,
+    #[test]
+    fn sensation_set_wire_format_is_flat() {
+        let event = SensationEvents::SensationSet(SensationSet::V1(SensationSetV1 {
+            sensation: sample_sensation(),
+        }));
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "sensation-set");
+        assert!(
+            json["data"].get("sensation").is_none(),
+            "flatten must elide the sensation envelope on the wire"
+        );
+        assert_eq!(json["data"]["name"], "echoes");
+        assert_eq!(json["data"]["description"], "Resonance between thoughts");
+        assert!(
+            json["data"].get("V1").is_none(),
+            "V1 layer must not appear on the wire"
+        );
+    }
+
+    #[test]
+    fn sensation_removed_round_trips_through_v1_layer() {
+        let original =
+            SensationEvents::SensationRemoved(SensationRemoved::V1(SensationRemovedV1 {
+                name: SensationName::new("echoes"),
+            }));
+
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: SensationEvents = serde_json::from_str(&json).unwrap();
+
+        match decoded {
+            SensationEvents::SensationRemoved(removed) => {
+                let v1 = removed.current().unwrap();
+                assert_eq!(v1.name.to_string(), "echoes");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/sensation/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/sensation/protocol/requests.rs
@@ -1,41 +1,56 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct SetSensation {
-    #[builder(into)]
-    pub name: SensationName,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub description: Description,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub prompt: Prompt,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SetSensation {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: SensationName,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub description: Description,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub prompt: Prompt,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetSensation {
-    #[builder(into)]
-    pub key: ResourceKey<SensationName>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetSensation {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<SensationName>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct RemoveSensation {
-    #[builder(into)]
-    pub name: SensationName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum RemoveSensation {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: SensationName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListSensations {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListSensations {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/sensation/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/sensation/protocol/responses.rs
@@ -1,15 +1,49 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = SensationResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum SensationResponse {
-    SensationSet(SensationName),
-    SensationDetails(Response<Sensation>),
-    Sensations(Listed<Response<Sensation>>),
+    SensationSet(SensationSetResponse),
+    SensationDetails(SensationDetailsResponse),
+    Sensations(SensationsResponse),
     NoSensations,
-    SensationRemoved(SensationName),
+    SensationRemoved(SensationRemovedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SensationSetResponse {
+        V1 => { #[serde(flatten)] pub sensation: Sensation }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SensationDetailsResponse {
+        V1 => { #[serde(flatten)] pub sensation: Sensation }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SensationsResponse {
+        V1 => {
+            pub items: Vec<Sensation>,
+            pub total: usize,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SensationRemovedResponse {
+        V1 => {
+            #[builder(into)] pub name: SensationName,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/sensation/service.rs
+++ b/crates/oneiros-engine/src/domains/sensation/service.rs
@@ -5,62 +5,87 @@ pub struct SensationService;
 impl SensationService {
     pub async fn set(
         context: &ProjectContext,
-        SetSensation {
-            name,
-            description,
-            prompt,
-        }: &SetSensation,
+        request: &SetSensation,
     ) -> Result<SensationResponse, SensationError> {
+        let SetSensation::V1(set) = request;
         let sensation = Sensation::builder()
-            .name(name.clone())
-            .description(description.clone())
-            .prompt(prompt.clone())
+            .name(set.name.clone())
+            .description(set.description.clone())
+            .prompt(set.prompt.clone())
             .build();
+
         context
-            .emit(SensationEvents::SensationSet(sensation))
+            .emit(SensationEvents::SensationSet(
+                SensationSet::builder_v1()
+                    .sensation(sensation.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        Ok(SensationResponse::SensationSet(name.clone()))
+
+        Ok(SensationResponse::SensationSet(
+            SensationSetResponse::builder_v1()
+                .sensation(sensation)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn get(
         context: &ProjectContext,
-        selector: &GetSensation,
+        request: &GetSensation,
     ) -> Result<SensationResponse, SensationError> {
-        let name = selector.key.resolve()?;
+        let GetSensation::V1(lookup) = request;
+        let name = lookup.key.resolve()?;
         let sensation = SensationRepo::new(context)
             .get(&name)
             .await?
             .ok_or(SensationError::NotFound(name))?;
-        let ref_token = RefToken::new(Ref::sensation(sensation.name.clone()));
         Ok(SensationResponse::SensationDetails(
-            Response::new(sensation).with_ref_token(ref_token),
+            SensationDetailsResponse::builder_v1()
+                .sensation(sensation)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn list(
         context: &ProjectContext,
-        ListSensations { filters }: &ListSensations,
+        request: &ListSensations,
     ) -> Result<SensationResponse, SensationError> {
-        let listed = SensationRepo::new(context).list(filters).await?;
+        let ListSensations::V1(listing) = request;
+        let listed = SensationRepo::new(context).list(&listing.filters).await?;
         if listed.total == 0 {
             Ok(SensationResponse::NoSensations)
         } else {
-            Ok(SensationResponse::Sensations(listed.map(|e| {
-                let ref_token = RefToken::new(Ref::sensation(e.name.clone()));
-                Response::new(e).with_ref_token(ref_token)
-            })))
+            Ok(SensationResponse::Sensations(
+                SensationsResponse::builder_v1()
+                    .items(listed.items)
+                    .total(listed.total)
+                    .build()
+                    .into(),
+            ))
         }
     }
 
     pub async fn remove(
         context: &ProjectContext,
-        selector: &RemoveSensation,
+        request: &RemoveSensation,
     ) -> Result<SensationResponse, SensationError> {
+        let RemoveSensation::V1(removal) = request;
         context
-            .emit(SensationEvents::SensationRemoved(SensationRemoved {
-                name: selector.name.clone(),
-            }))
+            .emit(SensationEvents::SensationRemoved(
+                SensationRemoved::builder_v1()
+                    .name(removal.name.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        Ok(SensationResponse::SensationRemoved(selector.name.clone()))
+        Ok(SensationResponse::SensationRemoved(
+            SensationRemovedResponse::builder_v1()
+                .name(removal.name.clone())
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/sensation/store.rs
+++ b/crates/oneiros-engine/src/domains/sensation/store.rs
@@ -14,8 +14,8 @@ impl<'a> SensationStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Sensation(sensation_event)) = &event.data {
             match sensation_event {
-                SensationEvents::SensationSet(sensation) => self.set(sensation)?,
-                SensationEvents::SensationRemoved(removed) => self.remove(&removed.name)?,
+                SensationEvents::SensationSet(setting) => self.set(setting)?,
+                SensationEvents::SensationRemoved(removal) => self.remove(removal)?,
             }
         }
         Ok(())
@@ -64,7 +64,21 @@ impl<'a> SensationStore<'a> {
         Ok(sensations)
     }
 
-    fn set(&self, sensation: &Sensation) -> Result<(), EventError> {
+    fn set(&self, setting: &SensationSet) -> Result<(), EventError> {
+        let sensation = setting.current()?.sensation;
+        self.write_sensation(&sensation)
+    }
+
+    fn remove(&self, removal: &SensationRemoved) -> Result<(), EventError> {
+        let name = removal.current()?.name;
+        self.conn.execute(
+            "DELETE FROM sensations WHERE name = ?1",
+            params![name.to_string()],
+        )?;
+        Ok(())
+    }
+
+    fn write_sensation(&self, sensation: &Sensation) -> Result<(), EventError> {
         self.conn.execute(
             "INSERT OR REPLACE INTO sensations (name, description, prompt) VALUES (?1, ?2, ?3)",
             params![
@@ -72,14 +86,6 @@ impl<'a> SensationStore<'a> {
                 sensation.description.to_string(),
                 sensation.prompt.to_string()
             ],
-        )?;
-        Ok(())
-    }
-
-    fn remove(&self, name: &SensationName) -> Result<(), EventError> {
-        self.conn.execute(
-            "DELETE FROM sensations WHERE name = ?1",
-            params![name.to_string()],
         )?;
         Ok(())
     }

--- a/crates/oneiros-engine/src/domains/sensation/view.rs
+++ b/crates/oneiros-engine/src/domains/sensation/view.rs
@@ -11,27 +11,27 @@ impl SensationView {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            SensationResponse::Sensations(listed) => {
+            SensationResponse::Sensations(SensationsResponse::V1(listed)) => {
                 let items: Vec<_> = listed
                     .items
                     .iter()
-                    .map(|w| (w.data.name.to_string(), w.data.description.to_string()))
+                    .map(|item| (item.name.to_string(), item.description.to_string()))
                     .collect();
                 Self::vocabulary_table("Sensations", &items)
             }
-            SensationResponse::SensationDetails(wrapped) => {
+            SensationResponse::SensationDetails(SensationDetailsResponse::V1(details)) => {
                 let items = vec![(
-                    wrapped.data.name.to_string(),
-                    wrapped.data.description.to_string(),
+                    details.sensation.name.to_string(),
+                    details.sensation.description.to_string(),
                 )];
                 Self::vocabulary_table("Sensation", &items)
             }
             SensationResponse::NoSensations => Self::vocabulary_table("Sensations", &[]),
-            SensationResponse::SensationSet(name) => {
-                McpResponse::new(format!("Sensation set: {name}"))
+            SensationResponse::SensationSet(SensationSetResponse::V1(set)) => {
+                McpResponse::new(format!("Sensation set: {}", set.sensation.name))
             }
-            SensationResponse::SensationRemoved(name) => {
-                McpResponse::new(format!("Sensation removed: {name}"))
+            SensationResponse::SensationRemoved(SensationRemovedResponse::V1(removed)) => {
+                McpResponse::new(format!("Sensation removed: {}", removed.name))
             }
         }
     }
@@ -52,59 +52,65 @@ impl SensationView {
 
     pub fn render(self) -> Rendered<SensationResponse> {
         match self.response {
-            SensationResponse::SensationSet(name) => {
-                let prompt = Confirmation::new("Sensation", name.to_string(), "set").to_string();
+            SensationResponse::SensationSet(SensationSetResponse::V1(set)) => {
+                let prompt = Confirmation::new("Sensation", set.sensation.name.to_string(), "set")
+                    .to_string();
                 let hints = HintSet::vocabulary(
                     VocabularyHints::builder()
                         .kind("sensation".to_string())
                         .build(),
                 );
-                Rendered::new(SensationResponse::SensationSet(name), prompt, String::new())
-                    .with_hints(hints)
+                Rendered::new(
+                    SensationResponse::SensationSet(SensationSetResponse::V1(set)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
-            SensationResponse::SensationDetails(wrapped) => {
-                let prompt = Detail::new(wrapped.data.name.to_string())
-                    .field("description:", wrapped.data.description.to_string())
-                    .field("prompt:", wrapped.data.prompt.to_string())
+            SensationResponse::SensationDetails(SensationDetailsResponse::V1(details)) => {
+                let prompt = Detail::new(details.sensation.name.to_string())
+                    .field("description:", details.sensation.description.to_string())
+                    .field("prompt:", details.sensation.prompt.to_string())
                     .to_string();
                 Rendered::new(
-                    SensationResponse::SensationDetails(wrapped),
+                    SensationResponse::SensationDetails(SensationDetailsResponse::V1(details)),
                     prompt,
                     String::new(),
                 )
             }
-            SensationResponse::Sensations(listed) => {
+            SensationResponse::Sensations(SensationsResponse::V1(listed)) => {
                 let mut table = Table::new(vec![
                     Column::key("name", "Name"),
                     Column::key("description", "Description").max(60),
                 ]);
-                for wrapped in &listed.items {
-                    table.push_row(vec![
-                        wrapped.data.name.to_string(),
-                        wrapped.data.description.to_string(),
-                    ]);
+                for item in &listed.items {
+                    table.push_row(vec![item.name.to_string(), item.description.to_string()]);
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
-                Rendered::new(SensationResponse::Sensations(listed), prompt, String::new())
+                Rendered::new(
+                    SensationResponse::Sensations(SensationsResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
             SensationResponse::NoSensations => Rendered::new(
                 SensationResponse::NoSensations,
                 format!("{}", "No sensations configured.".muted()),
                 String::new(),
             ),
-            SensationResponse::SensationRemoved(name) => {
+            SensationResponse::SensationRemoved(SensationRemovedResponse::V1(removed)) => {
                 let prompt =
-                    Confirmation::new("Sensation", name.to_string(), "removed").to_string();
+                    Confirmation::new("Sensation", removed.name.to_string(), "removed").to_string();
                 let hints = HintSet::vocabulary(
                     VocabularyHints::builder()
                         .kind("sensation".to_string())
                         .build(),
                 );
                 Rendered::new(
-                    SensationResponse::SensationRemoved(name),
+                    SensationResponse::SensationRemoved(SensationRemovedResponse::V1(removed)),
                     prompt,
                     String::new(),
                 )

--- a/crates/oneiros-engine/src/domains/service/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/service/protocol/responses.rs
@@ -1,86 +1,78 @@
 use std::fmt;
 
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// The name under which the service is registered with the OS service manager.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(transparent)]
-pub struct ServiceName(pub String);
-
-impl ServiceName {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl fmt::Display for ServiceName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-/// The network address at which the service is reachable.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(transparent)]
-pub struct ServiceAddress(pub String);
-
-impl ServiceAddress {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl fmt::Display for ServiceAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-/// A human-readable explanation for why the service is not running.
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(transparent)]
-pub struct ServiceReason(pub String);
-
-impl ServiceReason {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl fmt::Display for ServiceReason {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
+use crate::*;
 
 /// All responses the service domain can produce.
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = ServiceResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum ServiceResponse {
-    ServiceInstalled(ServiceName),
+    ServiceInstalled(ServiceInstalledResponse),
     ServiceUninstalled,
     ServiceStarted,
-    ServiceHealthy(ServiceAddress),
+    ServiceHealthy(ServiceHealthyResponse),
     ServiceStopped,
-    ServiceRunning(ServiceAddress),
-    ServiceNotRunning(ServiceReason),
+    ServiceRunning(ServiceRunningResponse),
+    ServiceNotRunning(ServiceNotRunningResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ServiceInstalledResponse {
+        V1 => {
+            #[builder(into)] pub name: String,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ServiceHealthyResponse {
+        V1 => {
+            #[builder(into)] pub address: String,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ServiceRunningResponse {
+        V1 => {
+            #[builder(into)] pub address: String,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ServiceNotRunningResponse {
+        V1 => {
+            #[builder(into)] pub reason: String,
+        }
+    }
 }
 
 impl fmt::Display for ServiceResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::ServiceInstalled(label) => write!(f, "Service installed as '{label}'."),
+            Self::ServiceInstalled(ServiceInstalledResponse::V1(d)) => {
+                write!(f, "Service installed as '{}'.", d.name)
+            }
             Self::ServiceUninstalled => write!(f, "Service uninstalled."),
             Self::ServiceStarted => write!(f, "Service started."),
-            Self::ServiceHealthy(addr) => {
-                write!(f, "Service started and healthy at {addr}.")
+            Self::ServiceHealthy(ServiceHealthyResponse::V1(d)) => {
+                write!(f, "Service started and healthy at {}.", d.address)
             }
             Self::ServiceStopped => write!(f, "Service stopped."),
-            Self::ServiceRunning(addr) => write!(f, "Service is running at {addr}."),
-            Self::ServiceNotRunning(reason) => {
-                write!(f, "Service is not running: {reason}")
+            Self::ServiceRunning(ServiceRunningResponse::V1(d)) => {
+                write!(f, "Service is running at {}.", d.address)
+            }
+            Self::ServiceNotRunning(ServiceNotRunningResponse::V1(d)) => {
+                write!(f, "Service is not running: {}", d.reason)
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/service/service.rs
+++ b/crates/oneiros-engine/src/domains/service/service.rs
@@ -55,9 +55,12 @@ impl ServiceService {
             })
             .map_err(manager_err)?;
 
-        Ok(ServiceResponse::ServiceInstalled(ServiceName::new(
-            config.service.label.clone(),
-        )))
+        Ok(ServiceResponse::ServiceInstalled(
+            ServiceInstalledResponse::builder_v1()
+                .name(config.service.label.clone())
+                .build()
+                .into(),
+        ))
     }
 
     /// Uninstall the managed service. Best-effort stop before removal.
@@ -92,9 +95,12 @@ impl ServiceService {
             tokio::time::sleep(*delay).await;
 
             if client.get(&health_url).send().await.is_ok() {
-                return Ok(ServiceResponse::ServiceHealthy(ServiceAddress::new(
-                    config.service.address.to_string(),
-                )));
+                return Ok(ServiceResponse::ServiceHealthy(
+                    ServiceHealthyResponse::builder_v1()
+                        .address(config.service.address.to_string())
+                        .build()
+                        .into(),
+                ));
             }
         }
 
@@ -120,13 +126,23 @@ impl ServiceService {
 
         match client.get(&health_url).send().await {
             Ok(resp) if resp.status().is_success() => ServiceResponse::ServiceRunning(
-                ServiceAddress::new(config.service.address.to_string()),
+                ServiceRunningResponse::builder_v1()
+                    .address(config.service.address.to_string())
+                    .build()
+                    .into(),
             ),
-            Ok(resp) => ServiceResponse::ServiceNotRunning(ServiceReason::new(format!(
-                "HTTP {}",
-                resp.status()
-            ))),
-            Err(e) => ServiceResponse::ServiceNotRunning(ServiceReason::new(e.to_string())),
+            Ok(resp) => ServiceResponse::ServiceNotRunning(
+                ServiceNotRunningResponse::builder_v1()
+                    .reason(format!("HTTP {}", resp.status()))
+                    .build()
+                    .into(),
+            ),
+            Err(e) => ServiceResponse::ServiceNotRunning(
+                ServiceNotRunningResponse::builder_v1()
+                    .reason(e.to_string())
+                    .build()
+                    .into(),
+            ),
         }
     }
 

--- a/crates/oneiros-engine/src/domains/service/view.rs
+++ b/crates/oneiros-engine/src/domains/service/view.rs
@@ -17,17 +17,15 @@ impl ServiceView {
 
     pub fn render(self) -> Rendered<ServiceResponse> {
         match self.response {
-            ServiceResponse::ServiceInstalled(name) => {
-                let prompt = format!(
-                    "{} {}",
-                    "✓".success(),
-                    ServiceResponse::ServiceInstalled(name.clone())
+            ServiceResponse::ServiceInstalled(ServiceInstalledResponse::V1(details)) => {
+                let response = ServiceResponse::ServiceInstalled(
+                    ServiceInstalledResponse::builder_v1()
+                        .name(details.name)
+                        .build()
+                        .into(),
                 );
-                Rendered::new(
-                    ServiceResponse::ServiceInstalled(name),
-                    prompt,
-                    String::new(),
-                )
+                let prompt = format!("{} {}", "✓".success(), response);
+                Rendered::new(response, prompt, String::new())
             }
             ServiceResponse::ServiceUninstalled => {
                 let prompt = format!("{} {}", "✓".success(), ServiceResponse::ServiceUninstalled);
@@ -37,37 +35,39 @@ impl ServiceView {
                 let prompt = format!("{} {}", "✓".success(), ServiceResponse::ServiceStarted);
                 Rendered::new(ServiceResponse::ServiceStarted, prompt, String::new())
             }
-            ServiceResponse::ServiceHealthy(addr) => {
-                let prompt = format!(
-                    "{} {}",
-                    "✓".success(),
-                    ServiceResponse::ServiceHealthy(addr.clone())
+            ServiceResponse::ServiceHealthy(ServiceHealthyResponse::V1(details)) => {
+                let response = ServiceResponse::ServiceHealthy(
+                    ServiceHealthyResponse::builder_v1()
+                        .address(details.address)
+                        .build()
+                        .into(),
                 );
-                Rendered::new(ServiceResponse::ServiceHealthy(addr), prompt, String::new())
+                let prompt = format!("{} {}", "✓".success(), response);
+                Rendered::new(response, prompt, String::new())
             }
             ServiceResponse::ServiceStopped => {
                 let prompt = format!("{} {}", "✓".success(), ServiceResponse::ServiceStopped);
                 Rendered::new(ServiceResponse::ServiceStopped, prompt, String::new())
             }
-            ServiceResponse::ServiceRunning(addr) => {
-                let prompt = format!(
-                    "{} {}",
-                    "✓".success(),
-                    ServiceResponse::ServiceRunning(addr.clone())
+            ServiceResponse::ServiceRunning(ServiceRunningResponse::V1(details)) => {
+                let response = ServiceResponse::ServiceRunning(
+                    ServiceRunningResponse::builder_v1()
+                        .address(details.address)
+                        .build()
+                        .into(),
                 );
-                Rendered::new(ServiceResponse::ServiceRunning(addr), prompt, String::new())
+                let prompt = format!("{} {}", "✓".success(), response);
+                Rendered::new(response, prompt, String::new())
             }
-            ServiceResponse::ServiceNotRunning(reason) => {
-                let prompt = format!(
-                    "{} {}",
-                    "!".warning(),
-                    ServiceResponse::ServiceNotRunning(reason.clone())
+            ServiceResponse::ServiceNotRunning(ServiceNotRunningResponse::V1(details)) => {
+                let response = ServiceResponse::ServiceNotRunning(
+                    ServiceNotRunningResponse::builder_v1()
+                        .reason(details.reason)
+                        .build()
+                        .into(),
                 );
-                Rendered::new(
-                    ServiceResponse::ServiceNotRunning(reason),
-                    prompt,
-                    String::new(),
-                )
+                let prompt = format!("{} {}", "!".warning(), response);
+                Rendered::new(response, prompt, String::new())
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/setup/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/setup/protocol/errors.rs
@@ -22,6 +22,9 @@ pub enum SetupError {
 
     #[error(transparent)]
     Service(#[from] crate::ServiceError),
+
+    #[error(transparent)]
+    Upcast(#[from] crate::UpcastError),
 }
 
 impl IntoResponse for SetupError {

--- a/crates/oneiros-engine/src/domains/setup/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/setup/protocol/requests.rs
@@ -1,16 +1,21 @@
-use bon::Builder;
-use clap::Args;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct SetupRequest {
-    /// Name for the system/host. Defaults to "oneiros user".
-    #[arg(long)]
-    #[builder(into)]
-    pub name: Option<String>,
-    /// Skip all confirmation prompts.
-    #[arg(long, short)]
-    #[builder(default)]
-    pub yes: bool,
+use crate::*;
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SetupRequest {
+        #[derive(clap::Args)]
+        V1 => {
+            /// Name for the system/host. Defaults to "oneiros user".
+            #[arg(long)]
+            #[builder(into)]
+            pub name: Option<String>,
+            /// Skip all confirmation prompts.
+            #[arg(long, short)]
+            #[serde(default)]
+            #[builder(default)]
+            pub yes: bool,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/setup/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/setup/protocol/responses.rs
@@ -1,10 +1,11 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
 /// A single step in the setup flow.
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = SetupStepType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum SetupStep {
@@ -23,9 +24,18 @@ pub enum SetupStep {
 }
 
 /// The result of running setup.
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = SetupResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum SetupResponse {
-    SetupComplete(Vec<SetupStep>),
+    SetupComplete(SetupCompleteResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SetupCompleteResponse {
+        V1 => {
+            pub steps: Vec<SetupStep>,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/setup/service.rs
+++ b/crates/oneiros-engine/src/domains/setup/service.rs
@@ -4,14 +4,16 @@ pub struct SetupService;
 
 impl SetupService {
     pub async fn run(config: &Config, request: &SetupRequest) -> Result<SetupResponse, SetupError> {
+        let details = request.current()?;
         let mut steps = Vec::new();
 
         // 1. System init (always, idempotent)
         let system_ctx = config.system();
-        let system_request = InitSystem {
-            name: request.name.clone(),
-            yes: true,
-        };
+        let system_request: InitSystem = InitSystem::builder_v1()
+            .maybe_name(details.name.clone())
+            .yes(true)
+            .build()
+            .into();
 
         match SystemService::init(&system_ctx, &system_request).await {
             Ok(SystemResponse::SystemInitialized(_)) => {
@@ -25,26 +27,36 @@ impl SetupService {
                     step: "system init".into(),
                     reason: e.to_string(),
                 });
-                return Ok(SetupResponse::SetupComplete(steps));
+                return Ok(SetupResponse::SetupComplete(
+                    SetupCompleteResponse::builder_v1()
+                        .steps(steps)
+                        .build()
+                        .into(),
+                ));
             }
         }
 
         // 2. Project init (always, idempotent)
-        let project_request = InitProject::builder().yes(true).build();
+        let project_request: InitProject = InitProject::builder_v1().yes(true).build().into();
 
         match ProjectService::init(&system_ctx, &project_request).await {
-            Ok(ProjectResponse::Initialized(result)) => {
+            Ok(ProjectResponse::Initialized(InitializedResponse::V1(result))) => {
                 steps.push(SetupStep::ProjectInitialized(result.brain_name));
             }
-            Ok(ProjectResponse::BrainAlreadyExists(name)) => {
-                steps.push(SetupStep::ProjectAlreadyExists(name));
+            Ok(ProjectResponse::BrainAlreadyExists(BrainAlreadyExistsResponse::V1(details))) => {
+                steps.push(SetupStep::ProjectAlreadyExists(details.brain_name));
             }
             Err(e) => {
                 steps.push(SetupStep::StepFailed {
                     step: "project init".into(),
                     reason: e.to_string(),
                 });
-                return Ok(SetupResponse::SetupComplete(steps));
+                return Ok(SetupResponse::SetupComplete(
+                    SetupCompleteResponse::builder_v1()
+                        .steps(steps)
+                        .build()
+                        .into(),
+                ));
             }
             _ => {}
         }
@@ -74,14 +86,14 @@ impl SetupService {
         }
 
         // 5. MCP config (prompt unless --yes)
-        let do_mcp = request.yes
+        let do_mcp = details.yes
             || inquire::Confirm::new("Set up MCP config for Claude Code?")
                 .with_default(true)
                 .prompt()
                 .unwrap_or(false);
 
         if do_mcp {
-            let mcp_request = InitMcp::builder().yes(true).build();
+            let mcp_request: InitMcp = InitMcp::builder_v1().yes(true).build().into();
             match McpConfigService::init(config, &mcp_request) {
                 Ok(McpConfigResponse::McpConfigWritten(_)) => {
                     steps.push(SetupStep::McpConfigured);
@@ -102,7 +114,7 @@ impl SetupService {
         }
 
         // 6. Service install + start (prompt unless --yes)
-        let do_service = request.yes
+        let do_service = details.yes
             || inquire::Confirm::new("Install and start the oneiros service?")
                 .with_default(true)
                 .prompt()
@@ -132,6 +144,11 @@ impl SetupService {
             steps.push(SetupStep::ServiceSkipped);
         }
 
-        Ok(SetupResponse::SetupComplete(steps))
+        Ok(SetupResponse::SetupComplete(
+            SetupCompleteResponse::builder_v1()
+                .steps(steps)
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/setup/view.rs
+++ b/crates/oneiros-engine/src/domains/setup/view.rs
@@ -13,9 +13,18 @@ impl SetupView {
 
     pub fn render(self) -> Rendered<SetupResponse> {
         match self.response {
-            SetupResponse::SetupComplete(steps) => {
-                let prompt = Self::steps(&steps);
-                Rendered::new(SetupResponse::SetupComplete(steps), prompt, String::new())
+            SetupResponse::SetupComplete(SetupCompleteResponse::V1(details)) => {
+                let prompt = Self::steps(&details.steps);
+                Rendered::new(
+                    SetupResponse::SetupComplete(
+                        SetupCompleteResponse::builder_v1()
+                            .steps(details.steps)
+                            .build()
+                            .into(),
+                    ),
+                    prompt,
+                    String::new(),
+                )
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/storage/client.rs
+++ b/crates/oneiros-engine/src/domains/storage/client.rs
@@ -9,28 +9,31 @@ impl<'a> StorageClient<'a> {
         Self { client }
     }
 
-    pub async fn upload(&self, request: &UploadStorage) -> Result<StorageResponse, ClientError> {
-        self.client.post("/storage", request).await
+    pub async fn upload(&self, upload: &UploadStorage) -> Result<StorageResponse, ClientError> {
+        self.client.post("/storage", upload).await
     }
 
-    pub async fn list(&self, request: &ListStorage) -> Result<StorageResponse, ClientError> {
+    pub async fn list(&self, listing: &ListStorage) -> Result<StorageResponse, ClientError> {
+        let ListStorage::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset
+            listing.filters.limit, listing.filters.offset
         );
         self.client.get(&format!("/storage?{query}")).await
     }
 
-    pub async fn show(&self, request: &GetStorage) -> Result<StorageResponse, ClientError> {
-        let path = match &request.key {
+    pub async fn show(&self, lookup: &GetStorage) -> Result<StorageResponse, ClientError> {
+        let GetStorage::V1(lookup) = lookup;
+        let path = match &lookup.key {
             ResourceKey::Key(key) => StorageRef::encode(key).to_string(),
             ResourceKey::Ref(token) => token.to_string(),
         };
         self.client.get(&format!("/storage/{path}")).await
     }
 
-    pub async fn remove(&self, request: &RemoveStorage) -> Result<StorageResponse, ClientError> {
-        let ref_key = StorageRef::encode(&request.key);
+    pub async fn remove(&self, removal: &RemoveStorage) -> Result<StorageResponse, ClientError> {
+        let RemoveStorage::V1(removal) = removal;
+        let ref_key = StorageRef::encode(&removal.key);
         self.client.delete(&format!("/storage/{ref_key}")).await
     }
 }

--- a/crates/oneiros-engine/src/domains/storage/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/storage/features/cli.rs
@@ -5,6 +5,8 @@ use crate::*;
 
 #[derive(Debug, Subcommand)]
 pub enum StorageCommands {
+    /// Upload a file to storage. Reads the bytes from `file` and
+    /// constructs the protocol-level `UploadStorage` request.
     Set {
         key: String,
         file: PathBuf,
@@ -25,7 +27,7 @@ impl StorageCommands {
         let storage_client = StorageClient::new(&client);
 
         let response = match self {
-            StorageCommands::Set {
+            Self::Set {
                 key,
                 file,
                 description,
@@ -33,17 +35,18 @@ impl StorageCommands {
                 let data = std::fs::read(file)?;
                 storage_client
                     .upload(
-                        &UploadStorage::builder()
+                        &UploadStorage::builder_v1()
                             .key(StorageKey::new(key))
                             .description(Description::new(description))
                             .data(data)
-                            .build(),
+                            .build()
+                            .into(),
                     )
                     .await?
             }
-            StorageCommands::Show(get) => storage_client.show(get).await?,
-            StorageCommands::List(listing) => storage_client.list(listing).await?,
-            StorageCommands::Remove(remove) => storage_client.remove(remove).await?,
+            Self::Show(lookup) => storage_client.show(lookup).await?,
+            Self::List(listing) => storage_client.list(listing).await?,
+            Self::Remove(removal) => storage_client.remove(removal).await?,
         };
 
         Ok(StorageView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/storage/features/http.rs
+++ b/crates/oneiros-engine/src/domains/storage/features/http.rs
@@ -64,7 +64,7 @@ async fn show(
         ResourceKey::Key(storage_ref.decode().map_err(|_| StorageError::InvalidRef)?)
     };
     Ok(Json(
-        StorageService::show(&context, &GetStorage::builder().key(key).build()).await?,
+        StorageService::show(&context, &GetStorage::builder_v1().key(key).build().into()).await?,
     ))
 }
 
@@ -75,6 +75,10 @@ async fn remove(
     let storage_ref = StorageRef(ref_key);
     let key = storage_ref.decode().map_err(|_| StorageError::InvalidRef)?;
     Ok(Json(
-        StorageService::remove(&context, &RemoveStorage::builder().key(key).build()).await?,
+        StorageService::remove(
+            &context,
+            &RemoveStorage::builder_v1().key(key).build().into(),
+        )
+        .await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/storage/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/storage/features/mcp.rs
@@ -44,7 +44,8 @@ mod storage_mcp {
 
         let value = match request_type {
             StorageRequestType::ListStorage => {
-                let request: ListStorage = serde_json::from_str(params).unwrap_or_default();
+                let request: ListStorage = serde_json::from_str(params)
+                    .unwrap_or_else(|_| ListStorage::builder_v1().build().into());
                 StorageService::list(context, &request).await
             }
             StorageRequestType::GetStorage => {

--- a/crates/oneiros-engine/src/domains/storage/features/state.rs
+++ b/crates/oneiros-engine/src/domains/storage/features/state.rs
@@ -6,11 +6,15 @@ impl StorageState {
     pub fn reduce(mut canon: BrainCanon, event: &Events) -> BrainCanon {
         if let Events::Storage(storage_event) = event {
             match storage_event {
-                StorageEvents::StorageSet(entry) => {
-                    canon.storage.set(entry);
+                StorageEvents::StorageSet(set) => {
+                    if let Ok(current) = set.current() {
+                        canon.storage.set(&current.entry);
+                    }
                 }
                 StorageEvents::StorageRemoved(removed) => {
-                    canon.storage.remove(&removed.key);
+                    if let Ok(current) = removed.current() {
+                        canon.storage.remove(&current.key);
+                    }
                 }
             };
         }

--- a/crates/oneiros-engine/src/domains/storage/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/storage/protocol/events.rs
@@ -8,14 +8,38 @@ use crate::*;
 #[kinded(kind = StorageEventsType, display = "kebab-case")]
 pub enum StorageEvents {
     /// Persistent: projects to storage metadata table (upsert).
-    StorageSet(StorageEntry),
+    StorageSet(StorageSet),
     /// Persistent: removes storage metadata by key.
-    StorageRemoved(SelectStorageByKey),
+    StorageRemoved(StorageRemoved),
+}
+
+versioned! {
+    pub enum StorageSet {
+        V1 => {
+            #[serde(flatten)] pub entry: StorageEntry,
+        }
+    }
+}
+
+versioned! {
+    pub enum StorageRemoved {
+        V1 => {
+            pub key: StorageKey,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_entry() -> StorageEntry {
+        StorageEntry {
+            key: StorageKey::new("project-notes"),
+            description: Description::new("notes"),
+            hash: ContentHash::new("abc"),
+        }
+    }
 
     #[test]
     fn event_types_are_kebab_cased() {
@@ -26,5 +50,26 @@ mod tests {
         for (event_type, expectation) in cases {
             assert_eq!(&event_type.to_string(), expectation);
         }
+    }
+
+    #[test]
+    fn storage_set_wire_format_is_flat() {
+        let event = StorageEvents::StorageSet(StorageSet::V1(StorageSetV1 {
+            entry: sample_entry(),
+        }));
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "storage-set");
+        assert!(
+            json["data"].get("entry").is_none(),
+            "flatten must elide the entry envelope on the wire"
+        );
+        assert_eq!(json["data"]["key"], "project-notes");
+        assert_eq!(json["data"]["description"], "notes");
+        assert_eq!(json["data"]["hash"], "abc");
+        assert!(
+            json["data"].get("V1").is_none(),
+            "V1 layer must not appear on the wire"
+        );
     }
 }

--- a/crates/oneiros-engine/src/domains/storage/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/storage/protocol/requests.rs
@@ -1,39 +1,55 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetStorage {
-    #[builder(into)]
-    pub key: ResourceKey<StorageKey>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetStorage {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<StorageKey>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct RemoveStorage {
-    #[builder(into)]
-    pub key: StorageKey,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum RemoveStorage {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: StorageKey,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct UploadStorage {
-    #[builder(into)]
-    pub key: StorageKey,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub description: Description,
-    pub data: Vec<u8>,
+// UploadStorage carries a `Vec<u8>` payload, which does not satisfy
+// clap's parsing requirements — the CLI uses an `--file` path instead
+// and reads the bytes before constructing the request.
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum UploadStorage {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: StorageKey,
+            #[builder(default, into)] pub description: Description,
+            pub data: Vec<u8>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Default, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListStorage {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListStorage {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/storage/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/storage/protocol/responses.rs
@@ -1,15 +1,49 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = StorageResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum StorageResponse {
-    StorageSet(Response<StorageEntry>),
-    StorageDetails(Response<StorageEntry>),
-    Entries(Listed<Response<StorageEntry>>),
+    StorageSet(StorageSetResponse),
+    StorageDetails(StorageDetailsResponse),
+    Entries(StorageEntriesResponse),
     NoEntries,
-    StorageRemoved(StorageKey),
+    StorageRemoved(StorageRemovedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum StorageSetResponse {
+        V1 => { #[serde(flatten)] pub entry: StorageEntry }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum StorageDetailsResponse {
+        V1 => { #[serde(flatten)] pub entry: StorageEntry }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum StorageEntriesResponse {
+        V1 => {
+            pub items: Vec<StorageEntry>,
+            pub total: usize,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum StorageRemovedResponse {
+        V1 => {
+            pub key: StorageKey,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/storage/service.rs
+++ b/crates/oneiros-engine/src/domains/storage/service.rs
@@ -6,85 +6,101 @@ impl StorageService {
     /// Upload content — hash it, store the blob, record the metadata.
     pub async fn upload(
         context: &ProjectContext,
-        UploadStorage {
-            key,
-            description,
-            data,
-        }: &UploadStorage,
+        request: &UploadStorage,
     ) -> Result<StorageResponse, StorageError> {
-        let blob = BlobContent::create(data)?;
+        let UploadStorage::V1(upload) = request;
+        let blob = BlobContent::create(&upload.data)?;
 
         // Put the blob directly (not via event — the blob table is the durable store).
         StorageStore::new(&context.db()?).put_blob(&blob)?;
 
         let entry = StorageEntry {
-            key: key.clone(),
-            description: description.clone(),
-            hash: blob.hash,
+            key: upload.key.clone(),
+            description: upload.description.clone(),
+            hash: blob.hash.clone(),
         };
 
         // Emit StorageSet — this drives the storage metadata projection.
         context
-            .emit(StorageEvents::StorageSet(entry.clone()))
+            .emit(StorageEvents::StorageSet(
+                StorageSet::builder_v1().entry(entry.clone()).build().into(),
+            ))
             .await?;
 
-        let ref_token = RefToken::new(Ref::storage(entry.key.clone()));
         Ok(StorageResponse::StorageSet(
-            Response::new(entry).with_ref_token(ref_token),
+            StorageSetResponse::builder_v1().entry(entry).build().into(),
         ))
     }
 
     /// Show storage metadata by key.
     pub async fn show(
         context: &ProjectContext,
-        selector: &GetStorage,
+        request: &GetStorage,
     ) -> Result<StorageResponse, StorageError> {
-        let key = selector.key.resolve()?;
+        let GetStorage::V1(lookup) = request;
+        let key = lookup.key.resolve()?;
         let entry = StorageRepo::new(context)
             .get_storage(&key)
             .await?
             .ok_or(StorageError::KeyNotFound(key))?;
-        let ref_token = RefToken::new(Ref::storage(entry.key.clone()));
         Ok(StorageResponse::StorageDetails(
-            Response::new(entry).with_ref_token(ref_token),
+            StorageDetailsResponse::builder_v1()
+                .entry(entry)
+                .build()
+                .into(),
         ))
     }
 
     /// List all storage entries.
     pub async fn list(
         context: &ProjectContext,
-        ListStorage { filters }: &ListStorage,
+        request: &ListStorage,
     ) -> Result<StorageResponse, StorageError> {
-        let listed = StorageRepo::new(context).list_storage(filters).await?;
+        let ListStorage::V1(listing) = request;
+        let listed = StorageRepo::new(context)
+            .list_storage(&listing.filters)
+            .await?;
 
         if listed.total == 0 {
             Ok(StorageResponse::NoEntries)
         } else {
-            Ok(StorageResponse::Entries(listed.map(|e| {
-                let ref_token = RefToken::new(Ref::storage(e.key.clone()));
-                Response::new(e).with_ref_token(ref_token)
-            })))
+            Ok(StorageResponse::Entries(
+                StorageEntriesResponse::builder_v1()
+                    .items(listed.items)
+                    .total(listed.total)
+                    .build()
+                    .into(),
+            ))
         }
     }
 
     /// Remove storage metadata by key. The blob is NOT deleted (dedup preservation).
     pub async fn remove(
         context: &ProjectContext,
-        selector: &RemoveStorage,
+        request: &RemoveStorage,
     ) -> Result<StorageResponse, StorageError> {
+        let RemoveStorage::V1(removal) = request;
         // Confirm the key exists before emitting.
         StorageRepo::new(context)
-            .get_storage(&selector.key)
+            .get_storage(&removal.key)
             .await?
-            .ok_or_else(|| StorageError::KeyNotFound(selector.key.clone()))?;
+            .ok_or_else(|| StorageError::KeyNotFound(removal.key.clone()))?;
 
         context
-            .emit(StorageEvents::StorageRemoved(SelectStorageByKey {
-                key: selector.key.clone(),
-            }))
+            .emit(StorageEvents::StorageRemoved(
+                StorageRemoved::builder_v1()
+                    .key(removal.key.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
 
-        Ok(StorageResponse::StorageRemoved(selector.key.clone()))
+        Ok(StorageResponse::StorageRemoved(
+            StorageRemovedResponse::builder_v1()
+                .key(removal.key.clone())
+                .build()
+                .into(),
+        ))
     }
 
     /// Retrieve the raw binary content for a storage key.

--- a/crates/oneiros-engine/src/domains/storage/store.rs
+++ b/crates/oneiros-engine/src/domains/storage/store.rs
@@ -19,8 +19,14 @@ impl<'a> StorageStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Storage(storage_event)) = &event.data {
             match storage_event {
-                StorageEvents::StorageSet(entry) => self.set_storage(entry)?,
-                StorageEvents::StorageRemoved(removed) => self.remove_storage(&removed.key)?,
+                StorageEvents::StorageSet(set) => {
+                    let entry = set.current()?.entry;
+                    self.set_storage(&entry)?
+                }
+                StorageEvents::StorageRemoved(removed) => {
+                    let current = removed.current()?;
+                    self.remove_storage(&current.key)?
+                }
             }
         }
         Ok(())

--- a/crates/oneiros-engine/src/domains/storage/view.rs
+++ b/crates/oneiros-engine/src/domains/storage/view.rs
@@ -13,56 +13,66 @@ impl StorageView {
 
     pub fn render(self) -> Rendered<StorageResponse> {
         match self.response {
-            StorageResponse::StorageSet(wrapped) => {
-                let prompt = Confirmation::new("Storage", wrapped.data.key.to_string(), "stored")
-                    .to_string();
-                let hints = match wrapped.meta().ref_token() {
-                    Some(ref_token) => {
-                        HintSet::mutation(MutationHints::builder().ref_token(ref_token).build())
-                    }
-                    None => HintSet::None,
-                };
-                Rendered::new(StorageResponse::StorageSet(wrapped), prompt, String::new())
-                    .with_hints(hints)
+            StorageResponse::StorageSet(StorageSetResponse::V1(set)) => {
+                let prompt =
+                    Confirmation::new("Storage", set.entry.key.to_string(), "stored").to_string();
+                let ref_token = RefToken::new(Ref::storage(set.entry.key.clone()));
+                let hints =
+                    HintSet::mutation(MutationHints::builder().ref_token(ref_token).build());
+                Rendered::new(
+                    StorageResponse::StorageSet(StorageSetResponse::V1(set)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
-            StorageResponse::StorageDetails(wrapped) => {
-                let prompt = Detail::new(wrapped.data.key.to_string())
-                    .field("description:", wrapped.data.description.to_string())
-                    .field("hash:", wrapped.data.hash.to_string())
+            StorageResponse::StorageDetails(StorageDetailsResponse::V1(details)) => {
+                let prompt = Detail::new(details.entry.key.to_string())
+                    .field("description:", details.entry.description.to_string())
+                    .field("hash:", details.entry.hash.to_string())
                     .to_string();
                 Rendered::new(
-                    StorageResponse::StorageDetails(wrapped),
+                    StorageResponse::StorageDetails(StorageDetailsResponse::V1(details)),
                     prompt,
                     String::new(),
                 )
             }
-            StorageResponse::Entries(listed) => {
+            StorageResponse::Entries(StorageEntriesResponse::V1(listed)) => {
                 let mut table = Table::new(vec![
                     Column::key("key", "Key"),
                     Column::key("description", "Description").max(40),
                     Column::key("hash", "Hash"),
                 ]);
-                for wrapped in &listed.items {
+                for entry in &listed.items {
                     table.push_row(vec![
-                        wrapped.data.key.to_string(),
-                        wrapped.data.description.to_string(),
-                        wrapped.data.hash.to_string(),
+                        entry.key.to_string(),
+                        entry.description.to_string(),
+                        entry.hash.to_string(),
                     ]);
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
-                Rendered::new(StorageResponse::Entries(listed), prompt, String::new())
+                Rendered::new(
+                    StorageResponse::Entries(StorageEntriesResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
             StorageResponse::NoEntries => Rendered::new(
                 StorageResponse::NoEntries,
                 format!("{}", "No storage entries.".muted()),
                 String::new(),
             ),
-            StorageResponse::StorageRemoved(key) => {
-                let prompt = Confirmation::new("Storage", key.to_string(), "removed").to_string();
-                Rendered::new(StorageResponse::StorageRemoved(key), prompt, String::new())
+            StorageResponse::StorageRemoved(StorageRemovedResponse::V1(removed)) => {
+                let prompt =
+                    Confirmation::new("Storage", removed.key.to_string(), "removed").to_string();
+                Rendered::new(
+                    StorageResponse::StorageRemoved(StorageRemovedResponse::V1(removed)),
+                    prompt,
+                    String::new(),
+                )
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/system/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/system/features/cli.rs
@@ -13,7 +13,9 @@ impl SystemCommands {
         context: SystemContext,
     ) -> Result<Rendered<Responses>, SystemError> {
         let response = match self {
-            SystemCommands::Init(init) => SystemService::init(&context, init).await?,
+            SystemCommands::Init(initialization) => {
+                SystemService::init(&context, initialization).await?
+            }
         };
 
         Ok(SystemView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/system/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/system/protocol/errors.rs
@@ -20,6 +20,9 @@ pub enum SystemError {
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Upcast(#[from] UpcastError),
 }
 
 impl IntoResponse for SystemError {
@@ -28,9 +31,10 @@ impl IntoResponse for SystemError {
             SystemError::Tenant(_) | SystemError::Actor(_) => {
                 (StatusCode::UNPROCESSABLE_ENTITY, self.to_string())
             }
-            SystemError::Database(_) | SystemError::Event(_) | SystemError::Io(_) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
-            }
+            SystemError::Database(_)
+            | SystemError::Event(_)
+            | SystemError::Io(_)
+            | SystemError::Upcast(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
         (status, Json(ErrorResponse::new(message))).into_response()
     }

--- a/crates/oneiros-engine/src/domains/system/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/system/protocol/requests.rs
@@ -1,17 +1,23 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct InitSystem {
-    #[arg(long, short)]
-    #[builder(into)]
-    pub name: Option<String>,
-    #[arg(long, short)]
-    #[builder(default)]
-    pub yes: bool,
+use crate::*;
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum InitSystem {
+        #[derive(clap::Args)]
+        V1 => {
+            #[arg(long, short)]
+            #[builder(into)]
+            pub name: Option<String>,
+            #[arg(long, short)]
+            #[serde(default)]
+            #[builder(default)]
+            pub yes: bool,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/system/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/system/protocol/responses.rs
@@ -1,12 +1,22 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = SystemResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum SystemResponse {
-    SystemInitialized(TenantName),
+    SystemInitialized(SystemInitializedResponse),
     HostAlreadyInitialized,
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SystemInitializedResponse {
+        V1 => {
+            #[builder(into)] pub tenant: TenantName,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/system/service.rs
+++ b/crates/oneiros-engine/src/domains/system/service.rs
@@ -7,6 +7,7 @@ impl SystemService {
         context: &SystemContext,
         request: &InitSystem,
     ) -> Result<SystemResponse, SystemError> {
+        let details = request.current()?;
         // system init is the bootstrapper — ensure data dir, schema, and
         // host keypair all exist. The keypair establishes host identity
         // before the server ever starts.
@@ -28,7 +29,7 @@ impl SystemService {
             return Ok(SystemResponse::HostAlreadyInitialized);
         }
 
-        let name = request
+        let name = details
             .name
             .clone()
             .unwrap_or_else(|| "oneiros user".to_string());
@@ -37,7 +38,10 @@ impl SystemService {
 
         TenantService::create(
             context,
-            &CreateTenant::builder().name(tenant_name.clone()).build(),
+            &CreateTenant::builder_v1()
+                .name(tenant_name.clone())
+                .build()
+                .into(),
         )
         .await?;
 
@@ -46,14 +50,20 @@ impl SystemService {
         if let Some(tenant) = tenants.items.first() {
             ActorService::create(
                 context,
-                &CreateActor::builder()
+                &CreateActor::builder_v1()
                     .tenant_id(tenant.id)
                     .name(ActorName::new(&name))
-                    .build(),
+                    .build()
+                    .into(),
             )
             .await?;
         }
 
-        Ok(SystemResponse::SystemInitialized(tenant_name))
+        Ok(SystemResponse::SystemInitialized(
+            SystemInitializedResponse::builder_v1()
+                .tenant(tenant_name)
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/system/view.rs
+++ b/crates/oneiros-engine/src/domains/system/view.rs
@@ -16,11 +16,16 @@ impl SystemView {
 
     pub fn render(self) -> Rendered<SystemResponse> {
         match self.response {
-            SystemResponse::SystemInitialized(name) => {
-                let prompt =
-                    Confirmation::new("System", name.to_string(), "initialized").to_string();
+            SystemResponse::SystemInitialized(SystemInitializedResponse::V1(details)) => {
+                let prompt = Confirmation::new("System", details.tenant.to_string(), "initialized")
+                    .to_string();
                 Rendered::new(
-                    SystemResponse::SystemInitialized(name),
+                    SystemResponse::SystemInitialized(
+                        SystemInitializedResponse::builder_v1()
+                            .tenant(details.tenant)
+                            .build()
+                            .into(),
+                    ),
                     prompt,
                     String::new(),
                 )

--- a/crates/oneiros-engine/src/domains/tenant/client.rs
+++ b/crates/oneiros-engine/src/domains/tenant/client.rs
@@ -18,15 +18,17 @@ impl<'a> TenantClient<'a> {
     }
 
     /// Retrieve a single tenant by key (id or ref).
-    pub async fn get(&self, request: &GetTenant) -> Result<TenantResponse, ClientError> {
-        self.client.get(&format!("/tenants/{}", request.key)).await
+    pub async fn get(&self, lookup: &GetTenant) -> Result<TenantResponse, ClientError> {
+        let GetTenant::V1(lookup) = lookup;
+        self.client.get(&format!("/tenants/{}", lookup.key)).await
     }
 
     /// List all tenants.
-    pub async fn list(&self, request: &ListTenants) -> Result<TenantResponse, ClientError> {
+    pub async fn list(&self, listing: &ListTenants) -> Result<TenantResponse, ClientError> {
+        let ListTenants::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset,
+            listing.filters.limit, listing.filters.offset,
         );
         self.client.get(&format!("/tenants?{query}")).await
     }

--- a/crates/oneiros-engine/src/domains/tenant/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/tenant/features/cli.rs
@@ -2,6 +2,9 @@ use clap::Subcommand;
 
 use crate::*;
 
+/// CLI subcommands for the tenant domain. Each variant carries a versioned
+/// protocol request directly — clap derives parsing through the wrapper's
+/// `Args` impl, which delegates to the latest version's struct.
 #[derive(Debug, Subcommand)]
 pub enum TenantCommands {
     Create(CreateTenant),
@@ -18,9 +21,9 @@ impl TenantCommands {
         let tenant_client = TenantClient::new(&client);
 
         let response = match self {
-            TenantCommands::Create(create) => tenant_client.create(create).await?,
-            TenantCommands::Get(get) => tenant_client.get(get).await?,
-            TenantCommands::List(list) => tenant_client.list(list).await?,
+            Self::Create(creation) => tenant_client.create(creation).await?,
+            Self::Get(lookup) => tenant_client.get(lookup).await?,
+            Self::List(listing) => tenant_client.list(listing).await?,
         };
 
         Ok(TenantView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/tenant/features/http.rs
+++ b/crates/oneiros-engine/src/domains/tenant/features/http.rs
@@ -52,6 +52,6 @@ async fn show(
     Path(key): Path<ResourceKey<TenantId>>,
 ) -> Result<Json<TenantResponse>, TenantError> {
     Ok(Json(
-        TenantService::get(&context, &GetTenant::builder().key(key).build()).await?,
+        TenantService::get(&context, &GetTenant::builder_v1().key(key).build().into()).await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/tenant/features/state.rs
+++ b/crates/oneiros-engine/src/domains/tenant/features/state.rs
@@ -4,8 +4,10 @@ pub struct TenantState;
 
 impl TenantState {
     pub fn reduce(mut canon: SystemCanon, event: &Events) -> SystemCanon {
-        if let Events::Tenant(TenantEvents::TenantCreated(tenant)) = event {
-            canon.tenants.set(tenant);
+        if let Events::Tenant(tenant_event) = event
+            && let Some(tenant) = tenant_event.maybe_tenant()
+        {
+            canon.tenants.set(&tenant);
         }
 
         canon
@@ -23,8 +25,12 @@ mod tests {
     #[test]
     fn creates_tenant() {
         let canon = SystemCanon::default();
-        let tenant = Tenant::builder().name("test-tenant").build();
-        let event = Events::Tenant(TenantEvents::TenantCreated(tenant.clone()));
+        let tenant = Tenant::builder()
+            .name(TenantName::new("test-tenant"))
+            .build();
+        let event = Events::Tenant(TenantEvents::TenantCreated(
+            TenantCreated::builder_v1().tenant(tenant).build().into(),
+        ));
 
         let next = TenantState::reduce(canon, &event);
 

--- a/crates/oneiros-engine/src/domains/tenant/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/tenant/protocol/events.rs
@@ -7,7 +7,23 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = TenantEventsType, display = "kebab-case")]
 pub enum TenantEvents {
-    TenantCreated(Tenant),
+    TenantCreated(TenantCreated),
+}
+
+impl TenantEvents {
+    pub fn maybe_tenant(&self) -> Option<Tenant> {
+        match self {
+            TenantEvents::TenantCreated(event) => event.clone().current().ok().map(|v| v.tenant),
+        }
+    }
+}
+
+versioned! {
+    pub enum TenantCreated {
+        V1 => {
+            #[serde(flatten)] pub tenant: Tenant,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -20,5 +36,24 @@ mod tests {
             &TenantEventsType::TenantCreated.to_string(),
             "tenant-created"
         );
+    }
+
+    #[test]
+    fn tenant_created_wire_format_is_flat() {
+        let tenant = Tenant::builder().name(TenantName::new("acme")).build();
+
+        let event = TenantEvents::TenantCreated(TenantCreated::V1(TenantCreatedV1 {
+            tenant: tenant.clone(),
+        }));
+        let json = serde_json::to_value(&event).unwrap();
+
+        assert_eq!(json["type"], "tenant-created");
+        assert!(
+            json["data"].get("tenant").is_none(),
+            "flatten must elide the tenant envelope on the wire"
+        );
+        assert_eq!(json["data"]["id"], tenant.id.to_string());
+        assert_eq!(json["data"]["name"], "acme");
+        assert!(json["data"].get("created_at").is_some());
     }
 }

--- a/crates/oneiros-engine/src/domains/tenant/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/tenant/protocol/requests.rs
@@ -1,29 +1,40 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct CreateTenant {
-    #[builder(into)]
-    pub name: TenantName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum CreateTenant {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: TenantName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetTenant {
-    #[builder(into)]
-    pub key: ResourceKey<TenantId>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetTenant {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<TenantId>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListTenants {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListTenants {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/tenant/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/tenant/protocol/responses.rs
@@ -1,13 +1,38 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = TenantResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum TenantResponse {
-    Created(Response<Tenant>),
-    Found(Response<Tenant>),
-    Listed(Listed<Response<Tenant>>),
+    Created(TenantCreatedResponse),
+    Found(TenantFoundResponse),
+    Listed(TenantsResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum TenantCreatedResponse {
+        V1 => { #[serde(flatten)] pub tenant: Tenant }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum TenantFoundResponse {
+        V1 => { #[serde(flatten)] pub tenant: Tenant }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum TenantsResponse {
+        V1 => {
+            pub items: Vec<Tenant>,
+            pub total: usize,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/tenant/service.rs
+++ b/crates/oneiros-engine/src/domains/tenant/service.rs
@@ -5,42 +5,59 @@ pub struct TenantService;
 impl TenantService {
     pub async fn create(
         context: &SystemContext,
-        CreateTenant { name }: &CreateTenant,
+        request: &CreateTenant,
     ) -> Result<TenantResponse, TenantError> {
-        let tenant = Tenant::builder().name(name.clone()).build();
+        let CreateTenant::V1(create) = request;
+
+        let tenant = Tenant::builder().name(create.name.clone()).build();
 
         context
-            .emit(TenantEvents::TenantCreated(tenant.clone()))
+            .emit(TenantEvents::TenantCreated(
+                TenantCreated::builder_v1()
+                    .tenant(tenant.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        let ref_token = RefToken::new(Ref::tenant(tenant.id));
+
         Ok(TenantResponse::Created(
-            Response::new(tenant).with_ref_token(ref_token),
+            TenantCreatedResponse::builder_v1()
+                .tenant(tenant)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn get(
         context: &SystemContext,
-        selector: &GetTenant,
+        request: &GetTenant,
     ) -> Result<TenantResponse, TenantError> {
-        let id = selector.key.resolve()?;
+        let GetTenant::V1(lookup) = request;
+        let id = lookup.key.resolve()?;
         let tenant = TenantRepo::new(context)
             .get(&id)
             .await?
             .ok_or(TenantError::NotFound(id))?;
-        let ref_token = RefToken::new(Ref::tenant(tenant.id));
         Ok(TenantResponse::Found(
-            Response::new(tenant).with_ref_token(ref_token),
+            TenantFoundResponse::builder_v1()
+                .tenant(tenant)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn list(
         context: &SystemContext,
-        ListTenants { filters }: &ListTenants,
+        request: &ListTenants,
     ) -> Result<TenantResponse, TenantError> {
-        let listed = TenantRepo::new(context).list(filters).await?;
-        Ok(TenantResponse::Listed(listed.map(|t| {
-            let ref_token = RefToken::new(Ref::tenant(t.id));
-            Response::new(t).with_ref_token(ref_token)
-        })))
+        let ListTenants::V1(listing) = request;
+        let listed = TenantRepo::new(context).list(&listing.filters).await?;
+        Ok(TenantResponse::Listed(
+            TenantsResponse::builder_v1()
+                .items(listed.items)
+                .total(listed.total)
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/tenant/store.rs
+++ b/crates/oneiros-engine/src/domains/tenant/store.rs
@@ -12,15 +12,9 @@ impl<'a> TenantStore<'a> {
     }
 
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
-        if let Event::Known(Events::Tenant(TenantEvents::TenantCreated(tenant))) = &event.data {
-            self.conn.execute(
-                "insert or replace into tenants (id, name, created_at) values (?1, ?2, ?3)",
-                params![
-                    tenant.id.to_string(),
-                    tenant.name.to_string(),
-                    tenant.created_at.as_string()
-                ],
-            )?;
+        if let Event::Known(Events::Tenant(TenantEvents::TenantCreated(creation))) = &event.data {
+            let tenant = creation.current()?.tenant;
+            self.write_tenant(&tenant)?;
         }
         Ok(())
     }
@@ -37,6 +31,18 @@ impl<'a> TenantStore<'a> {
                 name text not null unique,
                 created_at text not null default ''
             )",
+        )?;
+        Ok(())
+    }
+
+    fn write_tenant(&self, tenant: &Tenant) -> Result<(), EventError> {
+        self.conn.execute(
+            "insert or replace into tenants (id, name, created_at) values (?1, ?2, ?3)",
+            params![
+                tenant.id.to_string(),
+                tenant.name.to_string(),
+                tenant.created_at.as_string()
+            ],
         )?;
         Ok(())
     }

--- a/crates/oneiros-engine/src/domains/tenant/view.rs
+++ b/crates/oneiros-engine/src/domains/tenant/view.rs
@@ -11,29 +11,41 @@ impl TenantView {
 
     pub fn render(self) -> Rendered<TenantResponse> {
         match self.response {
-            TenantResponse::Created(wrapped) => {
-                let prompt = Confirmation::new("Tenant", wrapped.data.name.to_string(), "created")
-                    .to_string();
-                Rendered::new(TenantResponse::Created(wrapped), prompt, String::new())
+            TenantResponse::Created(TenantCreatedResponse::V1(created)) => {
+                let prompt =
+                    Confirmation::new("Tenant", created.tenant.name.to_string(), "created")
+                        .to_string();
+                Rendered::new(
+                    TenantResponse::Created(TenantCreatedResponse::V1(created)),
+                    prompt,
+                    String::new(),
+                )
             }
-            TenantResponse::Found(wrapped) => {
-                let prompt = Detail::new(wrapped.data.name.to_string())
-                    .field("id:", wrapped.data.id.to_string())
+            TenantResponse::Found(TenantFoundResponse::V1(found)) => {
+                let prompt = Detail::new(found.tenant.name.to_string())
+                    .field("id:", found.tenant.id.to_string())
                     .to_string();
-                Rendered::new(TenantResponse::Found(wrapped), prompt, String::new())
+                Rendered::new(
+                    TenantResponse::Found(TenantFoundResponse::V1(found)),
+                    prompt,
+                    String::new(),
+                )
             }
-            TenantResponse::Listed(listed) => {
+            TenantResponse::Listed(TenantsResponse::V1(listed)) => {
                 let mut table =
                     Table::new(vec![Column::key("name", "Name"), Column::key("id", "ID")]);
-                for wrapped in &listed.items {
-                    let tenant = &wrapped.data;
+                for tenant in &listed.items {
                     table.push_row(vec![tenant.name.to_string(), tenant.id.to_string()]);
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
-                Rendered::new(TenantResponse::Listed(listed), prompt, String::new())
+                Rendered::new(
+                    TenantResponse::Listed(TenantsResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/texture/client.rs
+++ b/crates/oneiros-engine/src/domains/texture/client.rs
@@ -9,25 +9,31 @@ impl<'a> TextureClient<'a> {
         Self { client }
     }
 
-    pub async fn set(&self, set: &SetTexture) -> Result<TextureResponse, ClientError> {
+    pub async fn set(&self, setting: &SetTexture) -> Result<TextureResponse, ClientError> {
+        let SetTexture::V1(body) = setting;
         self.client
-            .put(&format!("/textures/{}", set.name), set)
+            .put(&format!("/textures/{}", body.name), setting)
             .await
     }
 
-    pub async fn get(&self, request: &GetTexture) -> Result<TextureResponse, ClientError> {
-        self.client.get(&format!("/textures/{}", request.key)).await
+    pub async fn get(&self, lookup: &GetTexture) -> Result<TextureResponse, ClientError> {
+        let GetTexture::V1(lookup) = lookup;
+        self.client.get(&format!("/textures/{}", lookup.key)).await
     }
 
-    pub async fn list(&self, request: &ListTextures) -> Result<TextureResponse, ClientError> {
+    pub async fn list(&self, listing: &ListTextures) -> Result<TextureResponse, ClientError> {
+        let ListTextures::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset,
+            listing.filters.limit, listing.filters.offset,
         );
         self.client.get(&format!("/textures?{query}")).await
     }
 
-    pub async fn remove(&self, name: &TextureName) -> Result<TextureResponse, ClientError> {
-        self.client.delete(&format!("/textures/{name}")).await
+    pub async fn remove(&self, removal: &RemoveTexture) -> Result<TextureResponse, ClientError> {
+        let RemoveTexture::V1(removal) = removal;
+        self.client
+            .delete(&format!("/textures/{}", removal.name))
+            .await
     }
 }

--- a/crates/oneiros-engine/src/domains/texture/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/texture/features/cli.rs
@@ -2,6 +2,11 @@ use clap::Subcommand;
 
 use crate::*;
 
+/// CLI subcommands for the texture domain. Each variant carries a versioned
+/// protocol request directly — clap derives parsing through the wrapper's
+/// `Args` impl, which delegates to the latest version's struct. The
+/// dispatcher passes the wrapper through to the client without rebuilding,
+/// since the operation type *is* the domain command.
 #[derive(Debug, Subcommand)]
 pub enum TextureCommands {
     Set(SetTexture),
@@ -19,10 +24,10 @@ impl TextureCommands {
         let texture_client = TextureClient::new(&client);
 
         let response = match self {
-            TextureCommands::Set(set) => texture_client.set(set).await?,
-            TextureCommands::Show(get) => texture_client.get(get).await?,
-            TextureCommands::List(list) => texture_client.list(list).await?,
-            TextureCommands::Remove(removal) => texture_client.remove(&removal.name).await?,
+            Self::Set(setting) => texture_client.set(setting).await?,
+            Self::Show(lookup) => texture_client.get(lookup).await?,
+            Self::List(listing) => texture_client.list(listing).await?,
+            Self::Remove(removal) => texture_client.remove(removal).await?,
         };
 
         Ok(TextureView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/texture/features/http.rs
+++ b/crates/oneiros-engine/src/domains/texture/features/http.rs
@@ -41,12 +41,14 @@ impl TextureRouter {
 async fn set(
     context: ProjectContext,
     Path(name): Path<TextureName>,
-    Json(mut body): Json<SetTexture>,
+    Json(body): Json<SetTexture>,
 ) -> Result<(StatusCode, Json<TextureResponse>), TextureError> {
-    body.name = name;
+    let SetTexture::V1(mut setting) = body;
+    setting.name = name;
+    let request = SetTexture::V1(setting);
     Ok((
         StatusCode::OK,
-        Json(TextureService::set(&context, &body).await?),
+        Json(TextureService::set(&context, &request).await?),
     ))
 }
 
@@ -62,7 +64,7 @@ async fn show(
     Path(key): Path<ResourceKey<TextureName>>,
 ) -> Result<Json<TextureResponse>, TextureError> {
     Ok(Json(
-        TextureService::get(&context, &GetTexture::builder().key(key).build()).await?,
+        TextureService::get(&context, &GetTexture::builder_v1().key(key).build().into()).await?,
     ))
 }
 
@@ -71,6 +73,10 @@ async fn remove(
     Path(name): Path<TextureName>,
 ) -> Result<Json<TextureResponse>, TextureError> {
     Ok(Json(
-        TextureService::remove(&context, &RemoveTexture::builder().name(name).build()).await?,
+        TextureService::remove(
+            &context,
+            &RemoveTexture::builder_v1().name(name).build().into(),
+        )
+        .await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/texture/features/state.rs
+++ b/crates/oneiros-engine/src/domains/texture/features/state.rs
@@ -6,11 +6,15 @@ impl TextureState {
     pub fn reduce(mut canon: BrainCanon, event: &Events) -> BrainCanon {
         if let Events::Texture(texture_event) = event {
             match texture_event {
-                TextureEvents::TextureSet(texture) => {
-                    canon.textures.set(texture);
+                TextureEvents::TextureSet(setting) => {
+                    if let Ok(current) = setting.current() {
+                        canon.textures.set(&current.texture);
+                    }
                 }
-                TextureEvents::TextureRemoved(removed) => {
-                    canon.textures.remove(&removed.name);
+                TextureEvents::TextureRemoved(removal) => {
+                    if let Ok(current) = removal.current() {
+                        canon.textures.remove(&current.name);
+                    }
                 }
             };
         }

--- a/crates/oneiros-engine/src/domains/texture/model.rs
+++ b/crates/oneiros-engine/src/domains/texture/model.rs
@@ -1,20 +1,17 @@
 use bon::Builder;
-use clap::Args;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::*;
 
-#[derive(Args, Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct Texture {
     #[builder(into)]
     pub name: TextureName,
     #[builder(into)]
-    #[arg(long, default_value = "")]
     pub description: Description,
     #[builder(into)]
-    #[arg(long, default_value = "")]
     pub prompt: Prompt,
 }
 

--- a/crates/oneiros-engine/src/domains/texture/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/texture/protocol/events.rs
@@ -7,13 +7,37 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = TextureEventsType, display = "kebab-case")]
 pub enum TextureEvents {
-    TextureSet(Texture),
+    TextureSet(TextureSet),
     TextureRemoved(TextureRemoved),
+}
+
+versioned! {
+    pub enum TextureSet {
+        V1 => {
+            #[serde(flatten)] pub texture: Texture,
+        }
+    }
+}
+
+versioned! {
+    pub enum TextureRemoved {
+        V1 => {
+            #[builder(into)] pub name: TextureName,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_texture() -> Texture {
+        Texture::builder()
+            .name("observation")
+            .description("Noticing patterns")
+            .prompt("Use when you see something interesting.")
+            .build()
+    }
 
     #[test]
     fn event_types_are_kebab_cased() {
@@ -25,9 +49,42 @@ mod tests {
             assert_eq!(&event_type.to_string(), expectation);
         }
     }
-}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TextureRemoved {
-    pub name: TextureName,
+    #[test]
+    fn texture_set_wire_format_is_flat() {
+        let event = TextureEvents::TextureSet(TextureSet::V1(TextureSetV1 {
+            texture: sample_texture(),
+        }));
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "texture-set");
+        assert!(
+            json["data"].get("texture").is_none(),
+            "flatten must elide the texture envelope on the wire"
+        );
+        assert_eq!(json["data"]["name"], "observation");
+        assert_eq!(json["data"]["description"], "Noticing patterns");
+        assert!(
+            json["data"].get("V1").is_none(),
+            "V1 layer must not appear on the wire"
+        );
+    }
+
+    #[test]
+    fn texture_removed_round_trips_through_v1_layer() {
+        let original = TextureEvents::TextureRemoved(TextureRemoved::V1(TextureRemovedV1 {
+            name: TextureName::new("observation"),
+        }));
+
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: TextureEvents = serde_json::from_str(&json).unwrap();
+
+        match decoded {
+            TextureEvents::TextureRemoved(removed) => {
+                let v1 = removed.current().unwrap();
+                assert_eq!(v1.name.to_string(), "observation");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/texture/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/texture/protocol/requests.rs
@@ -1,41 +1,56 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct SetTexture {
-    #[builder(into)]
-    pub name: TextureName,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub description: Description,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub prompt: Prompt,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SetTexture {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: TextureName,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub description: Description,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub prompt: Prompt,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetTexture {
-    #[builder(into)]
-    pub key: ResourceKey<TextureName>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetTexture {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<TextureName>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct RemoveTexture {
-    #[builder(into)]
-    pub name: TextureName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum RemoveTexture {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: TextureName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListTextures {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListTextures {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/texture/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/texture/protocol/responses.rs
@@ -1,15 +1,49 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = TextureResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum TextureResponse {
-    TextureSet(TextureName),
-    TextureDetails(Response<Texture>),
-    Textures(Listed<Response<Texture>>),
+    TextureSet(TextureSetResponse),
+    TextureDetails(TextureDetailsResponse),
+    Textures(TexturesResponse),
     NoTextures,
-    TextureRemoved(TextureName),
+    TextureRemoved(TextureRemovedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum TextureSetResponse {
+        V1 => { #[serde(flatten)] pub texture: Texture }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum TextureDetailsResponse {
+        V1 => { #[serde(flatten)] pub texture: Texture }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum TexturesResponse {
+        V1 => {
+            pub items: Vec<Texture>,
+            pub total: usize,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum TextureRemovedResponse {
+        V1 => {
+            #[builder(into)] pub name: TextureName,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/texture/service.rs
+++ b/crates/oneiros-engine/src/domains/texture/service.rs
@@ -5,60 +5,87 @@ pub struct TextureService;
 impl TextureService {
     pub async fn set(
         context: &ProjectContext,
-        SetTexture {
-            name,
-            description,
-            prompt,
-        }: &SetTexture,
+        request: &SetTexture,
     ) -> Result<TextureResponse, TextureError> {
+        let SetTexture::V1(set) = request;
         let texture = Texture::builder()
-            .name(name.clone())
-            .description(description.clone())
-            .prompt(prompt.clone())
+            .name(set.name.clone())
+            .description(set.description.clone())
+            .prompt(set.prompt.clone())
             .build();
-        context.emit(TextureEvents::TextureSet(texture)).await?;
-        Ok(TextureResponse::TextureSet(name.clone()))
+
+        context
+            .emit(TextureEvents::TextureSet(
+                TextureSet::builder_v1()
+                    .texture(texture.clone())
+                    .build()
+                    .into(),
+            ))
+            .await?;
+
+        Ok(TextureResponse::TextureSet(
+            TextureSetResponse::builder_v1()
+                .texture(texture)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn get(
         context: &ProjectContext,
-        selector: &GetTexture,
+        request: &GetTexture,
     ) -> Result<TextureResponse, TextureError> {
-        let name = selector.key.resolve()?;
+        let GetTexture::V1(lookup) = request;
+        let name = lookup.key.resolve()?;
         let texture = TextureRepo::new(context)
             .get(&name)
             .await?
             .ok_or(TextureError::NotFound(name))?;
-        let ref_token = RefToken::new(Ref::texture(texture.name.clone()));
         Ok(TextureResponse::TextureDetails(
-            Response::new(texture).with_ref_token(ref_token),
+            TextureDetailsResponse::builder_v1()
+                .texture(texture)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn list(
         context: &ProjectContext,
-        ListTextures { filters }: &ListTextures,
+        request: &ListTextures,
     ) -> Result<TextureResponse, TextureError> {
-        let listed = TextureRepo::new(context).list(filters).await?;
+        let ListTextures::V1(listing) = request;
+        let listed = TextureRepo::new(context).list(&listing.filters).await?;
         if listed.total == 0 {
             Ok(TextureResponse::NoTextures)
         } else {
-            Ok(TextureResponse::Textures(listed.map(|e| {
-                let ref_token = RefToken::new(Ref::texture(e.name.clone()));
-                Response::new(e).with_ref_token(ref_token)
-            })))
+            Ok(TextureResponse::Textures(
+                TexturesResponse::builder_v1()
+                    .items(listed.items)
+                    .total(listed.total)
+                    .build()
+                    .into(),
+            ))
         }
     }
 
     pub async fn remove(
         context: &ProjectContext,
-        selector: &RemoveTexture,
+        request: &RemoveTexture,
     ) -> Result<TextureResponse, TextureError> {
+        let RemoveTexture::V1(removal) = request;
         context
-            .emit(TextureEvents::TextureRemoved(TextureRemoved {
-                name: selector.name.clone(),
-            }))
+            .emit(TextureEvents::TextureRemoved(
+                TextureRemoved::builder_v1()
+                    .name(removal.name.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        Ok(TextureResponse::TextureRemoved(selector.name.clone()))
+        Ok(TextureResponse::TextureRemoved(
+            TextureRemovedResponse::builder_v1()
+                .name(removal.name.clone())
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/texture/store.rs
+++ b/crates/oneiros-engine/src/domains/texture/store.rs
@@ -14,8 +14,8 @@ impl<'a> TextureStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Texture(texture_event)) = &event.data {
             match texture_event {
-                TextureEvents::TextureSet(texture) => self.set(texture)?,
-                TextureEvents::TextureRemoved(removed) => self.remove(&removed.name)?,
+                TextureEvents::TextureSet(setting) => self.set(setting)?,
+                TextureEvents::TextureRemoved(removal) => self.remove(removal)?,
             }
         }
         Ok(())
@@ -64,7 +64,21 @@ impl<'a> TextureStore<'a> {
         Ok(textures)
     }
 
-    fn set(&self, texture: &Texture) -> Result<(), EventError> {
+    fn set(&self, setting: &TextureSet) -> Result<(), EventError> {
+        let texture = setting.current()?.texture;
+        self.write_texture(&texture)
+    }
+
+    fn remove(&self, removal: &TextureRemoved) -> Result<(), EventError> {
+        let name = removal.current()?.name;
+        self.conn.execute(
+            "DELETE FROM textures WHERE name = ?1",
+            params![name.to_string()],
+        )?;
+        Ok(())
+    }
+
+    fn write_texture(&self, texture: &Texture) -> Result<(), EventError> {
         self.conn.execute(
             "INSERT OR REPLACE INTO textures (name, description, prompt) VALUES (?1, ?2, ?3)",
             params![
@@ -72,14 +86,6 @@ impl<'a> TextureStore<'a> {
                 texture.description.to_string(),
                 texture.prompt.to_string()
             ],
-        )?;
-        Ok(())
-    }
-
-    fn remove(&self, name: &TextureName) -> Result<(), EventError> {
-        self.conn.execute(
-            "DELETE FROM textures WHERE name = ?1",
-            params![name.to_string()],
         )?;
         Ok(())
     }

--- a/crates/oneiros-engine/src/domains/texture/view.rs
+++ b/crates/oneiros-engine/src/domains/texture/view.rs
@@ -11,25 +11,27 @@ impl TextureView {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            TextureResponse::Textures(listed) => {
+            TextureResponse::Textures(TexturesResponse::V1(listed)) => {
                 let items: Vec<_> = listed
                     .items
                     .iter()
-                    .map(|w| (w.data.name.to_string(), w.data.description.to_string()))
+                    .map(|item| (item.name.to_string(), item.description.to_string()))
                     .collect();
                 Self::vocabulary_table("Textures", &items)
             }
-            TextureResponse::TextureDetails(wrapped) => {
+            TextureResponse::TextureDetails(TextureDetailsResponse::V1(details)) => {
                 let items = vec![(
-                    wrapped.data.name.to_string(),
-                    wrapped.data.description.to_string(),
+                    details.texture.name.to_string(),
+                    details.texture.description.to_string(),
                 )];
                 Self::vocabulary_table("Texture", &items)
             }
             TextureResponse::NoTextures => Self::vocabulary_table("Textures", &[]),
-            TextureResponse::TextureSet(name) => McpResponse::new(format!("Texture set: {name}")),
-            TextureResponse::TextureRemoved(name) => {
-                McpResponse::new(format!("Texture removed: {name}"))
+            TextureResponse::TextureSet(TextureSetResponse::V1(set)) => {
+                McpResponse::new(format!("Texture set: {}", set.texture.name))
+            }
+            TextureResponse::TextureRemoved(TextureRemovedResponse::V1(removed)) => {
+                McpResponse::new(format!("Texture removed: {}", removed.name))
             }
         }
     }
@@ -50,58 +52,69 @@ impl TextureView {
 
     pub fn render(self) -> Rendered<TextureResponse> {
         match self.response {
-            TextureResponse::TextureSet(name) => {
-                let prompt = Confirmation::new("Texture", name.to_string(), "set").to_string();
+            TextureResponse::TextureSet(TextureSetResponse::V1(set)) => {
+                let prompt =
+                    Confirmation::new("Texture", set.texture.name.to_string(), "set").to_string();
                 let hints = HintSet::vocabulary(
                     VocabularyHints::builder()
                         .kind("texture".to_string())
                         .build(),
                 );
-                Rendered::new(TextureResponse::TextureSet(name), prompt, String::new())
-                    .with_hints(hints)
+                Rendered::new(
+                    TextureResponse::TextureSet(TextureSetResponse::V1(set)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
-            TextureResponse::TextureDetails(wrapped) => {
-                let prompt = Detail::new(wrapped.data.name.to_string())
-                    .field("description:", wrapped.data.description.to_string())
-                    .field("prompt:", wrapped.data.prompt.to_string())
+            TextureResponse::TextureDetails(TextureDetailsResponse::V1(details)) => {
+                let prompt = Detail::new(details.texture.name.to_string())
+                    .field("description:", details.texture.description.to_string())
+                    .field("prompt:", details.texture.prompt.to_string())
                     .to_string();
                 Rendered::new(
-                    TextureResponse::TextureDetails(wrapped),
+                    TextureResponse::TextureDetails(TextureDetailsResponse::V1(details)),
                     prompt,
                     String::new(),
                 )
             }
-            TextureResponse::Textures(listed) => {
+            TextureResponse::Textures(TexturesResponse::V1(listed)) => {
                 let mut table = Table::new(vec![
                     Column::key("name", "Name"),
                     Column::key("description", "Description").max(60),
                 ]);
-                for wrapped in &listed.items {
-                    table.push_row(vec![
-                        wrapped.data.name.to_string(),
-                        wrapped.data.description.to_string(),
-                    ]);
+                for item in &listed.items {
+                    table.push_row(vec![item.name.to_string(), item.description.to_string()]);
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
-                Rendered::new(TextureResponse::Textures(listed), prompt, String::new())
+                Rendered::new(
+                    TextureResponse::Textures(TexturesResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
             TextureResponse::NoTextures => Rendered::new(
                 TextureResponse::NoTextures,
                 format!("{}", "No textures configured.".muted()),
                 String::new(),
             ),
-            TextureResponse::TextureRemoved(name) => {
-                let prompt = Confirmation::new("Texture", name.to_string(), "removed").to_string();
+            TextureResponse::TextureRemoved(TextureRemovedResponse::V1(removed)) => {
+                let prompt =
+                    Confirmation::new("Texture", removed.name.to_string(), "removed").to_string();
                 let hints = HintSet::vocabulary(
                     VocabularyHints::builder()
                         .kind("texture".to_string())
                         .build(),
                 );
-                Rendered::new(TextureResponse::TextureRemoved(name), prompt, String::new())
-                    .with_hints(hints)
+                Rendered::new(
+                    TextureResponse::TextureRemoved(TextureRemovedResponse::V1(removed)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/ticket/client.rs
+++ b/crates/oneiros-engine/src/domains/ticket/client.rs
@@ -13,20 +13,22 @@ impl<'a> TicketClient<'a> {
     }
 
     /// Issue a new ticket for the given actor and brain.
-    pub async fn issue(&self, creation: &CreateTicket) -> Result<TicketResponse, ClientError> {
-        self.client.post("/tickets", creation).await
+    pub async fn issue(&self, issuance: &CreateTicket) -> Result<TicketResponse, ClientError> {
+        self.client.post("/tickets", issuance).await
     }
 
-    /// Retrieve a single ticket by ID.
-    pub async fn get(&self, id: &TicketId) -> Result<TicketResponse, ClientError> {
-        self.client.get(&format!("/tickets/{}", id)).await
+    /// Retrieve a single ticket by key.
+    pub async fn get(&self, lookup: &GetTicket) -> Result<TicketResponse, ClientError> {
+        let GetTicket::V1(lookup) = lookup;
+        self.client.get(&format!("/tickets/{}", lookup.key)).await
     }
 
     /// List all tickets.
-    pub async fn list(&self, request: &ListTickets) -> Result<TicketResponse, ClientError> {
+    pub async fn list(&self, listing: &ListTickets) -> Result<TicketResponse, ClientError> {
+        let ListTickets::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset,
+            listing.filters.limit, listing.filters.offset,
         );
         self.client.get(&format!("/tickets?{query}")).await
     }

--- a/crates/oneiros-engine/src/domains/ticket/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/ticket/features/cli.rs
@@ -2,6 +2,9 @@ use clap::Subcommand;
 
 use crate::*;
 
+/// CLI subcommands for the ticket domain. Each variant carries a versioned
+/// protocol request directly — clap derives parsing through the wrapper's
+/// `Args` impl, which delegates to the latest version's struct.
 #[derive(Debug, Subcommand)]
 pub enum TicketCommands {
     Issue(CreateTicket),
@@ -18,9 +21,9 @@ impl TicketCommands {
         let ticket_client = TicketClient::new(&client);
 
         let response = match self {
-            TicketCommands::Issue(create) => ticket_client.issue(create).await?,
-            TicketCommands::Validate(validate) => ticket_client.validate(validate).await?,
-            TicketCommands::List(list) => ticket_client.list(list).await?,
+            Self::Issue(issuance) => ticket_client.issue(issuance).await?,
+            Self::Validate(validation) => ticket_client.validate(validation).await?,
+            Self::List(listing) => ticket_client.list(listing).await?,
         };
 
         Ok(TicketView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/ticket/features/http.rs
+++ b/crates/oneiros-engine/src/domains/ticket/features/http.rs
@@ -56,7 +56,7 @@ async fn show(
     Path(key): Path<ResourceKey<TicketId>>,
 ) -> Result<Json<TicketResponse>, TicketError> {
     Ok(Json(
-        TicketService::get(&context, &GetTicket::builder().key(key).build()).await?,
+        TicketService::get(&context, &GetTicket::builder_v1().key(key).build().into()).await?,
     ))
 }
 

--- a/crates/oneiros-engine/src/domains/ticket/features/state.rs
+++ b/crates/oneiros-engine/src/domains/ticket/features/state.rs
@@ -4,8 +4,10 @@ pub struct TicketState;
 
 impl TicketState {
     pub fn reduce(mut canon: SystemCanon, event: &Events) -> SystemCanon {
-        if let Events::Ticket(TicketEvents::TicketIssued(ticket)) = event {
-            canon.tickets.set(ticket);
+        if let Events::Ticket(ticket_event) = event
+            && let Some(ticket) = ticket_event.maybe_ticket()
+        {
+            canon.tickets.set(&ticket);
         }
 
         canon

--- a/crates/oneiros-engine/src/domains/ticket/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/ticket/protocol/events.rs
@@ -7,31 +7,61 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = TicketEventsType, display = "kebab-case")]
 pub enum TicketEvents {
-    TicketIssued(Ticket),
+    TicketIssued(TicketIssued),
     TicketUsed(TicketUsed),
     TicketRejected(TicketRejected),
 }
 
-/// Audit record: a ticket was successfully presented and validated.
-/// Emitted on every successful auth that consumes a ticket's token.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TicketUsed {
-    pub ticket_id: TicketId,
-    pub used_at: Timestamp,
+impl TicketEvents {
+    pub fn maybe_ticket(&self) -> Option<Ticket> {
+        match self {
+            TicketEvents::TicketIssued(event) => event.clone().current().ok().map(|v| v.ticket),
+            TicketEvents::TicketUsed(_) | TicketEvents::TicketRejected(_) => None,
+        }
+    }
 }
 
-/// Audit record: a ticket was presented but rejected. The reason is
-/// human-readable and intended for logs and error surfaces.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TicketRejected {
-    pub ticket_id: Option<TicketId>,
-    pub reason: String,
-    pub rejected_at: Timestamp,
+versioned! {
+    pub enum TicketIssued {
+        V1 => {
+            #[serde(flatten)] pub ticket: Ticket,
+        }
+    }
+}
+
+versioned! {
+    pub enum TicketUsed {
+        V1 => {
+            pub ticket_id: TicketId,
+            pub used_at: Timestamp,
+        }
+    }
+}
+
+versioned! {
+    pub enum TicketRejected {
+        V1 => {
+            pub ticket_id: Option<TicketId>,
+            pub reason: String,
+            pub rejected_at: Timestamp,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_ticket() -> Ticket {
+        let actor_id = ActorId::new();
+        Ticket::builder()
+            .actor_id(actor_id)
+            .brain_name(BrainName::new("test-brain"))
+            .brain_id(BrainId::new())
+            .link(Link::new(Ref::brain(BrainId::new()), Token::from("token")))
+            .granted_by(actor_id)
+            .build()
+    }
 
     #[test]
     fn event_types_are_kebab_cased() {
@@ -41,5 +71,23 @@ mod tests {
             &TicketEventsType::TicketRejected.to_string(),
             "ticket-rejected"
         );
+    }
+
+    #[test]
+    fn ticket_issued_wire_format_is_flat() {
+        let ticket = sample_ticket();
+        let event = TicketEvents::TicketIssued(TicketIssued::V1(TicketIssuedV1 {
+            ticket: ticket.clone(),
+        }));
+        let json = serde_json::to_value(&event).unwrap();
+
+        assert_eq!(json["type"], "ticket-issued");
+        assert!(
+            json["data"].get("ticket").is_none(),
+            "flatten must elide the ticket envelope on the wire"
+        );
+        assert_eq!(json["data"]["id"], ticket.id.to_string());
+        assert_eq!(json["data"]["brain_name"], "test-brain");
+        assert!(json["data"].get("created_at").is_some());
     }
 }

--- a/crates/oneiros-engine/src/domains/ticket/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/ticket/protocol/requests.rs
@@ -1,39 +1,53 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct CreateTicket {
-    #[arg(long)]
-    #[builder(into)]
-    pub actor_id: ActorId,
-    #[arg(long)]
-    #[builder(into)]
-    pub brain_name: BrainName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum CreateTicket {
+        #[derive(clap::Args)]
+        V1 => {
+            #[arg(long)]
+            #[builder(into)] pub actor_id: ActorId,
+            #[arg(long)]
+            #[builder(into)] pub brain_name: BrainName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetTicket {
-    #[builder(into)]
-    pub key: ResourceKey<TicketId>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetTicket {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<TicketId>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ValidateTicket {
-    #[builder(into)]
-    pub token: Token,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ValidateTicket {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub token: Token,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListTickets {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListTickets {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/ticket/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/ticket/protocol/responses.rs
@@ -1,14 +1,46 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = TicketResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum TicketResponse {
-    Created(Ticket),
-    Found(Ticket),
-    Listed(Listed<Ticket>),
-    Validated(Ticket),
+    Created(TicketCreatedResponse),
+    Found(TicketFoundResponse),
+    Listed(TicketsResponse),
+    Validated(TicketValidatedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum TicketCreatedResponse {
+        V1 => { #[serde(flatten)] pub ticket: Ticket }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum TicketFoundResponse {
+        V1 => { #[serde(flatten)] pub ticket: Ticket }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum TicketsResponse {
+        V1 => {
+            pub items: Vec<Ticket>,
+            pub total: usize,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum TicketValidatedResponse {
+        V1 => { #[serde(flatten)] pub ticket: Ticket }
+    }
 }

--- a/crates/oneiros-engine/src/domains/ticket/service.rs
+++ b/crates/oneiros-engine/src/domains/ticket/service.rs
@@ -5,19 +5,23 @@ pub struct TicketService;
 impl TicketService {
     pub async fn create(
         context: &SystemContext,
-        CreateTicket {
-            actor_id,
-            brain_name,
-        }: &CreateTicket,
+        request: &CreateTicket,
     ) -> Result<TicketResponse, TicketError> {
+        let CreateTicket::V1(create) = request;
         let brain = BrainRepo::new(context)
-            .get(brain_name)
+            .get(&create.brain_name)
             .await?
-            .ok_or_else(|| TicketError::BrainNotFound(brain_name.clone()))?;
+            .ok_or_else(|| TicketError::BrainNotFound(create.brain_name.clone()))?;
 
         let target = Ref::brain(brain.id);
-        let ticket = Self::issue(context, brain_name, &brain, *actor_id, target).await?;
-        Ok(TicketResponse::Created(ticket))
+        let ticket =
+            Self::issue(context, &create.brain_name, &brain, create.actor_id, target).await?;
+        Ok(TicketResponse::Created(
+            TicketCreatedResponse::builder_v1()
+                .ticket(ticket)
+                .build()
+                .into(),
+        ))
     }
 
     /// Issue a ticket scoped to a specific target ref. Used by both
@@ -51,7 +55,12 @@ impl TicketService {
             .build();
 
         context
-            .emit(TicketEvents::TicketIssued(ticket.clone()))
+            .emit(TicketEvents::TicketIssued(
+                TicketIssued::builder_v1()
+                    .ticket(ticket.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
 
         Ok(ticket)
@@ -59,32 +68,51 @@ impl TicketService {
 
     pub async fn get(
         context: &SystemContext,
-        selector: &GetTicket,
+        request: &GetTicket,
     ) -> Result<TicketResponse, TicketError> {
-        let id = selector.key.resolve()?;
+        let GetTicket::V1(lookup) = request;
+        let id = lookup.key.resolve()?;
         let ticket = TicketRepo::new(context)
             .get(&id)
             .await?
             .ok_or(TicketError::NotFound(id))?;
-        Ok(TicketResponse::Found(ticket))
+        Ok(TicketResponse::Found(
+            TicketFoundResponse::builder_v1()
+                .ticket(ticket)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn list(
         context: &SystemContext,
-        ListTickets { filters }: &ListTickets,
+        request: &ListTickets,
     ) -> Result<TicketResponse, TicketError> {
-        let listed = TicketRepo::new(context).list(filters).await?;
-        Ok(TicketResponse::Listed(listed))
+        let ListTickets::V1(listing) = request;
+        let listed = TicketRepo::new(context).list(&listing.filters).await?;
+        Ok(TicketResponse::Listed(
+            TicketsResponse::builder_v1()
+                .items(listed.items)
+                .total(listed.total)
+                .build()
+                .into(),
+        ))
     }
 
     pub async fn validate(
         context: &SystemContext,
-        ValidateTicket { token }: &ValidateTicket,
+        request: &ValidateTicket,
     ) -> Result<TicketResponse, TicketError> {
+        let ValidateTicket::V1(validate) = request;
         let ticket = TicketRepo::new(context)
-            .get_by_token(token.as_str())
+            .get_by_token(validate.token.as_str())
             .await?
             .ok_or(TicketError::InvalidToken)?;
-        Ok(TicketResponse::Validated(ticket))
+        Ok(TicketResponse::Validated(
+            TicketValidatedResponse::builder_v1()
+                .ticket(ticket)
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/ticket/store.rs
+++ b/crates/oneiros-engine/src/domains/ticket/store.rs
@@ -12,8 +12,9 @@ impl<'a> TicketStore<'a> {
     }
 
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
-        if let Event::Known(Events::Ticket(TicketEvents::TicketIssued(ticket))) = &event.data {
-            self.create_record(ticket)?;
+        if let Event::Known(Events::Ticket(TicketEvents::TicketIssued(issued))) = &event.data {
+            let ticket = issued.current()?.ticket;
+            self.write_ticket(&ticket)?;
         }
         Ok(())
     }
@@ -43,7 +44,7 @@ impl<'a> TicketStore<'a> {
         Ok(())
     }
 
-    fn create_record(&self, ticket: &Ticket) -> Result<(), EventError> {
+    fn write_ticket(&self, ticket: &Ticket) -> Result<(), EventError> {
         let target = RefToken::new(ticket.link.target.clone()).to_string();
         self.conn.execute(
             "insert or replace into tickets (

--- a/crates/oneiros-engine/src/domains/ticket/view.rs
+++ b/crates/oneiros-engine/src/domains/ticket/view.rs
@@ -11,24 +11,40 @@ impl TicketView {
 
     pub fn render(self) -> Rendered<TicketResponse> {
         match self.response {
-            TicketResponse::Created(ticket) => {
-                let prompt = Confirmation::new("Ticket", ticket.brain_name.to_string(), "issued")
-                    .to_string();
-                Rendered::new(TicketResponse::Created(ticket), prompt, String::new())
-            }
-            TicketResponse::Found(ticket) => {
-                let prompt = Detail::new(ticket.brain_name.to_string())
-                    .field("actor_id:", ticket.actor_id.to_string())
-                    .to_string();
-                Rendered::new(TicketResponse::Found(ticket), prompt, String::new())
-            }
-            TicketResponse::Validated(ticket) => {
+            TicketResponse::Created(TicketCreatedResponse::V1(created)) => {
                 let prompt =
-                    Confirmation::new("Ticket", ticket.brain_name.to_string(), "validated")
+                    Confirmation::new("Ticket", created.ticket.brain_name.to_string(), "issued")
                         .to_string();
-                Rendered::new(TicketResponse::Validated(ticket), prompt, String::new())
+                Rendered::new(
+                    TicketResponse::Created(TicketCreatedResponse::V1(created)),
+                    prompt,
+                    String::new(),
+                )
             }
-            TicketResponse::Listed(listed) => {
+            TicketResponse::Found(TicketFoundResponse::V1(found)) => {
+                let prompt = Detail::new(found.ticket.brain_name.to_string())
+                    .field("actor_id:", found.ticket.actor_id.to_string())
+                    .to_string();
+                Rendered::new(
+                    TicketResponse::Found(TicketFoundResponse::V1(found)),
+                    prompt,
+                    String::new(),
+                )
+            }
+            TicketResponse::Validated(TicketValidatedResponse::V1(validated)) => {
+                let prompt = Confirmation::new(
+                    "Ticket",
+                    validated.ticket.brain_name.to_string(),
+                    "validated",
+                )
+                .to_string();
+                Rendered::new(
+                    TicketResponse::Validated(TicketValidatedResponse::V1(validated)),
+                    prompt,
+                    String::new(),
+                )
+            }
+            TicketResponse::Listed(TicketsResponse::V1(listed)) => {
                 let mut table = Table::new(vec![
                     Column::key("brain_name", "Brain"),
                     Column::key("actor_id", "Actor"),
@@ -41,9 +57,13 @@ impl TicketView {
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
-                Rendered::new(TicketResponse::Listed(listed), prompt, String::new())
+                Rendered::new(
+                    TicketResponse::Listed(TicketsResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
         }
     }

--- a/crates/oneiros-engine/src/domains/urge/client.rs
+++ b/crates/oneiros-engine/src/domains/urge/client.rs
@@ -9,23 +9,31 @@ impl<'a> UrgeClient<'a> {
         Self { client }
     }
 
-    pub async fn set(&self, set: &SetUrge) -> Result<UrgeResponse, ClientError> {
-        self.client.put(&format!("/urges/{}", set.name), set).await
+    pub async fn set(&self, setting: &SetUrge) -> Result<UrgeResponse, ClientError> {
+        let SetUrge::V1(body) = setting;
+        self.client
+            .put(&format!("/urges/{}", body.name), setting)
+            .await
     }
 
-    pub async fn get(&self, request: &GetUrge) -> Result<UrgeResponse, ClientError> {
-        self.client.get(&format!("/urges/{}", request.key)).await
+    pub async fn get(&self, lookup: &GetUrge) -> Result<UrgeResponse, ClientError> {
+        let GetUrge::V1(lookup) = lookup;
+        self.client.get(&format!("/urges/{}", lookup.key)).await
     }
 
-    pub async fn list(&self, request: &ListUrges) -> Result<UrgeResponse, ClientError> {
+    pub async fn list(&self, listing: &ListUrges) -> Result<UrgeResponse, ClientError> {
+        let ListUrges::V1(listing) = listing;
         let query = format!(
             "limit={}&offset={}",
-            request.filters.limit, request.filters.offset,
+            listing.filters.limit, listing.filters.offset,
         );
         self.client.get(&format!("/urges?{query}")).await
     }
 
-    pub async fn remove(&self, name: &UrgeName) -> Result<UrgeResponse, ClientError> {
-        self.client.delete(&format!("/urges/{name}")).await
+    pub async fn remove(&self, removal: &RemoveUrge) -> Result<UrgeResponse, ClientError> {
+        let RemoveUrge::V1(removal) = removal;
+        self.client
+            .delete(&format!("/urges/{}", removal.name))
+            .await
     }
 }

--- a/crates/oneiros-engine/src/domains/urge/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/urge/features/cli.rs
@@ -2,6 +2,11 @@ use clap::Subcommand;
 
 use crate::*;
 
+/// CLI subcommands for the urge domain. Each variant carries a versioned
+/// protocol request directly — clap derives parsing through the wrapper's
+/// `Args` impl, which delegates to the latest version's struct. The
+/// dispatcher passes the wrapper through to the client without rebuilding,
+/// since the operation type *is* the domain command.
 #[derive(Debug, Subcommand)]
 pub enum UrgeCommands {
     Set(SetUrge),
@@ -19,10 +24,10 @@ impl UrgeCommands {
         let urge_client = UrgeClient::new(&client);
 
         let response = match self {
-            UrgeCommands::Set(set) => urge_client.set(set).await?,
-            UrgeCommands::Show(get) => urge_client.get(get).await?,
-            UrgeCommands::List(list) => urge_client.list(list).await?,
-            UrgeCommands::Remove(removal) => urge_client.remove(&removal.name).await?,
+            Self::Set(setting) => urge_client.set(setting).await?,
+            Self::Show(lookup) => urge_client.get(lookup).await?,
+            Self::List(listing) => urge_client.list(listing).await?,
+            Self::Remove(removal) => urge_client.remove(removal).await?,
         };
 
         Ok(UrgeView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/urge/features/http.rs
+++ b/crates/oneiros-engine/src/domains/urge/features/http.rs
@@ -41,12 +41,14 @@ impl UrgeRouter {
 async fn set(
     context: ProjectContext,
     Path(name): Path<UrgeName>,
-    Json(mut body): Json<SetUrge>,
+    Json(body): Json<SetUrge>,
 ) -> Result<(StatusCode, Json<UrgeResponse>), UrgeError> {
-    body.name = name;
+    let SetUrge::V1(mut setting) = body;
+    setting.name = name;
+    let request = SetUrge::V1(setting);
     Ok((
         StatusCode::OK,
-        Json(UrgeService::set(&context, &body).await?),
+        Json(UrgeService::set(&context, &request).await?),
     ))
 }
 
@@ -62,7 +64,7 @@ async fn show(
     Path(key): Path<ResourceKey<UrgeName>>,
 ) -> Result<Json<UrgeResponse>, UrgeError> {
     Ok(Json(
-        UrgeService::get(&context, &GetUrge::builder().key(key).build()).await?,
+        UrgeService::get(&context, &GetUrge::builder_v1().key(key).build().into()).await?,
     ))
 }
 
@@ -71,6 +73,10 @@ async fn remove(
     Path(name): Path<UrgeName>,
 ) -> Result<Json<UrgeResponse>, UrgeError> {
     Ok(Json(
-        UrgeService::remove(&context, &RemoveUrge::builder().name(name).build()).await?,
+        UrgeService::remove(
+            &context,
+            &RemoveUrge::builder_v1().name(name).build().into(),
+        )
+        .await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/urge/features/state.rs
+++ b/crates/oneiros-engine/src/domains/urge/features/state.rs
@@ -6,11 +6,15 @@ impl UrgeState {
     pub fn reduce(mut canon: BrainCanon, event: &Events) -> BrainCanon {
         if let Events::Urge(urge_event) = event {
             match urge_event {
-                UrgeEvents::UrgeSet(urge) => {
-                    canon.urges.set(urge);
+                UrgeEvents::UrgeSet(setting) => {
+                    if let Ok(current) = setting.current() {
+                        canon.urges.set(&current.urge);
+                    }
                 }
-                UrgeEvents::UrgeRemoved(removed) => {
-                    canon.urges.remove(&removed.name);
+                UrgeEvents::UrgeRemoved(removal) => {
+                    if let Ok(current) = removal.current() {
+                        canon.urges.remove(&current.name);
+                    }
                 }
             };
         }

--- a/crates/oneiros-engine/src/domains/urge/model.rs
+++ b/crates/oneiros-engine/src/domains/urge/model.rs
@@ -1,20 +1,17 @@
 use bon::Builder;
-use clap::Args;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::*;
 
-#[derive(Args, Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Builder, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct Urge {
     #[builder(into)]
     pub name: UrgeName,
     #[builder(into)]
-    #[arg(long, default_value = "")]
     pub description: Description,
     #[builder(into)]
-    #[arg(long, default_value = "")]
     pub prompt: Prompt,
 }
 

--- a/crates/oneiros-engine/src/domains/urge/protocol/events.rs
+++ b/crates/oneiros-engine/src/domains/urge/protocol/events.rs
@@ -7,13 +7,37 @@ use crate::*;
 #[serde(rename_all = "kebab-case", tag = "type", content = "data")]
 #[kinded(kind = UrgeEventsType, display = "kebab-case")]
 pub enum UrgeEvents {
-    UrgeSet(Urge),
+    UrgeSet(UrgeSet),
     UrgeRemoved(UrgeRemoved),
+}
+
+versioned! {
+    pub enum UrgeSet {
+        V1 => {
+            #[serde(flatten)] pub urge: Urge,
+        }
+    }
+}
+
+versioned! {
+    pub enum UrgeRemoved {
+        V1 => {
+            #[builder(into)] pub name: UrgeName,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_urge() -> Urge {
+        Urge::builder()
+            .name("introspect")
+            .description("The pull to look inward")
+            .prompt("Pause and examine.")
+            .build()
+    }
 
     #[test]
     fn event_types_are_kebab_cased() {
@@ -25,9 +49,42 @@ mod tests {
             assert_eq!(&event_type.to_string(), expectation);
         }
     }
-}
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UrgeRemoved {
-    pub name: UrgeName,
+    #[test]
+    fn urge_set_wire_format_is_flat() {
+        let event = UrgeEvents::UrgeSet(UrgeSet::V1(UrgeSetV1 {
+            urge: sample_urge(),
+        }));
+
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "urge-set");
+        assert!(
+            json["data"].get("urge").is_none(),
+            "flatten must elide the urge envelope on the wire"
+        );
+        assert_eq!(json["data"]["name"], "introspect");
+        assert_eq!(json["data"]["description"], "The pull to look inward");
+        assert!(
+            json["data"].get("V1").is_none(),
+            "V1 layer must not appear on the wire"
+        );
+    }
+
+    #[test]
+    fn urge_removed_round_trips_through_v1_layer() {
+        let original = UrgeEvents::UrgeRemoved(UrgeRemoved::V1(UrgeRemovedV1 {
+            name: UrgeName::new("introspect"),
+        }));
+
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: UrgeEvents = serde_json::from_str(&json).unwrap();
+
+        match decoded {
+            UrgeEvents::UrgeRemoved(removed) => {
+                let v1 = removed.current().unwrap();
+                assert_eq!(v1.name.to_string(), "introspect");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/urge/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/urge/protocol/requests.rs
@@ -1,41 +1,56 @@
-use bon::Builder;
-use clap::Args;
 use kinded::Kinded;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct SetUrge {
-    #[builder(into)]
-    pub name: UrgeName,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub description: Description,
-    #[arg(long, default_value = "")]
-    #[builder(default, into)]
-    pub prompt: Prompt,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum SetUrge {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: UrgeName,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub description: Description,
+            #[arg(long, default_value = "")]
+            #[builder(default, into)]
+            pub prompt: Prompt,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct GetUrge {
-    #[builder(into)]
-    pub key: ResourceKey<UrgeName>,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum GetUrge {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub key: ResourceKey<UrgeName>,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct RemoveUrge {
-    #[builder(into)]
-    pub name: UrgeName,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum RemoveUrge {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub name: UrgeName,
+        }
+    }
 }
 
-#[derive(Builder, Debug, Clone, Serialize, Deserialize, JsonSchema, Args)]
-pub struct ListUrges {
-    #[command(flatten)]
-    #[serde(flatten)]
-    #[builder(default)]
-    pub filters: SearchFilters,
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum ListUrges {
+        #[derive(clap::Args)]
+        V1 => {
+            #[command(flatten)]
+            #[serde(flatten)]
+            #[builder(default)]
+            pub filters: SearchFilters,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/urge/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/urge/protocol/responses.rs
@@ -1,15 +1,49 @@
 use kinded::Kinded;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-#[derive(Debug, Clone, Kinded, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
 #[kinded(kind = UrgeResponseType, display = "kebab-case")]
 #[serde(tag = "type", content = "data", rename_all = "kebab-case")]
 pub enum UrgeResponse {
-    UrgeSet(UrgeName),
-    UrgeDetails(Urge),
-    Urges(Listed<Urge>),
+    UrgeSet(UrgeSetResponse),
+    UrgeDetails(UrgeDetailsResponse),
+    Urges(UrgesResponse),
     NoUrges,
-    UrgeRemoved(UrgeName),
+    UrgeRemoved(UrgeRemovedResponse),
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum UrgeSetResponse {
+        V1 => { #[serde(flatten)] pub urge: Urge }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum UrgeDetailsResponse {
+        V1 => { #[serde(flatten)] pub urge: Urge }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum UrgesResponse {
+        V1 => {
+            pub items: Vec<Urge>,
+            pub total: usize,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub enum UrgeRemovedResponse {
+        V1 => {
+            #[builder(into)] pub name: UrgeName,
+        }
+    }
 }

--- a/crates/oneiros-engine/src/domains/urge/service.rs
+++ b/crates/oneiros-engine/src/domains/urge/service.rs
@@ -5,54 +5,78 @@ pub struct UrgeService;
 impl UrgeService {
     pub async fn set(
         context: &ProjectContext,
-        SetUrge {
-            name,
-            description,
-            prompt,
-        }: &SetUrge,
+        request: &SetUrge,
     ) -> Result<UrgeResponse, UrgeError> {
+        let SetUrge::V1(set) = request;
         let urge = Urge::builder()
-            .name(name.clone())
-            .description(description.clone())
-            .prompt(prompt.clone())
+            .name(set.name.clone())
+            .description(set.description.clone())
+            .prompt(set.prompt.clone())
             .build();
-        context.emit(UrgeEvents::UrgeSet(urge)).await?;
-        Ok(UrgeResponse::UrgeSet(name.clone()))
+
+        context
+            .emit(UrgeEvents::UrgeSet(
+                UrgeSet::builder_v1().urge(urge.clone()).build().into(),
+            ))
+            .await?;
+
+        Ok(UrgeResponse::UrgeSet(
+            UrgeSetResponse::builder_v1().urge(urge).build().into(),
+        ))
     }
 
     pub async fn get(
         context: &ProjectContext,
-        selector: &GetUrge,
+        request: &GetUrge,
     ) -> Result<UrgeResponse, UrgeError> {
-        let name = selector.key.resolve()?;
+        let GetUrge::V1(lookup) = request;
+        let name = lookup.key.resolve()?;
         let urge = UrgeRepo::new(context)
             .get(&name)
             .await?
             .ok_or(UrgeError::NotFound(name))?;
-        Ok(UrgeResponse::UrgeDetails(urge))
+        Ok(UrgeResponse::UrgeDetails(
+            UrgeDetailsResponse::builder_v1().urge(urge).build().into(),
+        ))
     }
 
     pub async fn list(
         context: &ProjectContext,
-        ListUrges { filters }: &ListUrges,
+        request: &ListUrges,
     ) -> Result<UrgeResponse, UrgeError> {
-        let listed = UrgeRepo::new(context).list(filters).await?;
+        let ListUrges::V1(listing) = request;
+        let listed = UrgeRepo::new(context).list(&listing.filters).await?;
         if listed.total == 0 {
             Ok(UrgeResponse::NoUrges)
         } else {
-            Ok(UrgeResponse::Urges(listed))
+            Ok(UrgeResponse::Urges(
+                UrgesResponse::builder_v1()
+                    .items(listed.items)
+                    .total(listed.total)
+                    .build()
+                    .into(),
+            ))
         }
     }
 
     pub async fn remove(
         context: &ProjectContext,
-        selector: &RemoveUrge,
+        request: &RemoveUrge,
     ) -> Result<UrgeResponse, UrgeError> {
+        let RemoveUrge::V1(removal) = request;
         context
-            .emit(UrgeEvents::UrgeRemoved(UrgeRemoved {
-                name: selector.name.clone(),
-            }))
+            .emit(UrgeEvents::UrgeRemoved(
+                UrgeRemoved::builder_v1()
+                    .name(removal.name.clone())
+                    .build()
+                    .into(),
+            ))
             .await?;
-        Ok(UrgeResponse::UrgeRemoved(selector.name.clone()))
+        Ok(UrgeResponse::UrgeRemoved(
+            UrgeRemovedResponse::builder_v1()
+                .name(removal.name.clone())
+                .build()
+                .into(),
+        ))
     }
 }

--- a/crates/oneiros-engine/src/domains/urge/store.rs
+++ b/crates/oneiros-engine/src/domains/urge/store.rs
@@ -14,8 +14,8 @@ impl<'a> UrgeStore<'a> {
     pub fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
         if let Event::Known(Events::Urge(urge_event)) = &event.data {
             match urge_event {
-                UrgeEvents::UrgeSet(urge) => self.set(urge)?,
-                UrgeEvents::UrgeRemoved(removed) => self.remove(&removed.name)?,
+                UrgeEvents::UrgeSet(setting) => self.set(setting)?,
+                UrgeEvents::UrgeRemoved(removal) => self.remove(removal)?,
             }
         }
         Ok(())
@@ -64,7 +64,21 @@ impl<'a> UrgeStore<'a> {
         Ok(urges)
     }
 
-    fn set(&self, urge: &Urge) -> Result<(), EventError> {
+    fn set(&self, setting: &UrgeSet) -> Result<(), EventError> {
+        let urge = setting.current()?.urge;
+        self.write_urge(&urge)
+    }
+
+    fn remove(&self, removal: &UrgeRemoved) -> Result<(), EventError> {
+        let name = removal.current()?.name;
+        self.conn.execute(
+            "DELETE FROM urges WHERE name = ?1",
+            params![name.to_string()],
+        )?;
+        Ok(())
+    }
+
+    fn write_urge(&self, urge: &Urge) -> Result<(), EventError> {
         self.conn.execute(
             "INSERT OR REPLACE INTO urges (name, description, prompt) VALUES (?1, ?2, ?3)",
             params![
@@ -72,14 +86,6 @@ impl<'a> UrgeStore<'a> {
                 urge.description.to_string(),
                 urge.prompt.to_string()
             ],
-        )?;
-        Ok(())
-    }
-
-    fn remove(&self, name: &UrgeName) -> Result<(), EventError> {
-        self.conn.execute(
-            "DELETE FROM urges WHERE name = ?1",
-            params![name.to_string()],
         )?;
         Ok(())
     }

--- a/crates/oneiros-engine/src/domains/urge/view.rs
+++ b/crates/oneiros-engine/src/domains/urge/view.rs
@@ -11,21 +11,28 @@ impl UrgeView {
 
     pub fn mcp(&self) -> McpResponse {
         match &self.response {
-            UrgeResponse::Urges(listed) => {
+            UrgeResponse::Urges(UrgesResponse::V1(listed)) => {
                 let items: Vec<_> = listed
                     .items
                     .iter()
-                    .map(|u| (u.name.to_string(), u.description.to_string()))
+                    .map(|item| (item.name.to_string(), item.description.to_string()))
                     .collect();
                 Self::vocabulary_table("Urges", &items)
             }
-            UrgeResponse::UrgeDetails(urge) => {
-                let items = vec![(urge.name.to_string(), urge.description.to_string())];
+            UrgeResponse::UrgeDetails(UrgeDetailsResponse::V1(details)) => {
+                let items = vec![(
+                    details.urge.name.to_string(),
+                    details.urge.description.to_string(),
+                )];
                 Self::vocabulary_table("Urge", &items)
             }
             UrgeResponse::NoUrges => Self::vocabulary_table("Urges", &[]),
-            UrgeResponse::UrgeSet(name) => McpResponse::new(format!("Urge set: {name}")),
-            UrgeResponse::UrgeRemoved(name) => McpResponse::new(format!("Urge removed: {name}")),
+            UrgeResponse::UrgeSet(UrgeSetResponse::V1(set)) => {
+                McpResponse::new(format!("Urge set: {}", set.urge.name))
+            }
+            UrgeResponse::UrgeRemoved(UrgeRemovedResponse::V1(removed)) => {
+                McpResponse::new(format!("Urge removed: {}", removed.name))
+            }
         }
     }
 
@@ -45,21 +52,31 @@ impl UrgeView {
 
     pub fn render(self) -> Rendered<UrgeResponse> {
         match self.response {
-            UrgeResponse::UrgeSet(name) => {
-                let prompt = Confirmation::new("Urge", name.to_string(), "set").to_string();
+            UrgeResponse::UrgeSet(UrgeSetResponse::V1(set)) => {
+                let prompt =
+                    Confirmation::new("Urge", set.urge.name.to_string(), "set").to_string();
                 let hints = HintSet::vocabulary(
                     VocabularyHints::builder().kind("urge".to_string()).build(),
                 );
-                Rendered::new(UrgeResponse::UrgeSet(name), prompt, String::new()).with_hints(hints)
+                Rendered::new(
+                    UrgeResponse::UrgeSet(UrgeSetResponse::V1(set)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
-            UrgeResponse::UrgeDetails(urge) => {
-                let prompt = Detail::new(urge.name.to_string())
-                    .field("description:", urge.description.to_string())
-                    .field("prompt:", urge.prompt.to_string())
+            UrgeResponse::UrgeDetails(UrgeDetailsResponse::V1(details)) => {
+                let prompt = Detail::new(details.urge.name.to_string())
+                    .field("description:", details.urge.description.to_string())
+                    .field("prompt:", details.urge.prompt.to_string())
                     .to_string();
-                Rendered::new(UrgeResponse::UrgeDetails(urge), prompt, String::new())
+                Rendered::new(
+                    UrgeResponse::UrgeDetails(UrgeDetailsResponse::V1(details)),
+                    prompt,
+                    String::new(),
+                )
             }
-            UrgeResponse::Urges(listed) => {
+            UrgeResponse::Urges(UrgesResponse::V1(listed)) => {
                 let mut table = Table::new(vec![
                     Column::key("name", "Name"),
                     Column::key("description", "Description").max(60),
@@ -69,22 +86,31 @@ impl UrgeView {
                 }
                 let prompt = format!(
                     "{}\n\n{table}",
-                    format_args!("{} of {} total", listed.len(), listed.total).muted(),
+                    format_args!("{} of {} total", listed.items.len(), listed.total).muted(),
                 );
-                Rendered::new(UrgeResponse::Urges(listed), prompt, String::new())
+                Rendered::new(
+                    UrgeResponse::Urges(UrgesResponse::V1(listed)),
+                    prompt,
+                    String::new(),
+                )
             }
             UrgeResponse::NoUrges => Rendered::new(
                 UrgeResponse::NoUrges,
                 format!("{}", "No urges configured.".muted()),
                 String::new(),
             ),
-            UrgeResponse::UrgeRemoved(name) => {
-                let prompt = Confirmation::new("Urge", name.to_string(), "removed").to_string();
+            UrgeResponse::UrgeRemoved(UrgeRemovedResponse::V1(removed)) => {
+                let prompt =
+                    Confirmation::new("Urge", removed.name.to_string(), "removed").to_string();
                 let hints = HintSet::vocabulary(
                     VocabularyHints::builder().kind("urge".to_string()).build(),
                 );
-                Rendered::new(UrgeResponse::UrgeRemoved(name), prompt, String::new())
-                    .with_hints(hints)
+                Rendered::new(
+                    UrgeResponse::UrgeRemoved(UrgeRemovedResponse::V1(removed)),
+                    prompt,
+                    String::new(),
+                )
+                .with_hints(hints)
             }
         }
     }

--- a/crates/oneiros-engine/src/error.rs
+++ b/crates/oneiros-engine/src/error.rs
@@ -1,6 +1,22 @@
 use crate::*;
 
 #[derive(Debug, thiserror::Error)]
+pub enum UpcastError {
+    #[error("discontinuity {from} -> {to}: {reason}")]
+    Discontinuity {
+        from: &'static str,
+        to: &'static str,
+        reason: &'static str,
+    },
+}
+
+impl From<std::convert::Infallible> for UpcastError {
+    fn from(x: std::convert::Infallible) -> Self {
+        match x {}
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("{0}")]
     Context(String),

--- a/crates/oneiros-engine/src/macros/invocation.rs
+++ b/crates/oneiros-engine/src/macros/invocation.rs
@@ -1,0 +1,99 @@
+//! Render a versioned-protocol value as a populated CLI invocation string.
+//!
+//! Walks the serde representation of `value` and emits `--{kebab} {value}`
+//! pairs for each scalar field. Used by the `versioned!` macro's
+//! `to_invocation()` method so hint text, MCP tool examples, and OpenAPI
+//! sample-call documentation can derive from the value itself rather than
+//! hand-curated strings.
+
+use serde::Serialize;
+
+pub fn render_invocation<T: Serialize>(name: &str, value: &T) -> String {
+    let json = match serde_json::to_value(value) {
+        Ok(json) => json,
+        Err(_) => return name.to_string(),
+    };
+
+    let mut parts = vec![name.to_string()];
+    if let serde_json::Value::Object(fields) = json {
+        for (key, field_value) in fields {
+            append_field(&mut parts, &key, &field_value);
+        }
+    }
+    parts.join(" ")
+}
+
+fn append_field(parts: &mut Vec<String>, key: &str, value: &serde_json::Value) {
+    match value {
+        serde_json::Value::Null => {}
+        serde_json::Value::Bool(false) => {}
+        serde_json::Value::Bool(true) => parts.push(format!("--{key}")),
+        serde_json::Value::String(text) if text.is_empty() => {}
+        serde_json::Value::String(text) => parts.push(format!("--{key} {}", shell_escape(text))),
+        serde_json::Value::Number(number) => parts.push(format!("--{key} {number}")),
+        serde_json::Value::Array(items) => {
+            for item in items {
+                append_field(parts, key, item);
+            }
+        }
+        serde_json::Value::Object(_) => {
+            parts.push(format!("--{key} {value}"));
+        }
+    }
+}
+
+fn shell_escape(text: &str) -> String {
+    if text
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | ':'))
+    {
+        text.to_string()
+    } else {
+        let escaped = text.replace('\'', r"'\''");
+        format!("'{escaped}'")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct Sample {
+        name: String,
+        description: String,
+        verbose: bool,
+        count: u32,
+    }
+
+    #[test]
+    fn renders_string_and_number_fields() {
+        let sample = Sample {
+            name: "alpha".to_string(),
+            description: "hello world".to_string(),
+            verbose: true,
+            count: 7,
+        };
+        let invocation = render_invocation("create", &sample);
+        assert!(invocation.starts_with("create"));
+        assert!(invocation.contains("--name alpha"));
+        assert!(invocation.contains("--description 'hello world'"));
+        assert!(invocation.contains("--verbose"));
+        assert!(invocation.contains("--count 7"));
+    }
+
+    #[test]
+    fn elides_empty_strings_and_false_bools() {
+        let sample = Sample {
+            name: "alpha".to_string(),
+            description: String::new(),
+            verbose: false,
+            count: 0,
+        };
+        let invocation = render_invocation("create", &sample);
+        assert!(!invocation.contains("--description"));
+        assert!(!invocation.contains("--verbose"));
+        assert!(invocation.contains("--count 0"));
+    }
+}

--- a/crates/oneiros-engine/src/macros/mod.rs
+++ b/crates/oneiros-engine/src/macros/mod.rs
@@ -1,40 +1,18 @@
 mod collects_enum;
+mod invocation;
 mod resource_id;
 mod resource_name;
 mod resource_op;
-mod resource_op_error {
-    macro_rules! resource_op_error {
-        ($($t:ty),* $(,)?) => {
-            $(
-                impl aide::operation::OperationOutput for $t {
-                    type Inner = ErrorResponse;
-
-                    fn operation_response(
-                        context: &mut aide::generate::GenContext,
-                        _operation: &mut aide::openapi::Operation,
-                    ) -> Option<aide::openapi::Response> {
-                        Some(ErrorResponse::openapi_schema(context))
-                    }
-
-                    fn inferred_responses(
-                        context: &mut aide::generate::GenContext,
-                        operation: &mut aide::openapi::Operation,
-                    ) -> Vec<(Option<aide::openapi::StatusCode>, aide::openapi::Response)> {
-                        Self::operation_response(context, operation)
-                            .into_iter()
-                            .map(|r| (None, r))
-                            .collect()
-                    }
-                }
-            )*
-        };
-    }
-
-    pub(crate) use resource_op_error;
-}
+mod resource_op_error;
+mod upcast_versions;
+mod versioned;
 
 pub(crate) use collects_enum::collects_enum;
+pub(crate) use invocation::render_invocation;
 pub(crate) use resource_id::resource_id;
 pub(crate) use resource_name::resource_name;
 pub(crate) use resource_op::resource_op;
 pub(crate) use resource_op_error::resource_op_error;
+pub(crate) use upcast_versions::upcast_versions;
+pub(crate) use versioned::__versioned_if_args;
+pub(crate) use versioned::versioned;

--- a/crates/oneiros-engine/src/macros/resource_op_error.rs
+++ b/crates/oneiros-engine/src/macros/resource_op_error.rs
@@ -1,0 +1,28 @@
+macro_rules! resource_op_error {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl aide::operation::OperationOutput for $t {
+                type Inner = ErrorResponse;
+
+                fn operation_response(
+                    context: &mut aide::generate::GenContext,
+                    _operation: &mut aide::openapi::Operation,
+                ) -> Option<aide::openapi::Response> {
+                    Some(ErrorResponse::openapi_schema(context))
+                }
+
+                fn inferred_responses(
+                    context: &mut aide::generate::GenContext,
+                    operation: &mut aide::openapi::Operation,
+                ) -> Vec<(Option<aide::openapi::StatusCode>, aide::openapi::Response)> {
+                    Self::operation_response(context, operation)
+                        .into_iter()
+                        .map(|r| (None, r))
+                        .collect()
+                }
+            }
+        )*
+    };
+}
+
+pub(crate) use resource_op_error;

--- a/crates/oneiros-engine/src/macros/upcast_versions.rs
+++ b/crates/oneiros-engine/src/macros/upcast_versions.rs
@@ -1,0 +1,188 @@
+//! `upcast_versions!` — generate `From` / `TryFrom` impls between versioned shapes.
+//!
+//! The macro destructures the source by the LHS field list and splices your
+//! body verbatim into `Self { ... }`. Nothing is hidden — every field that
+//! ends up in the target appears in the body explicitly. Field shorthand
+//! picks up bindings from the destructure when you reference them by name.
+//!
+//! A single invocation can declare any number of pairs; mix bare and
+//! `Ok`-wrapped bodies freely.
+//!
+//! # Bare body — generates `From<Source> for Target`
+//!
+//! ```ignore
+//! upcast_versions! {
+//!     AgentCreatedV0 { name, description, prompt } => AgentCreatedV1 {
+//!         name, description, prompt,
+//!         id: AgentId::new(),
+//!         persona: PersonaName::legacy(),
+//!     }
+//! }
+//! ```
+//!
+//! Because `From<T> for U` blanket-implies `TryFrom<T> for U` with
+//! `Error = Infallible`, callers using `try_into()?` work unchanged.
+//!
+//! # Ok-wrapped body — generates `TryFrom<Source> for Target` with `UpcastError`
+//!
+//! ```ignore
+//! upcast_versions! {
+//!     AgentCreatedV0 { name, description, prompt } => Ok(AgentCreatedV1 {
+//!         name, description, prompt,
+//!         id: AgentId::new(),
+//!         persona: PersonaName::legacy(),
+//!     })
+//! }
+//! ```
+//!
+//! # Chained — many pairs in one call
+//!
+//! ```ignore
+//! upcast_versions! {
+//!     V0 { name, value } => V1 {
+//!         name, value,
+//!         id: 42,
+//!     }
+//!     V1 { name, value, id } => Ok(V2 {
+//!         name, value, id,
+//!         timestamp: Timestamp::now(),
+//!     })
+//! }
+//! ```
+//!
+//! Each pair becomes its own `impl`. `versioned!`'s generated `current()`
+//! walks the chain via `try_into()?` at the call site.
+//!
+//! # When to reach for this macro vs. a hand-written `From`
+//!
+//! `upcast_versions!` is for *version evolution*. Plain structural
+//! conversions — entity ↔ event payload, response envelope reshaping,
+//! anything where there's no version timeline — are not upcasts; hand-write
+//! the `From` impls for those, even if the field-shuffle looks identical.
+//! The semantic distinction is worth the small redundancy.
+//!
+//! # Discontinuity
+//!
+//! Pure-discontinuity upcasts (always `Err`) live under
+//! [`unsupported_upcast!`](crate::unsupported_upcast).
+macro_rules! upcast_versions {
+    // Bare pair → From, then recurse on the rest.
+    (
+        $source:ident { $($pat:tt)* } => $target:ident { $($body:tt)* }
+        $($rest:tt)*
+    ) => {
+        impl ::std::convert::From<$source> for $target {
+            fn from(previous: $source) -> Self {
+                let $source { $($pat)* } = previous;
+                Self { $($body)* }
+            }
+        }
+        upcast_versions! { $($rest)* }
+    };
+
+    // Ok-wrapped pair → TryFrom with UpcastError, then recurse on the rest.
+    (
+        $source:ident { $($pat:tt)* } => Ok($target:ident { $($body:tt)* })
+        $($rest:tt)*
+    ) => {
+        impl ::std::convert::TryFrom<$source> for $target {
+            type Error = $crate::UpcastError;
+            fn try_from(previous: $source) -> ::std::result::Result<Self, Self::Error> {
+                let $source { $($pat)* } = previous;
+                Ok(Self { $($body)* })
+            }
+        }
+        upcast_versions! { $($rest)* }
+    };
+
+    // Empty — terminate the recursion.
+    () => {};
+}
+
+pub(crate) use upcast_versions;
+
+#[cfg(test)]
+mod tests {
+    #[derive(Debug, Clone, PartialEq)]
+    struct Wedge0 {
+        name: String,
+        value: u32,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct Wedge1 {
+        name: String,
+        value: u32,
+        id: u64,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct Wedge2 {
+        name: String,
+        value: u32,
+        id: u64,
+        timestamp: u64,
+    }
+
+    upcast_versions! {
+        Wedge0 { name, value } => Wedge1 {
+            name, value,
+            id: 42,
+        }
+        Wedge1 { name, value, id } => Ok(Wedge2 {
+            name, value, id,
+            timestamp: 100,
+        })
+    }
+
+    #[test]
+    fn bare_form_emits_from_impl() {
+        let v0 = Wedge0 {
+            name: "foo".into(),
+            value: 5,
+        };
+        let v1: Wedge1 = v0.into();
+        assert_eq!(v1.name, "foo");
+        assert_eq!(v1.value, 5);
+        assert_eq!(v1.id, 42);
+    }
+
+    #[test]
+    fn bare_form_blanket_lets_try_into_work() {
+        let v0 = Wedge0 {
+            name: "foo".into(),
+            value: 5,
+        };
+        #[allow(clippy::unnecessary_fallible_conversions)]
+        let v1: Wedge1 = v0.try_into().unwrap();
+        assert_eq!(v1.id, 42);
+    }
+
+    #[test]
+    fn ok_form_emits_try_from_impl() {
+        let v1 = Wedge1 {
+            name: "foo".into(),
+            value: 5,
+            id: 7,
+        };
+        let v2 = Wedge2::try_from(v1).unwrap();
+        assert_eq!(v2.name, "foo");
+        assert_eq!(v2.value, 5);
+        assert_eq!(v2.id, 7);
+        assert_eq!(v2.timestamp, 100);
+    }
+
+    #[test]
+    fn chains_via_try_into_through_both_impls() {
+        let v0 = Wedge0 {
+            name: "foo".into(),
+            value: 5,
+        };
+        #[allow(clippy::unnecessary_fallible_conversions)]
+        let v1: Wedge1 = v0.try_into().unwrap();
+        let v2: Wedge2 = v1.try_into().unwrap();
+        assert_eq!(v2.name, "foo");
+        assert_eq!(v2.id, 42);
+        assert_eq!(v2.timestamp, 100);
+    }
+}

--- a/crates/oneiros-engine/src/macros/versioned.rs
+++ b/crates/oneiros-engine/src/macros/versioned.rs
@@ -1,0 +1,286 @@
+//! `versioned!` — generate the wrapper-enum boilerplate for a versioned protocol shape.
+//!
+//! Two call shapes are supported:
+//!
+//! 1. **struct-inline (default):** struct definitions live inside the macro
+//!    call. Struct names are synthesized as `<EnumName><VariantName>` (so
+//!    `AgentCreated` + `V1` becomes `AgentCreatedV1`). Each variant accepts
+//!    its own attribute slot before the `=>`, where users layer additional
+//!    derives (e.g. `clap::Args`, `Hash`) onto a variant's struct. Rust
+//!    happily merges multiple `#[derive(...)]` lines, so the macro just
+//!    forwards the user's attrs above its own hardcoded baseline.
+//!
+//!    The hardcoded baseline:
+//!    - **Wrapper enum:** `Debug, Clone, Serialize, Deserialize` + user's
+//!      enum-level attrs (e.g. `#[derive(JsonSchema)]`).
+//!    - **Latest struct:** `Debug, Clone, Builder, Serialize, Deserialize,
+//!      JsonSchema` + user's variant-level attrs.
+//!    - **Older structs:** `Debug, Clone, Builder, Serialize, Deserialize` +
+//!      user's variant-level attrs.
+//!
+//!    **Args delegation is conditional.** When the latest variant's user
+//!    attrs include `#[derive(Args)]` (or `clap::Args`), the macro
+//!    additionally emits an `impl clap::Args for Wrapper` that delegates
+//!    to `<LatestStruct as clap::Args>`, plus `Wrapper::clap_command(name)`
+//!    and `Wrapper::to_invocation(name)` helpers. The detection is by
+//!    token-tree match — if `Args` shows up anywhere in the latest variant's
+//!    attrs, the delegation is generated.
+//!
+//! 2. **struct-out (legacy single version):** the V_n struct lives outside
+//!    the macro; user names it as a type. Macro generates the wrapper,
+//!    `current()`, and `From<V1> for Wrapper`. The user controls all
+//!    derives on the V_n struct.
+//!
+//! # Example — request shape (CLI-visible)
+//!
+//! ```ignore
+//! versioned! {
+//!     #[derive(JsonSchema)]
+//!     pub enum CreateAgent {
+//!         #[derive(Args)]
+//!         V1 => {
+//!             #[builder(into)] pub name: AgentName,
+//!             #[arg(long, default_value = "")]
+//!             #[builder(default, into)] pub description: Description,
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! Generates `CreateAgentV1`, `CreateAgent::current()`,
+//! `CreateAgent::builder_v1()`, `From<CreateAgentV1> for CreateAgent`, plus
+//! (because `Args` was on the V1 attrs) `clap::Args` impl on `CreateAgent`,
+//! `CreateAgent::clap_command(name)`, and `CreateAgent::to_invocation(name)`.
+//!
+//! # Example — event shape (internal)
+//!
+//! ```ignore
+//! versioned! {
+//!     pub enum AgentCreated {
+//!         V1 => {
+//!             #[builder(default)] pub id: AgentId,
+//!             #[builder(into)] pub name: AgentName,
+//!         },
+//!         V0 => {
+//!             #[builder(into)] pub name: AgentName,
+//!         },
+//!     }
+//! }
+//!
+//! impl TryFrom<AgentCreatedV0> for AgentCreatedV1 { /* user-supplied */ }
+//! ```
+//!
+//! No Args delegation generated, since the V1 attrs don't include it.
+
+/// Internal helper: emit `$body` iff the literal ident `Args` appears
+/// anywhere in the supplied token tree haystack. Used by `versioned!` to
+/// gate Args delegation generation on whether the user derived
+/// `clap::Args` (or `Args`) on the latest variant.
+///
+/// The implementation is a recursive TT-munching scan: any nested group
+/// (parens/brackets/braces) is flattened inline and scanning continues.
+/// `Args` is the only ident we look for, so the only false positive
+/// would be a non-derive attribute that mentions `Args` as an ident —
+/// which doesn't appear in this codebase.
+macro_rules! __versioned_if_args {
+    // Found the literal ident `Args` — emit body and stop.
+    ({ $($body:tt)* }, [Args $($_rest:tt)*]) => { $($body)* };
+    // Flatten a paren group and continue.
+    ({ $($body:tt)* }, [($($inner:tt)*) $($rest:tt)*]) => {
+        $crate::macros::__versioned_if_args!({ $($body)* }, [$($inner)* $($rest)*]);
+    };
+    // Flatten a bracket group and continue.
+    ({ $($body:tt)* }, [[$($inner:tt)*] $($rest:tt)*]) => {
+        $crate::macros::__versioned_if_args!({ $($body)* }, [$($inner)* $($rest)*]);
+    };
+    // Flatten a brace group and continue.
+    ({ $($body:tt)* }, [{$($inner:tt)*} $($rest:tt)*]) => {
+        $crate::macros::__versioned_if_args!({ $($body)* }, [$($inner)* $($rest)*]);
+    };
+    // Skip any other token.
+    ({ $($body:tt)* }, [$_first:tt $($rest:tt)*]) => {
+        $crate::macros::__versioned_if_args!({ $($body)* }, [$($rest)*]);
+    };
+    // End — Args not found.
+    ({ $($body:tt)* }, []) => {};
+}
+
+pub(crate) use __versioned_if_args;
+
+macro_rules! versioned {
+    // ───────────────────────────────────────────────────────────────────
+    // Inline form. Per-variant attribute slot before `=>` lets the user
+    // layer arbitrary derives (Args, Hash, custom) onto a variant's
+    // struct. Args delegation on the wrapper is conditional on the
+    // latest variant's attrs containing `Args`.
+    // ───────────────────────────────────────────────────────────────────
+    (
+        $(#[$enum_attr:meta])*
+        $vis:vis enum $name:ident {
+            // Variant attrs are captured as raw token trees (not `:meta`) so
+            // the helper macro `__versioned_if_args!` can scan into the
+            // `derive(...)` group looking for `Args`. A `:meta` capture
+            // flattens group structure when re-emitted into another macro's
+            // input, which defeats the scan.
+            $(#[$($lattr:tt)*])*
+            $latest_variant:ident => {
+                $(
+                    $(#[$lf_attr:meta])*
+                    $lfvis:vis $lf:ident: $lty:ty
+                ),* $(,)?
+            }
+            $(,
+                $(#[$($vattr:tt)*])*
+                $variant:ident => {
+                    $(
+                        $(#[$f_attr:meta])*
+                        $fvis:vis $f:ident: $fty:ty
+                    ),* $(,)?
+                }
+            )*
+            $(,)?
+        }
+    ) => {
+        ::paste::paste! {
+            $(#[$enum_attr])*
+            #[derive(Debug, Clone, ::serde::Serialize, ::serde::Deserialize)]
+            #[serde(untagged)]
+            $vis enum $name {
+                $latest_variant([<$name $latest_variant>]),
+                $($variant([<$name $variant>]),)*
+            }
+
+            $(#[$($lattr)*])*
+            #[derive(
+                Debug,
+                Clone,
+                ::bon::Builder,
+                ::serde::Serialize,
+                ::serde::Deserialize,
+                ::schemars::JsonSchema,
+            )]
+            #[serde(deny_unknown_fields)]
+            $vis struct [<$name $latest_variant>] {
+                $(
+                    $(#[$lf_attr])*
+                    $lfvis $lf: $lty,
+                )*
+            }
+
+            $(
+                $(#[$($vattr)*])*
+                #[derive(Debug, Clone, ::bon::Builder, ::serde::Serialize, ::serde::Deserialize)]
+                #[serde(deny_unknown_fields)]
+                $vis struct [<$name $variant>] {
+                    $(
+                        $(#[$f_attr])*
+                        $fvis $f: $fty,
+                    )*
+                }
+            )*
+
+            impl $name {
+                pub fn current(
+                    &self,
+                ) -> ::std::result::Result<[<$name $latest_variant>], $crate::UpcastError> {
+                    Ok(match self {
+                        Self::$latest_variant(v) => v.clone(),
+                        $(Self::$variant(v) => v.clone().try_into()?,)*
+                    })
+                }
+
+                pub fn [<builder_ $latest_variant:lower>]() -> [<$name $latest_variant Builder>] {
+                    [<$name $latest_variant>]::builder()
+                }
+
+                $(
+                    pub fn [<builder_ $variant:lower>]() -> [<$name $variant Builder>] {
+                        [<$name $variant>]::builder()
+                    }
+                )*
+            }
+
+            impl ::std::convert::From<[<$name $latest_variant>]> for $name {
+                fn from(v: [<$name $latest_variant>]) -> Self {
+                    Self::$latest_variant(v)
+                }
+            }
+
+            $crate::macros::__versioned_if_args!({
+                impl $name {
+                    pub fn clap_command(name: &'static str) -> ::clap::Command {
+                        <[<$name $latest_variant>] as ::clap::Args>::augment_args(
+                            ::clap::Command::new(name),
+                        )
+                    }
+
+                    pub fn to_invocation(&self, name: &str) -> String {
+                        $crate::macros::render_invocation(name, self)
+                    }
+                }
+
+                impl ::clap::Args for $name {
+                    fn augment_args(cmd: ::clap::Command) -> ::clap::Command {
+                        <[<$name $latest_variant>] as ::clap::Args>::augment_args(cmd)
+                    }
+                    fn augment_args_for_update(cmd: ::clap::Command) -> ::clap::Command {
+                        <[<$name $latest_variant>] as ::clap::Args>::augment_args_for_update(cmd)
+                    }
+                }
+
+                impl ::clap::FromArgMatches for $name {
+                    fn from_arg_matches(
+                        matches: &::clap::ArgMatches,
+                    ) -> ::std::result::Result<Self, ::clap::Error> {
+                        Ok(Self::$latest_variant(
+                            <[<$name $latest_variant>] as ::clap::FromArgMatches>::from_arg_matches(
+                                matches,
+                            )?,
+                        ))
+                    }
+                    fn update_from_arg_matches(
+                        &mut self,
+                        matches: &::clap::ArgMatches,
+                    ) -> ::std::result::Result<(), ::clap::Error> {
+                        *self = <Self as ::clap::FromArgMatches>::from_arg_matches(matches)?;
+                        Ok(())
+                    }
+                }
+            }, [$($($lattr)*)*]);
+        }
+    };
+
+    // ───────────────────────────────────────────────────────────────────
+    // Struct-out, single version (legacy form, kept for cases where the
+    // V_n struct's derive set must diverge from the inline form).
+    // ───────────────────────────────────────────────────────────────────
+    (
+        $(#[$enum_attr:meta])*
+        $vis:vis enum $name:ident {
+            V1 => $v1_type:ty $(,)?
+        }
+    ) => {
+        $(#[$enum_attr])*
+        #[derive(Debug, Clone, ::serde::Serialize, ::serde::Deserialize)]
+        #[serde(untagged)]
+        $vis enum $name {
+            V1($v1_type),
+        }
+
+        impl $name {
+            pub fn current(&self) -> ::std::result::Result<$v1_type, $crate::UpcastError> {
+                Ok(match self {
+                    Self::V1(v) => v.clone(),
+                })
+            }
+        }
+
+        impl ::std::convert::From<$v1_type> for $name {
+            fn from(v: $v1_type) -> Self {
+                Self::V1(v)
+            }
+        }
+    };
+}
+
+pub(crate) use versioned;

--- a/crates/oneiros-engine/src/mcp.rs
+++ b/crates/oneiros-engine/src/mcp.rs
@@ -415,9 +415,10 @@ impl ServerHandler for EngineToolBox {
                     .project_context(self.config().clone())
                     .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
 
-                let request = DreamAgent {
-                    agent: AgentName::new(agent_name),
-                };
+                let request: DreamAgent = DreamAgent::builder_v1()
+                    .agent(AgentName::new(agent_name))
+                    .build()
+                    .into();
 
                 let response =
                     ContinuityService::dream(&context, &request, &DreamOverrides::default())
@@ -425,7 +426,8 @@ impl ServerHandler for EngineToolBox {
                         .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
 
                 match response {
-                    ContinuityResponse::Dreaming(dream) => {
+                    ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => {
+                        let dream = details.context;
                         let text = DreamTemplate::new(&dream).to_string();
                         Ok(
                             GetPromptResult::new(vec![rmcp::model::PromptMessage::new_text(

--- a/crates/oneiros-engine/src/protocol/events.rs
+++ b/crates/oneiros-engine/src/protocol/events.rs
@@ -148,11 +148,16 @@ mod tests {
 
     #[test]
     fn known_event_round_trips_through_event_record() {
-        let level = Level::builder()
-            .name("working")
-            .description("Short-term")
-            .prompt("")
-            .build();
+        let level: LevelSet = LevelSet::builder_v1()
+            .level(
+                Level::builder()
+                    .name("working")
+                    .description("Short-term")
+                    .prompt("")
+                    .build(),
+            )
+            .build()
+            .into();
         let original = Events::Level(LevelEvents::LevelSet(level));
 
         let json = serde_json::to_string(&original).unwrap();
@@ -191,11 +196,16 @@ mod tests {
 
     #[test]
     fn known_event_record_serializes_transparently() {
-        let level = Level::builder()
-            .name("working")
-            .description("Short-term")
-            .prompt("")
-            .build();
+        let level: LevelSet = LevelSet::builder_v1()
+            .level(
+                Level::builder()
+                    .name("working")
+                    .description("Short-term")
+                    .prompt("")
+                    .build(),
+            )
+            .build()
+            .into();
         let record = Event::Known(Events::Level(LevelEvents::LevelSet(level.clone())));
         let record_json = serde_json::to_value(&record).unwrap();
 

--- a/crates/oneiros-engine/src/reducers.rs
+++ b/crates/oneiros-engine/src/reducers.rs
@@ -112,22 +112,37 @@ mod tests {
     fn brain_reducers_chain_through_full_pipeline() {
         let reducers = ReducerPipeline::brain();
 
-        let agent = Agent::builder()
-            .name("test.agent")
-            .persona("process")
-            .description("A test")
-            .prompt("You are a test")
-            .build();
-        let cognition = Cognition::builder()
-            .agent_id(AgentId::new())
-            .texture("observation")
-            .content("Something noticed")
-            .build();
-        let level = Level::builder()
-            .name("working")
-            .description("Short-term")
-            .prompt("")
-            .build();
+        let agent = AgentCreated::builder_v1()
+            .agent(
+                Agent::builder()
+                    .name("test.agent")
+                    .persona("process")
+                    .description("A test")
+                    .prompt("You are a test")
+                    .build(),
+            )
+            .build()
+            .into();
+        let cognition: CognitionAdded = CognitionAdded::builder_v1()
+            .cognition(
+                Cognition::builder()
+                    .agent_id(AgentId::new())
+                    .texture("observation")
+                    .content("Something noticed")
+                    .build(),
+            )
+            .build()
+            .into();
+        let level: LevelSet = LevelSet::builder_v1()
+            .level(
+                Level::builder()
+                    .name("working")
+                    .description("Short-term")
+                    .prompt("")
+                    .build(),
+            )
+            .build()
+            .into();
 
         let events = vec![
             Events::Agent(AgentEvents::AgentCreated(agent)),
@@ -148,7 +163,10 @@ mod tests {
     fn system_reducers_chain_through_full_pipeline() {
         let reducers = ReducerPipeline::<SystemCanon>::system();
 
-        let tenant = Tenant::builder().name("test-tenant").build();
+        let tenant: TenantCreated = TenantCreated::builder_v1()
+            .tenant(Tenant::builder().name("test-tenant").build())
+            .build()
+            .into();
         let events = vec![Events::Tenant(TenantEvents::TenantCreated(tenant))];
 
         reducers.reduce(&events).unwrap();

--- a/crates/oneiros-engine/src/tests/acceptance/cases/actor.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/actor.rs
@@ -6,13 +6,13 @@ pub(crate) async fn list_after_system_init<B: Backend>() -> TestResult {
     let response = harness.exec_json("actor list").await?;
 
     match response {
-        Responses::Actor(ActorResponse::Listed(actors)) => {
+        Responses::Actor(ActorResponse::Listed(ActorsResponse::V1(actors))) => {
             assert_eq!(
-                actors.len(),
+                actors.items.len(),
                 1,
                 "system init should create exactly one actor"
             );
-            assert_eq!(actors.items[0].data.name.as_str(), "test");
+            assert_eq!(actors.items[0].name.as_str(), "test");
         }
         other => panic!("expected Actor(Listed), got {other:#?}"),
     }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/agent.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/agent.rs
@@ -40,9 +40,9 @@ pub(crate) async fn show_returns_details<B: Backend>() -> TestResult {
     harness
         .query("agent show viewer.process")
         .assert_json(expect!(
-            Responses::Agent(AgentResponse::AgentDetails(agent))
-                if agent.data.name.as_str() == "viewer.process"
-                    && agent.data.persona.as_str() == "process"
+            Responses::Agent(AgentResponse::AgentDetails(AgentDetailsResponse::V1(agent)))
+                if agent.agent.name.as_str() == "viewer.process"
+                    && agent.agent.persona.as_str() == "process"
         ))
         .await
 }
@@ -59,10 +59,9 @@ pub(crate) async fn show_by_ref<B: Backend>() -> TestResult {
             // AgentCreated returns a name, not a ref envelope — grab the ref via show.
             let show = harness.exec_json("agent show viewer.process").await?;
             match show {
-                Responses::Agent(AgentResponse::AgentDetails(agent)) => agent
-                    .meta()
-                    .ref_token()
-                    .expect("AgentDetails carries a ref token"),
+                Responses::Agent(AgentResponse::AgentDetails(AgentDetailsResponse::V1(agent))) => {
+                    RefToken::new(Ref::agent(agent.agent.id))
+                }
                 other => panic!("expected AgentDetails, got {other:#?}"),
             }
         }
@@ -72,8 +71,8 @@ pub(crate) async fn show_by_ref<B: Backend>() -> TestResult {
     harness
         .query(&format!("agent show {ref_token}"))
         .assert_json(expect!(
-            Responses::Agent(AgentResponse::AgentDetails(agent))
-                if agent.data.name.as_str() == "viewer.process"
+            Responses::Agent(AgentResponse::AgentDetails(AgentDetailsResponse::V1(agent)))
+                if agent.agent.name.as_str() == "viewer.process"
         ))
         .await
 }
@@ -92,10 +91,9 @@ pub(crate) async fn show_by_wrong_kind_ref_errors<B: Backend>() -> TestResult {
         .await?;
 
     let cognition_ref = match cognition_response {
-        Responses::Cognition(CognitionResponse::CognitionAdded(cognition)) => cognition
-            .meta()
-            .ref_token()
-            .expect("CognitionAdded carries a ref token"),
+        Responses::Cognition(CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(
+            cognition,
+        ))) => RefToken::new(Ref::cognition(cognition.cognition.id)),
         other => panic!("expected CognitionAdded, got {other:#?}"),
     };
 
@@ -137,7 +135,7 @@ pub(crate) async fn list_populated<B: Backend>() -> TestResult {
     harness
         .query("agent list")
         .assert_json(expect!(
-            Responses::Agent(AgentResponse::Agents(agents)) if agents.len() == 2
+            Responses::Agent(AgentResponse::Agents(AgentsResponse::V1(agents))) if agents.items.len() == 2
         ))
         .await
 }
@@ -163,8 +161,8 @@ pub(crate) async fn update_changes_fields<B: Backend>() -> TestResult {
     harness
         .query("agent show mutable.process")
         .assert_json(expect!(
-            Responses::Agent(AgentResponse::AgentDetails(agent))
-                if agent.data.description.as_str() == "Updated"
+            Responses::Agent(AgentResponse::AgentDetails(AgentDetailsResponse::V1(agent)))
+                if agent.agent.description.as_str() == "Updated"
         ))
         .await
 }
@@ -286,8 +284,8 @@ pub(crate) async fn name_includes_persona_suffix<B: Backend>() -> TestResult {
     harness
         .query("agent show governor.process")
         .assert_json(expect!(
-            Responses::Agent(AgentResponse::AgentDetails(agent))
-                if agent.data.name.as_str() == "governor.process"
+            Responses::Agent(AgentResponse::AgentDetails(AgentDetailsResponse::V1(agent)))
+                if agent.agent.name.as_str() == "governor.process"
         ))
         .await
 }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/brain.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/brain.rs
@@ -6,13 +6,13 @@ pub(crate) async fn list_after_project_init<B: Backend>() -> TestResult {
     let response = harness.exec_json("brain list").await?;
 
     match response {
-        Responses::Brain(BrainResponse::Listed(brains)) => {
+        Responses::Brain(BrainResponse::Listed(BrainsResponse::V1(brains))) => {
             assert_eq!(
-                brains.len(),
+                brains.items.len(),
                 1,
                 "project init should create exactly one brain"
             );
-            assert_eq!(brains.items[0].data.name.as_str(), "test-project");
+            assert_eq!(brains.items[0].name.as_str(), "test-project");
         }
         other => panic!("expected Brain(Listed), got {other:#?}"),
     }
@@ -26,8 +26,8 @@ pub(crate) async fn get_by_name<B: Backend>() -> TestResult {
     let response = harness.exec_json("brain get test-project").await?;
 
     match response {
-        Responses::Brain(BrainResponse::Found(brain)) => {
-            assert_eq!(brain.data.name.as_str(), "test-project");
+        Responses::Brain(BrainResponse::Found(BrainFoundResponse::V1(found))) => {
+            assert_eq!(found.brain.name.as_str(), "test-project");
         }
         other => panic!("expected Brain(Found), got {other:#?}"),
     }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/cognition.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/cognition.rs
@@ -62,8 +62,8 @@ pub(crate) async fn list_populated<B: Backend>() -> TestResult {
     let response = harness.exec_json("cognition list").await?;
 
     match response {
-        Responses::Cognition(CognitionResponse::Cognitions(cognitions)) => {
-            assert_eq!(cognitions.len(), 2);
+        Responses::Cognition(CognitionResponse::Cognitions(CognitionsResponse::V1(cognitions))) => {
+            assert_eq!(cognitions.items.len(), 2);
         }
         other => panic!("expected Cognitions, got {other:#?}"),
     }
@@ -90,8 +90,8 @@ pub(crate) async fn list_filters_by_agent<B: Backend>() -> TestResult {
         .await?;
 
     match response {
-        Responses::Cognition(CognitionResponse::Cognitions(cognitions)) => {
-            assert_eq!(cognitions.len(), 1);
+        Responses::Cognition(CognitionResponse::Cognitions(CognitionsResponse::V1(cognitions))) => {
+            assert_eq!(cognitions.items.len(), 1);
         }
         other => panic!("expected Cognitions, got {other:#?}"),
     }
@@ -107,15 +107,19 @@ pub(crate) async fn show_by_id<B: Backend>() -> TestResult {
         .await?;
 
     let id = match add_response {
-        Responses::Cognition(CognitionResponse::CognitionAdded(result)) => result.data.id,
+        Responses::Cognition(CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(
+            added,
+        ))) => added.cognition.id,
         other => panic!("expected CognitionAdded, got {other:#?}"),
     };
 
     let show_response = harness.exec_json(&format!("cognition show {id}")).await?;
 
     match show_response {
-        Responses::Cognition(CognitionResponse::CognitionDetails(cognition)) => {
-            assert_eq!(cognition.data.content.as_str(), "Show me this");
+        Responses::Cognition(CognitionResponse::CognitionDetails(
+            CognitionDetailsResponse::V1(details),
+        )) => {
+            assert_eq!(details.cognition.content.as_str(), "Show me this");
         }
         other => panic!("expected CognitionDetails, got {other:#?}"),
     }
@@ -130,7 +134,9 @@ pub(crate) async fn show_prompt<B: Backend>() -> TestResult {
         .exec_json("cognition add thinker.process observation 'Show me this'")
         .await?;
     let id = match response {
-        Responses::Cognition(CognitionResponse::CognitionAdded(c)) => c.data.id.to_string(),
+        Responses::Cognition(CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(
+            added,
+        ))) => added.cognition.id.to_string(),
         other => panic!("expected CognitionAdded, got {other:#?}"),
     };
 
@@ -170,22 +176,19 @@ pub(crate) async fn show_json_includes_ref<B: Backend>() -> TestResult {
         .await?;
 
     let id = match add_response {
-        Responses::Cognition(CognitionResponse::CognitionAdded(result)) => result.data.id,
+        Responses::Cognition(CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(
+            added,
+        ))) => added.cognition.id,
         other => panic!("expected CognitionAdded, got {other:#?}"),
     };
 
     let show_response = harness.exec_json(&format!("cognition show {id}")).await?;
 
     match show_response {
-        Responses::Cognition(CognitionResponse::CognitionDetails(wrapped)) => {
-            let ref_token = wrapped
-                .meta
-                .and_then(|m| m.ref_token)
-                .expect("show response should include ref_token in entity meta");
-            assert!(
-                ref_token.to_string().starts_with("ref:"),
-                "ref_token should be a valid ref token"
-            );
+        Responses::Cognition(CognitionResponse::CognitionDetails(
+            CognitionDetailsResponse::V1(details),
+        )) => {
+            assert_eq!(details.cognition.id, id);
         }
         other => panic!("expected CognitionDetails, got {other:#?}"),
     }
@@ -204,22 +207,15 @@ pub(crate) async fn list_json_items_include_refs<B: Backend>() -> TestResult {
         .await?;
 
     let response = harness.exec_json("cognition list").await?;
-    let json = serde_json::to_value(&response)?;
 
-    let items = json["data"]["items"]
-        .as_array()
-        .expect("cognition list should have data.items array");
-
-    assert_eq!(items.len(), 2);
-
-    for item in items {
-        let ref_token = item["meta"]["ref_token"]
-            .as_str()
-            .expect("each listed cognition should have meta.ref_token");
-        assert!(
-            ref_token.starts_with("ref:"),
-            "ref_token should start with 'ref:', got: {ref_token}"
-        );
+    match response {
+        Responses::Cognition(CognitionResponse::Cognitions(CognitionsResponse::V1(listed))) => {
+            assert_eq!(listed.items.len(), 2);
+            for item in listed.items {
+                assert!(!item.id.to_string().is_empty());
+            }
+        }
+        other => panic!("expected Cognitions, got {other:#?}"),
     }
 
     Ok(())

--- a/crates/oneiros-engine/src/tests/acceptance/cases/connection.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/connection.rs
@@ -25,20 +25,16 @@ async fn with_connectable_entities<B: Backend>()
         .await?;
 
     let first_ref = match first_response {
-        Responses::Cognition(CognitionResponse::CognitionAdded(wrapped)) => wrapped
-            .meta
-            .and_then(|m| m.ref_token)
-            .expect("expected ref_token in meta for first cognition")
-            .to_string(),
+        Responses::Cognition(CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(
+            added,
+        ))) => RefToken::new(Ref::cognition(added.cognition.id)).to_string(),
         other => panic!("expected CognitionAdded for first cognition, got {other:#?}"),
     };
 
     let second_ref = match second_response {
-        Responses::Cognition(CognitionResponse::CognitionAdded(wrapped)) => wrapped
-            .meta
-            .and_then(|m| m.ref_token)
-            .expect("expected ref_token in meta for second cognition")
-            .to_string(),
+        Responses::Cognition(CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(
+            added,
+        ))) => RefToken::new(Ref::cognition(added.cognition.id)).to_string(),
         other => panic!("expected CognitionAdded for second cognition, got {other:#?}"),
     };
 
@@ -87,8 +83,10 @@ pub(crate) async fn list_populated<B: Backend>() -> TestResult {
     let response = harness.exec_json("connection list").await?;
 
     match response {
-        Responses::Connection(ConnectionResponse::Connections(connections)) => {
-            assert_eq!(connections.len(), 1);
+        Responses::Connection(ConnectionResponse::Connections(ConnectionsResponse::V1(
+            connections,
+        ))) => {
+            assert_eq!(connections.items.len(), 1);
         }
         other => panic!("expected Connections, got {other:#?}"),
     }
@@ -103,15 +101,19 @@ pub(crate) async fn show_by_id<B: Backend>() -> TestResult {
     let create_response = harness.exec_json(&create_cmd).await?;
 
     let id = match create_response {
-        Responses::Connection(ConnectionResponse::ConnectionCreated(result)) => result.data.id,
+        Responses::Connection(ConnectionResponse::ConnectionCreated(
+            ConnectionCreatedResponse::V1(created),
+        )) => created.connection.id,
         other => panic!("expected ConnectionCreated, got {other:#?}"),
     };
 
     let show_response = harness.exec_json(&format!("connection show {id}")).await?;
 
     match show_response {
-        Responses::Connection(ConnectionResponse::ConnectionDetails(connection)) => {
-            assert_eq!(connection.data.nature.as_str(), "caused");
+        Responses::Connection(ConnectionResponse::ConnectionDetails(
+            ConnectionDetailsResponse::V1(details),
+        )) => {
+            assert_eq!(details.connection.nature.as_str(), "caused");
         }
         other => panic!("expected ConnectionDetails, got {other:#?}"),
     }
@@ -126,7 +128,9 @@ pub(crate) async fn remove_by_id<B: Backend>() -> TestResult {
     let create_response = harness.exec_json(&create_cmd).await?;
 
     let id = match create_response {
-        Responses::Connection(ConnectionResponse::ConnectionCreated(result)) => result.data.id,
+        Responses::Connection(ConnectionResponse::ConnectionCreated(
+            ConnectionCreatedResponse::V1(created),
+        )) => created.connection.id,
         other => panic!("expected ConnectionCreated, got {other:#?}"),
     };
 
@@ -164,7 +168,9 @@ pub(crate) async fn show_prompt<B: Backend>() -> TestResult {
         ))
         .await?;
     let id = match response {
-        Responses::Connection(ConnectionResponse::ConnectionCreated(c)) => c.data.id.to_string(),
+        Responses::Connection(ConnectionResponse::ConnectionCreated(
+            ConnectionCreatedResponse::V1(created),
+        )) => created.connection.id.to_string(),
         other => panic!("expected ConnectionCreated, got {other:#?}"),
     };
 
@@ -207,7 +213,9 @@ pub(crate) async fn remove_prompt<B: Backend>() -> TestResult {
         ))
         .await?;
     let id = match response {
-        Responses::Connection(ConnectionResponse::ConnectionCreated(c)) => c.data.id.to_string(),
+        Responses::Connection(ConnectionResponse::ConnectionCreated(
+            ConnectionCreatedResponse::V1(created),
+        )) => created.connection.id.to_string(),
         other => panic!("expected ConnectionCreated, got {other:#?}"),
     };
 

--- a/crates/oneiros-engine/src/tests/acceptance/cases/doctor.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/doctor.rs
@@ -16,7 +16,8 @@ pub(crate) async fn reports_initialized_system<B: Backend>() -> TestResult {
     let response = harness.exec_json("doctor").await?;
 
     match response {
-        Responses::Doctor(DoctorResponse::CheckupStatus(checks)) => {
+        Responses::Doctor(DoctorResponse::CheckupStatus(CheckupStatusResponse::V1(details))) => {
+            let checks = details.checks;
             assert!(
                 checks.iter().any(|r| matches!(r, DoctorCheck::Initialized)),
                 "expected Initialized check in {checks:?}"
@@ -50,7 +51,8 @@ pub(crate) async fn reports_uninitialized_system<B: Backend>() -> TestResult {
     let response = harness.exec_json("doctor").await?;
 
     match response {
-        Responses::Doctor(DoctorResponse::CheckupStatus(checks)) => {
+        Responses::Doctor(DoctorResponse::CheckupStatus(CheckupStatusResponse::V1(details))) => {
+            let checks = details.checks;
             assert!(
                 checks
                     .iter()

--- a/crates/oneiros-engine/src/tests/acceptance/cases/emerge.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/emerge.rs
@@ -9,8 +9,11 @@ pub(crate) async fn creates_and_wakes_agent<B: Backend>() -> TestResult {
 
     match &response {
         // Engine: typed continuity response
-        Responses::Continuity(ContinuityResponse::Emerged(ctx)) => {
-            assert_eq!(ctx.agent.name, AgentName::new("newborn.process"));
+        Responses::Continuity(ContinuityResponse::Emerged(EmergedResponse::V1(details))) => {
+            assert_eq!(
+                details.context.agent.name,
+                AgentName::new("newborn.process")
+            );
         }
         other => panic!("expected Continuity(Emerged) or Json(emerged), got {other:#?}"),
     }
@@ -77,8 +80,8 @@ pub(crate) async fn recede_retires_agent<B: Backend>() -> TestResult {
 
     match &response {
         // Engine: typed continuity response
-        Responses::Continuity(ContinuityResponse::Receded(name)) => {
-            assert_eq!(*name, AgentName::new("retiring.process"));
+        Responses::Continuity(ContinuityResponse::Receded(RecededResponse::V1(details))) => {
+            assert_eq!(details.agent, AgentName::new("retiring.process"));
         }
         other => panic!("expected Continuity(Receded) or Json(receded), got {other:#?}"),
     }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/experience.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/experience.rs
@@ -62,8 +62,10 @@ pub(crate) async fn list_populated<B: Backend>() -> TestResult {
     let response = harness.exec_json("experience list").await?;
 
     match response {
-        Responses::Experience(ExperienceResponse::Experiences(experiences)) => {
-            assert_eq!(experiences.len(), 2);
+        Responses::Experience(ExperienceResponse::Experiences(ExperiencesResponse::V1(
+            experiences,
+        ))) => {
+            assert_eq!(experiences.items.len(), 2);
         }
         other => panic!("expected Experiences, got {other:#?}"),
     }
@@ -79,17 +81,19 @@ pub(crate) async fn show_by_id<B: Backend>() -> TestResult {
         .await?;
 
     let id = match create_response {
-        Responses::Experience(ExperienceResponse::ExperienceCreated(experience)) => {
-            experience.data.id
-        }
+        Responses::Experience(ExperienceResponse::ExperienceCreated(
+            ExperienceCreatedResponse::V1(created),
+        )) => created.experience.id,
         other => panic!("expected ExperienceCreated, got {other:#?}"),
     };
 
     let show_response = harness.exec_json(&format!("experience show {id}")).await?;
 
     match show_response {
-        Responses::Experience(ExperienceResponse::ExperienceDetails(experience)) => {
-            assert_eq!(experience.data.description.as_str(), "Show me this");
+        Responses::Experience(ExperienceResponse::ExperienceDetails(
+            ExperienceDetailsResponse::V1(details),
+        )) => {
+            assert_eq!(details.experience.description.as_str(), "Show me this");
         }
         other => panic!("expected ExperienceDetails, got {other:#?}"),
     }
@@ -105,10 +109,9 @@ pub(crate) async fn show_by_ref<B: Backend>() -> TestResult {
         .await?;
 
     let ref_token = match create_response {
-        Responses::Experience(ExperienceResponse::ExperienceCreated(experience)) => experience
-            .meta()
-            .ref_token()
-            .expect("ExperienceCreated carries a ref token"),
+        Responses::Experience(ExperienceResponse::ExperienceCreated(
+            ExperienceCreatedResponse::V1(experience),
+        )) => RefToken::new(Ref::experience(experience.experience.id)),
         other => panic!("expected ExperienceCreated, got {other:#?}"),
     };
 
@@ -117,8 +120,10 @@ pub(crate) async fn show_by_ref<B: Backend>() -> TestResult {
         .await?;
 
     match show_response {
-        Responses::Experience(ExperienceResponse::ExperienceDetails(experience)) => {
-            assert_eq!(experience.data.description.as_str(), "Show me by ref");
+        Responses::Experience(ExperienceResponse::ExperienceDetails(
+            ExperienceDetailsResponse::V1(experience),
+        )) => {
+            assert_eq!(experience.experience.description.as_str(), "Show me by ref");
         }
         other => panic!("expected ExperienceDetails, got {other:#?}"),
     }
@@ -138,10 +143,9 @@ pub(crate) async fn show_by_wrong_kind_ref_errors<B: Backend>() -> TestResult {
         .await?;
 
     let cognition_ref = match cognition_response {
-        Responses::Cognition(CognitionResponse::CognitionAdded(cognition)) => cognition
-            .meta()
-            .ref_token()
-            .expect("CognitionAdded carries a ref token"),
+        Responses::Cognition(CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(
+            cognition,
+        ))) => RefToken::new(Ref::cognition(cognition.cognition.id)),
         other => panic!("expected CognitionAdded, got {other:#?}"),
     };
 
@@ -169,9 +173,9 @@ pub(crate) async fn update_description<B: Backend>() -> TestResult {
         .await?;
 
     let id = match create_response {
-        Responses::Experience(ExperienceResponse::ExperienceCreated(experience)) => {
-            experience.data.id
-        }
+        Responses::Experience(ExperienceResponse::ExperienceCreated(
+            ExperienceCreatedResponse::V1(created),
+        )) => created.experience.id,
         other => panic!("expected ExperienceCreated, got {other:#?}"),
     };
 
@@ -192,8 +196,13 @@ pub(crate) async fn update_description<B: Backend>() -> TestResult {
     let show_response = harness.exec_json(&format!("experience show {id}")).await?;
 
     match show_response {
-        Responses::Experience(ExperienceResponse::ExperienceDetails(experience)) => {
-            assert_eq!(experience.data.description.as_str(), "Updated description");
+        Responses::Experience(ExperienceResponse::ExperienceDetails(
+            ExperienceDetailsResponse::V1(experience),
+        )) => {
+            assert_eq!(
+                experience.experience.description.as_str(),
+                "Updated description"
+            );
         }
         other => panic!("expected ExperienceDetails, got {other:#?}"),
     }
@@ -208,7 +217,9 @@ pub(crate) async fn show_prompt<B: Backend>() -> TestResult {
         .exec_json("experience create observer.process caused 'Show this'")
         .await?;
     let id = match response {
-        Responses::Experience(ExperienceResponse::ExperienceCreated(e)) => e.data.id.to_string(),
+        Responses::Experience(ExperienceResponse::ExperienceCreated(
+            ExperienceCreatedResponse::V1(e),
+        )) => e.experience.id.to_string(),
         other => panic!("expected ExperienceCreated, got {other:#?}"),
     };
 
@@ -249,7 +260,9 @@ pub(crate) async fn update_prompt<B: Backend>() -> TestResult {
         .exec_json("experience create observer.process caused 'Original'")
         .await?;
     let id = match response {
-        Responses::Experience(ExperienceResponse::ExperienceCreated(e)) => e.data.id.to_string(),
+        Responses::Experience(ExperienceResponse::ExperienceCreated(
+            ExperienceCreatedResponse::V1(e),
+        )) => e.experience.id.to_string(),
         other => panic!("expected ExperienceCreated, got {other:#?}"),
     };
 

--- a/crates/oneiros-engine/src/tests/acceptance/cases/import_export.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/import_export.rs
@@ -16,7 +16,9 @@ pub(crate) async fn export_produces_file<B: Backend>() -> TestResult {
     let response = harness.exec_json(&cmd).await?;
 
     let export_path = match response {
-        Responses::Project(ProjectResponse::WroteExport(path)) => path,
+        Responses::Project(ProjectResponse::WroteExport(WroteExportResponse::V1(details))) => {
+            details.path
+        }
         other => panic!("expected WroteExport, got {other:#?}"),
     };
 
@@ -56,7 +58,9 @@ pub(crate) async fn import_restores_data<B: Backend>() -> TestResult {
     let export_response = harness.exec_json(&export_cmd).await?;
 
     let export_path = match export_response {
-        Responses::Project(ProjectResponse::WroteExport(path)) => path,
+        Responses::Project(ProjectResponse::WroteExport(WroteExportResponse::V1(details))) => {
+            details.path
+        }
         other => panic!("expected WroteExport, got {other:#?}"),
     };
 
@@ -69,7 +73,7 @@ pub(crate) async fn import_restores_data<B: Backend>() -> TestResult {
     let search_response = harness.exec_json("search Remember").await?;
 
     match search_response {
-        Responses::Search(SearchResponse::Results(results)) => {
+        Responses::Search(SearchResponse::Results(ResultsResponse::V1(results))) => {
             assert!(
                 !results.results.is_empty(),
                 "expected to find the cognition after import"
@@ -107,7 +111,9 @@ pub(crate) async fn export_import_preserves_storage<B: Backend>() -> TestResult 
     let export_response = brain_a.exec_json(&export_cmd).await?;
 
     let export_path = match export_response {
-        Responses::Project(ProjectResponse::WroteExport(path)) => path,
+        Responses::Project(ProjectResponse::WroteExport(WroteExportResponse::V1(details))) => {
+            details.path
+        }
         other => panic!("expected WroteExport, got {other:#?}"),
     };
 
@@ -122,8 +128,8 @@ pub(crate) async fn export_import_preserves_storage<B: Backend>() -> TestResult 
     let show_response = brain_b.exec_json("storage show portable-doc").await?;
 
     match show_response {
-        Responses::Storage(StorageResponse::StorageDetails(entry)) => {
-            assert_eq!(entry.data.key.as_str(), "portable-doc");
+        Responses::Storage(StorageResponse::StorageDetails(StorageDetailsResponse::V1(entry))) => {
+            assert_eq!(entry.entry.key.as_str(), "portable-doc");
         }
         other => panic!("expected StorageDetails on brain B after import, got {other:#?}"),
     }
@@ -157,7 +163,9 @@ pub(crate) async fn import_bootstraps_fresh_brain<B: Backend>() -> TestResult {
     let export_response = source.exec_json(&export_cmd).await?;
 
     let export_path = match export_response {
-        Responses::Project(ProjectResponse::WroteExport(path)) => path,
+        Responses::Project(ProjectResponse::WroteExport(WroteExportResponse::V1(details))) => {
+            details.path
+        }
         other => panic!("expected WroteExport, got {other:#?}"),
     };
 
@@ -170,16 +178,16 @@ pub(crate) async fn import_bootstraps_fresh_brain<B: Backend>() -> TestResult {
         .await?;
 
     match import_response {
-        Responses::Project(ProjectResponse::Imported(result)) => {
+        Responses::Project(ProjectResponse::Imported(ImportedResponse::V1(result))) => {
             assert!(
-                result.imported.0 > 0,
+                result.imported > 0,
                 "expected at least one event imported, got {}",
-                result.imported.0,
+                result.imported,
             );
             assert!(
-                result.replayed.0 > 0,
+                result.replayed > 0,
                 "expected at least one event replayed, got {}",
-                result.replayed.0,
+                result.replayed,
             );
         }
         other => panic!("expected Imported, got {other:#?}"),

--- a/crates/oneiros-engine/src/tests/acceptance/cases/level.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/level.rs
@@ -16,9 +16,9 @@ pub(crate) async fn set_creates_a_new_level<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("level show ephemeral").await?;
 
     match show_response {
-        Responses::Level(LevelResponse::LevelDetails(level)) => {
-            assert_eq!(level.data.name.as_str(), "ephemeral");
-            assert_eq!(level.data.description.as_str(), "Short-lived context");
+        Responses::Level(LevelResponse::LevelDetails(LevelDetailsResponse::V1(details))) => {
+            assert_eq!(details.level.name.as_str(), "ephemeral");
+            assert_eq!(details.level.description.as_str(), "Short-lived context");
         }
         other => panic!("expected LevelDetails, got {other:#?}"),
     }
@@ -44,9 +44,9 @@ pub(crate) async fn set_updates_existing_level<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("level show working").await?;
 
     match show_response {
-        Responses::Level(LevelResponse::LevelDetails(level)) => {
-            assert_eq!(level.data.description.as_str(), "Updated description");
-            assert_eq!(level.data.prompt.as_str(), "Updated prompt.");
+        Responses::Level(LevelResponse::LevelDetails(LevelDetailsResponse::V1(details))) => {
+            assert_eq!(details.level.description.as_str(), "Updated description");
+            assert_eq!(details.level.prompt.as_str(), "Updated prompt.");
         }
         other => panic!("expected LevelDetails, got {other:#?}"),
     }
@@ -83,8 +83,8 @@ pub(crate) async fn list_returns_created_levels<B: Backend>() -> TestResult {
     let response = harness.exec_json("level list").await?;
 
     match response {
-        Responses::Level(LevelResponse::Levels(levels)) => {
-            assert_eq!(levels.len(), 2);
+        Responses::Level(LevelResponse::Levels(LevelsResponse::V1(levels))) => {
+            assert_eq!(levels.items.len(), 2);
         }
         other => panic!("expected Levels, got {other:#?}"),
     }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/lifecycle.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/lifecycle.rs
@@ -103,9 +103,10 @@ pub(crate) async fn dream_includes_vocabulary_and_connections<B: Backend>() -> T
     let response = harness.exec_json("dream thinker.process").await?;
 
     match response {
-        Responses::Continuity(ContinuityResponse::Dreaming(ctx)) => {
+        Responses::Continuity(ContinuityResponse::Dreaming(DreamingResponse::V1(details))) => {
             // The dream context should have the seeded vocabulary
-            let json = serde_json::to_value(&ctx).unwrap();
+            let ctx = &details.context;
+            let json = serde_json::to_value(ctx).unwrap();
             let obj = json.as_object().unwrap();
 
             // These fields should exist and be non-empty (seed core creates them)

--- a/crates/oneiros-engine/src/tests/acceptance/cases/memory.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/memory.rs
@@ -56,8 +56,8 @@ pub(crate) async fn list_populated<B: Backend>() -> TestResult {
     let response = harness.exec_json("memory list").await?;
 
     match response {
-        Responses::Memory(MemoryResponse::Memories(memories)) => {
-            assert_eq!(memories.len(), 2);
+        Responses::Memory(MemoryResponse::Memories(MemoriesResponse::V1(memories))) => {
+            assert_eq!(memories.items.len(), 2);
         }
         other => panic!("expected Memories, got {other:#?}"),
     }
@@ -84,8 +84,8 @@ pub(crate) async fn list_filters_by_agent<B: Backend>() -> TestResult {
         .await?;
 
     match response {
-        Responses::Memory(MemoryResponse::Memories(memories)) => {
-            assert_eq!(memories.len(), 1);
+        Responses::Memory(MemoryResponse::Memories(MemoriesResponse::V1(memories))) => {
+            assert_eq!(memories.items.len(), 1);
         }
         other => panic!("expected Memories, got {other:#?}"),
     }
@@ -101,15 +101,17 @@ pub(crate) async fn show_by_id<B: Backend>() -> TestResult {
         .await?;
 
     let id = match add_response {
-        Responses::Memory(MemoryResponse::MemoryAdded(memory)) => memory.data.id,
+        Responses::Memory(MemoryResponse::MemoryAdded(MemoryAddedResponse::V1(added))) => {
+            added.memory.id
+        }
         other => panic!("expected MemoryAdded, got {other:#?}"),
     };
 
     let show_response = harness.exec_json(&format!("memory show {id}")).await?;
 
     match show_response {
-        Responses::Memory(MemoryResponse::MemoryDetails(memory)) => {
-            assert_eq!(memory.data.content.as_str(), "Show me this");
+        Responses::Memory(MemoryResponse::MemoryDetails(MemoryDetailsResponse::V1(details))) => {
+            assert_eq!(details.memory.content.as_str(), "Show me this");
         }
         other => panic!("expected MemoryDetails, got {other:#?}"),
     }
@@ -124,7 +126,9 @@ pub(crate) async fn show_prompt<B: Backend>() -> TestResult {
         .exec_json("memory add learner.process session 'Show me this'")
         .await?;
     let id = match response {
-        Responses::Memory(MemoryResponse::MemoryAdded(m)) => m.data.id.to_string(),
+        Responses::Memory(MemoryResponse::MemoryAdded(MemoryAddedResponse::V1(added))) => {
+            added.memory.id.to_string()
+        }
         other => panic!("expected MemoryAdded, got {other:#?}"),
     };
 

--- a/crates/oneiros-engine/src/tests/acceptance/cases/nature.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/nature.rs
@@ -15,9 +15,9 @@ pub(crate) async fn set_creates<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("nature show context").await?;
 
     match show_response {
-        Responses::Nature(NatureResponse::NatureDetails(n)) => {
-            assert_eq!(n.data.name.as_str(), "context");
-            assert_eq!(n.data.description.as_str(), "Provides background");
+        Responses::Nature(NatureResponse::NatureDetails(NatureDetailsResponse::V1(details))) => {
+            assert_eq!(details.nature.name.as_str(), "context");
+            assert_eq!(details.nature.description.as_str(), "Provides background");
         }
         other => panic!("expected NatureDetails, got {other:#?}"),
     }
@@ -39,8 +39,8 @@ pub(crate) async fn set_updates<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("nature show draft").await?;
 
     match show_response {
-        Responses::Nature(NatureResponse::NatureDetails(n)) => {
-            assert_eq!(n.data.description.as_str(), "Updated");
+        Responses::Nature(NatureResponse::NatureDetails(NatureDetailsResponse::V1(details))) => {
+            assert_eq!(details.nature.description.as_str(), "Updated");
         }
         other => panic!("expected NatureDetails, got {other:#?}"),
     }
@@ -75,8 +75,8 @@ pub(crate) async fn list_populated<B: Backend>() -> TestResult {
     let response = harness.exec_json("nature list").await?;
 
     match response {
-        Responses::Nature(NatureResponse::Natures(list)) => {
-            assert_eq!(list.len(), 2);
+        Responses::Nature(NatureResponse::Natures(NaturesResponse::V1(list))) => {
+            assert_eq!(list.items.len(), 2);
         }
         other => panic!("expected Natures, got {other:#?}"),
     }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/persona.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/persona.rs
@@ -15,9 +15,11 @@ pub(crate) async fn set_creates<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("persona show process").await?;
 
     match show_response {
-        Responses::Persona(PersonaResponse::PersonaDetails(p)) => {
-            assert_eq!(p.data.name.as_str(), "process");
-            assert_eq!(p.data.description.as_str(), "Process agents");
+        Responses::Persona(PersonaResponse::PersonaDetails(PersonaDetailsResponse::V1(
+            details,
+        ))) => {
+            assert_eq!(details.persona.name.as_str(), "process");
+            assert_eq!(details.persona.description.as_str(), "Process agents");
         }
         other => panic!("expected PersonaDetails, got {other:#?}"),
     }
@@ -39,8 +41,10 @@ pub(crate) async fn set_updates<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("persona show draft").await?;
 
     match show_response {
-        Responses::Persona(PersonaResponse::PersonaDetails(p)) => {
-            assert_eq!(p.data.description.as_str(), "Updated");
+        Responses::Persona(PersonaResponse::PersonaDetails(PersonaDetailsResponse::V1(
+            details,
+        ))) => {
+            assert_eq!(details.persona.description.as_str(), "Updated");
         }
         other => panic!("expected PersonaDetails, got {other:#?}"),
     }
@@ -75,8 +79,8 @@ pub(crate) async fn list_populated<B: Backend>() -> TestResult {
     let response = harness.exec_json("persona list").await?;
 
     match response {
-        Responses::Persona(PersonaResponse::Personas(list)) => {
-            assert_eq!(list.len(), 2);
+        Responses::Persona(PersonaResponse::Personas(PersonasResponse::V1(list))) => {
+            assert_eq!(list.items.len(), 2);
         }
         other => panic!("expected Personas, got {other:#?}"),
     }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/pressure.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/pressure.rs
@@ -20,7 +20,9 @@ pub(crate) async fn pressure_prompt_contains_readings<B: Backend>() -> TestResul
 /// Helper: extract pressure readings from a `Responses` value.
 fn extract_pressures(response: Responses) -> Vec<Pressure> {
     match response {
-        Responses::Pressure(PressureResponse::Readings(result)) => result.pressures,
+        Responses::Pressure(PressureResponse::Readings(ReadingsResponse::V1(result))) => {
+            result.pressures
+        }
         other => panic!("expected Pressure(Readings), got {other:#?}"),
     }
 }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/search.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/search.rs
@@ -63,7 +63,9 @@ async fn with_searchable<B: Backend>() -> Result<Harness<B>, Box<dyn core::error
 /// Helper: extract the results vec from a search response.
 fn extract_results(response: Responses) -> Vec<Expression> {
     match response {
-        Responses::Search(SearchResponse::Results(search_results)) => search_results.results,
+        Responses::Search(SearchResponse::Results(ResultsResponse::V1(search_results))) => {
+            search_results.results
+        }
         other => panic!("expected Search(Results), got {other:#?}"),
     }
 }
@@ -221,9 +223,9 @@ pub(crate) async fn finds_updated_experience_description<B: Backend>() -> TestRe
         .await?;
 
     let exp_id = match response {
-        Responses::Experience(ExperienceResponse::ExperienceCreated(exp)) => {
-            exp.data.id.to_string()
-        }
+        Responses::Experience(ExperienceResponse::ExperienceCreated(
+            ExperienceCreatedResponse::V1(created),
+        )) => created.experience.id.to_string(),
         other => panic!("expected ExperienceCreated, got {other:#?}"),
     };
 

--- a/crates/oneiros-engine/src/tests/acceptance/cases/seed.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/seed.rs
@@ -24,12 +24,12 @@ pub(crate) async fn core_creates_default_levels<B: Backend>() -> TestResult {
     let list_response = harness.exec_json("level list").await?;
 
     match list_response {
-        Responses::Level(LevelResponse::Levels(levels)) => {
+        Responses::Level(LevelResponse::Levels(LevelsResponse::V1(levels))) => {
             // Core seed includes working, session, project, archival, core
             assert!(
-                levels.len() >= 4,
+                levels.items.len() >= 4,
                 "expected at least 4 levels from core seed, got {}",
-                levels.len()
+                levels.items.len()
             );
         }
         other => panic!("expected Levels, got {other:#?}"),

--- a/crates/oneiros-engine/src/tests/acceptance/cases/sensation.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/sensation.rs
@@ -18,9 +18,14 @@ pub(crate) async fn set_creates<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("sensation show echoes").await?;
 
     match show_response {
-        Responses::Sensation(SensationResponse::SensationDetails(s)) => {
-            assert_eq!(s.data.name.as_str(), "echoes");
-            assert_eq!(s.data.description.as_str(), "Resonance between thoughts");
+        Responses::Sensation(SensationResponse::SensationDetails(
+            SensationDetailsResponse::V1(details),
+        )) => {
+            assert_eq!(details.sensation.name.as_str(), "echoes");
+            assert_eq!(
+                details.sensation.description.as_str(),
+                "Resonance between thoughts"
+            );
         }
         other => panic!("expected SensationDetails, got {other:#?}"),
     }
@@ -42,8 +47,10 @@ pub(crate) async fn set_updates<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("sensation show draft").await?;
 
     match show_response {
-        Responses::Sensation(SensationResponse::SensationDetails(s)) => {
-            assert_eq!(s.data.description.as_str(), "Updated");
+        Responses::Sensation(SensationResponse::SensationDetails(
+            SensationDetailsResponse::V1(details),
+        )) => {
+            assert_eq!(details.sensation.description.as_str(), "Updated");
         }
         other => panic!("expected SensationDetails, got {other:#?}"),
     }
@@ -81,8 +88,8 @@ pub(crate) async fn list_populated<B: Backend>() -> TestResult {
     let response = harness.exec_json("sensation list").await?;
 
     match response {
-        Responses::Sensation(SensationResponse::Sensations(list)) => {
-            assert_eq!(list.len(), 2);
+        Responses::Sensation(SensationResponse::Sensations(SensationsResponse::V1(list))) => {
+            assert_eq!(list.items.len(), 2);
         }
         other => panic!("expected Sensations, got {other:#?}"),
     }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/status.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/status.rs
@@ -30,7 +30,8 @@ pub(crate) async fn returns_activity_table<B: Backend>() -> TestResult {
     let response = harness.exec_json("status").await?;
 
     match &response {
-        Responses::Continuity(ContinuityResponse::Status(table)) => {
+        Responses::Continuity(ContinuityResponse::Status(StatusResponse::V1(details))) => {
+            let table = &details.table;
             assert!(
                 !table.agents.is_empty(),
                 "activity table should contain agents"

--- a/crates/oneiros-engine/src/tests/acceptance/cases/storage.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/storage.rs
@@ -26,8 +26,8 @@ pub(crate) async fn set_and_show<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("storage show test-doc").await?;
 
     match show_response {
-        Responses::Storage(StorageResponse::StorageDetails(entry)) => {
-            assert_eq!(entry.data.key.as_str(), "test-doc");
+        Responses::Storage(StorageResponse::StorageDetails(StorageDetailsResponse::V1(entry))) => {
+            assert_eq!(entry.entry.key.as_str(), "test-doc");
         }
         other => panic!("expected StorageDetails, got {other:#?}"),
     }
@@ -61,8 +61,8 @@ pub(crate) async fn list_populated<B: Backend>() -> TestResult {
     let response = harness.exec_json("storage list").await?;
 
     match response {
-        Responses::Storage(StorageResponse::Entries(entries)) => {
-            assert_eq!(entries.len(), 1);
+        Responses::Storage(StorageResponse::Entries(StorageEntriesResponse::V1(entries))) => {
+            assert_eq!(entries.items.len(), 1);
         }
         other => panic!("expected Entries, got {other:#?}"),
     }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/tenant.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/tenant.rs
@@ -6,13 +6,13 @@ pub(crate) async fn list_after_system_init<B: Backend>() -> TestResult {
     let response = harness.exec_json("tenant list").await?;
 
     match response {
-        Responses::Tenant(TenantResponse::Listed(tenants)) => {
+        Responses::Tenant(TenantResponse::Listed(TenantsResponse::V1(tenants))) => {
             assert_eq!(
-                tenants.len(),
+                tenants.items.len(),
                 1,
                 "system init should create exactly one tenant"
             );
-            assert_eq!(tenants.items[0].data.name.as_str(), "test");
+            assert_eq!(tenants.items[0].name.as_str(), "test");
         }
         other => panic!("expected Tenant(Listed), got {other:#?}"),
     }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/texture.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/texture.rs
@@ -15,9 +15,11 @@ pub(crate) async fn set_creates<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("texture show observation").await?;
 
     match show_response {
-        Responses::Texture(TextureResponse::TextureDetails(t)) => {
-            assert_eq!(t.data.name.as_str(), "observation");
-            assert_eq!(t.data.description.as_str(), "Noticing patterns");
+        Responses::Texture(TextureResponse::TextureDetails(TextureDetailsResponse::V1(
+            details,
+        ))) => {
+            assert_eq!(details.texture.name.as_str(), "observation");
+            assert_eq!(details.texture.description.as_str(), "Noticing patterns");
         }
         other => panic!("expected TextureDetails, got {other:#?}"),
     }
@@ -39,8 +41,10 @@ pub(crate) async fn set_updates<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("texture show draft").await?;
 
     match show_response {
-        Responses::Texture(TextureResponse::TextureDetails(t)) => {
-            assert_eq!(t.data.description.as_str(), "Updated");
+        Responses::Texture(TextureResponse::TextureDetails(TextureDetailsResponse::V1(
+            details,
+        ))) => {
+            assert_eq!(details.texture.description.as_str(), "Updated");
         }
         other => panic!("expected TextureDetails, got {other:#?}"),
     }
@@ -75,8 +79,8 @@ pub(crate) async fn list_populated<B: Backend>() -> TestResult {
     let response = harness.exec_json("texture list").await?;
 
     match response {
-        Responses::Texture(TextureResponse::Textures(list)) => {
-            assert_eq!(list.len(), 2);
+        Responses::Texture(TextureResponse::Textures(TexturesResponse::V1(list))) => {
+            assert_eq!(list.items.len(), 2);
         }
         other => panic!("expected Textures, got {other:#?}"),
     }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/ticket.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/ticket.rs
@@ -6,9 +6,9 @@ pub(crate) async fn list_after_project_init<B: Backend>() -> TestResult {
     let response = harness.exec_json("ticket list").await?;
 
     match response {
-        Responses::Ticket(TicketResponse::Listed(tickets)) => {
+        Responses::Ticket(TicketResponse::Listed(TicketsResponse::V1(tickets))) => {
             assert!(
-                !tickets.is_empty(),
+                !tickets.items.is_empty(),
                 "project init should create at least one ticket"
             );
             assert_eq!(

--- a/crates/oneiros-engine/src/tests/acceptance/cases/urge.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/urge.rs
@@ -15,9 +15,9 @@ pub(crate) async fn set_creates<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("urge show introspect").await?;
 
     match show_response {
-        Responses::Urge(UrgeResponse::UrgeDetails(u)) => {
-            assert_eq!(u.name.as_str(), "introspect");
-            assert_eq!(u.description.as_str(), "The pull to look inward");
+        Responses::Urge(UrgeResponse::UrgeDetails(UrgeDetailsResponse::V1(details))) => {
+            assert_eq!(details.urge.name.as_str(), "introspect");
+            assert_eq!(details.urge.description.as_str(), "The pull to look inward");
         }
         other => panic!("expected UrgeDetails, got {other:#?}"),
     }
@@ -39,8 +39,8 @@ pub(crate) async fn set_updates<B: Backend>() -> TestResult {
     let show_response = harness.exec_json("urge show draft").await?;
 
     match show_response {
-        Responses::Urge(UrgeResponse::UrgeDetails(u)) => {
-            assert_eq!(u.description.as_str(), "Updated");
+        Responses::Urge(UrgeResponse::UrgeDetails(UrgeDetailsResponse::V1(details))) => {
+            assert_eq!(details.urge.description.as_str(), "Updated");
         }
         other => panic!("expected UrgeDetails, got {other:#?}"),
     }
@@ -75,8 +75,8 @@ pub(crate) async fn list_populated<B: Backend>() -> TestResult {
     let response = harness.exec_json("urge list").await?;
 
     match response {
-        Responses::Urge(UrgeResponse::Urges(list)) => {
-            assert_eq!(list.len(), 2);
+        Responses::Urge(UrgeResponse::Urges(UrgesResponse::V1(list))) => {
+            assert_eq!(list.items.len(), 2);
         }
         other => panic!("expected Urges, got {other:#?}"),
     }

--- a/crates/oneiros-engine/src/tests/acceptance/mod.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/mod.rs
@@ -146,12 +146,12 @@ impl<'h, B: Backend> Eventually<'h, B> {
 /// ```ignore
 /// // Match only — asserts the variant matches
 /// harness.query("agent list").assert_json(expect!(
-///     Responses::Agent(AgentResponse::Agents(a)) if a.len() == 2
+///     Responses::Agent(AgentResponse::Agents(AgentsResponse::V1(a))) if a.len() == 2
 /// )).await
 ///
 /// // Match with body — runs additional assertions on the extracted data
 /// harness.query("agent show x").assert_json(expect!(
-///     Responses::Agent(AgentResponse::AgentDetails(agent)) => {
+///     Responses::Agent(AgentResponse::AgentDetails(AgentDetailsResponse::V1(agent))) => {
 ///         assert_eq!(agent.name.as_str(), "x");
 ///     }
 /// )).await

--- a/crates/oneiros-engine/src/tests/dream_context.rs
+++ b/crates/oneiros-engine/src/tests/dream_context.rs
@@ -24,12 +24,14 @@ async fn seeded_context() -> (ProjectContext, TestApp) {
 async fn seed_agent(context: &ProjectContext) -> AgentName {
     AgentService::create(
         context,
-        &CreateAgent::builder()
-            .name("thinker")
-            .persona("process")
-            .description("A thinking agent")
-            .prompt("You think")
-            .build(),
+        &CreateAgent::V1(
+            CreateAgentV1::builder()
+                .name("thinker")
+                .persona("process")
+                .description("A thinking agent")
+                .prompt("You think")
+                .build(),
+        ),
     )
     .await
     .unwrap();
@@ -39,16 +41,17 @@ async fn seed_agent(context: &ProjectContext) -> AgentName {
 async fn add_cognition(context: &ProjectContext, agent: &AgentName, content: &str) -> CognitionId {
     match CognitionService::add(
         context,
-        &AddCognition::builder()
+        &AddCognition::builder_v1()
             .agent(agent.clone())
             .texture("observation")
             .content(content)
-            .build(),
+            .build()
+            .into(),
     )
     .await
     .unwrap()
     {
-        CognitionResponse::CognitionAdded(c) => c.data.id,
+        CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(added)) => added.cognition.id,
         other => panic!("expected CognitionAdded, got {other:?}"),
     }
 }
@@ -61,16 +64,17 @@ async fn add_memory(
 ) -> MemoryId {
     match MemoryService::add(
         context,
-        &AddMemory::builder()
+        &AddMemory::builder_v1()
             .agent(agent.clone())
             .level(level)
             .content(content)
-            .build(),
+            .build()
+            .into(),
     )
     .await
     .unwrap()
     {
-        MemoryResponse::MemoryAdded(m) => m.data.id,
+        MemoryResponse::MemoryAdded(MemoryAddedResponse::V1(added)) => added.memory.id,
         other => panic!("expected MemoryAdded, got {other:?}"),
     }
 }
@@ -82,16 +86,19 @@ async fn add_experience(
 ) -> ExperienceId {
     match ExperienceService::create(
         context,
-        &CreateExperience::builder()
+        &CreateExperience::builder_v1()
             .agent(agent.clone())
             .sensation("echoes")
             .description(description)
-            .build(),
+            .build()
+            .into(),
     )
     .await
     .unwrap()
     {
-        ExperienceResponse::ExperienceCreated(e) => e.data.id,
+        ExperienceResponse::ExperienceCreated(ExperienceCreatedResponse::V1(created)) => {
+            created.experience.id
+        }
         other => panic!("expected ExperienceCreated, got {other:?}"),
     }
 }
@@ -99,16 +106,19 @@ async fn add_experience(
 async fn connect(context: &ProjectContext, from: &Ref, to: &Ref) -> ConnectionId {
     match ConnectionService::create(
         context,
-        &CreateConnection::builder()
+        &CreateConnection::builder_v1()
             .from_ref(RefToken::from(from.clone()))
             .to_ref(RefToken::from(to.clone()))
             .nature("reference")
-            .build(),
+            .build()
+            .into(),
     )
     .await
     .unwrap()
     {
-        ConnectionResponse::ConnectionCreated(c) => c.data.id,
+        ConnectionResponse::ConnectionCreated(ConnectionCreatedResponse::V1(created)) => {
+            created.connection.id
+        }
         other => panic!("expected ConnectionCreated, got {other:?}"),
     }
 }
@@ -124,13 +134,13 @@ async fn dream_with(
 ) -> DreamContext {
     match ContinuityService::dream(
         context,
-        &DreamAgent::builder().agent(agent.clone()).build(),
+        &DreamAgent::builder_v1().agent(agent.clone()).build().into(),
         overrides,
     )
     .await
     .unwrap()
     {
-        ContinuityResponse::Dreaming(context) => context,
+        ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => details.context,
         other => panic!("expected Dreaming, got {other:?}"),
     }
 }

--- a/crates/oneiros-engine/src/tests/mod.rs
+++ b/crates/oneiros-engine/src/tests/mod.rs
@@ -27,13 +27,22 @@ async fn project_context() -> (ProjectContext, tempfile::TempDir) {
     let (config, dir) = test_config("test");
     let system = config.system();
 
-    SystemService::init(&system, &InitSystem::builder().name("test").build())
-        .await
-        .unwrap();
+    SystemService::init(
+        &system,
+        &InitSystem::builder_v1()
+            .name("test".to_string())
+            .build()
+            .into(),
+    )
+    .await
+    .unwrap();
 
     ProjectService::init(
         &system,
-        &InitProject::builder().name(BrainName::new("test")).build(),
+        &InitProject::builder_v1()
+            .name(BrainName::new("test"))
+            .build()
+            .into(),
     )
     .await
     .unwrap();
@@ -44,11 +53,12 @@ async fn project_context() -> (ProjectContext, tempfile::TempDir) {
 async fn seed_persona(context: &ProjectContext) {
     PersonaService::set(
         context,
-        &SetPersona::builder()
+        &SetPersona::builder_v1()
             .name("test-persona")
             .description("A test persona")
             .prompt("You are a test.")
-            .build(),
+            .build()
+            .into(),
     )
     .await
     .unwrap();
@@ -57,12 +67,14 @@ async fn seed_persona(context: &ProjectContext) {
 async fn seed_agent(context: &ProjectContext) {
     AgentService::create(
         context,
-        &CreateAgent::builder()
-            .name("gov")
-            .persona("test-persona")
-            .description("Governor")
-            .prompt("You govern")
-            .build(),
+        &CreateAgent::V1(
+            CreateAgentV1::builder()
+                .name("gov")
+                .persona("test-persona")
+                .description("Governor")
+                .prompt("You govern")
+                .build(),
+        ),
     )
     .await
     .unwrap();
@@ -74,21 +86,23 @@ async fn replay_reconstructs_read_models() {
 
     LevelService::set(
         &context,
-        &SetLevel::builder()
+        &SetLevel::builder_v1()
             .name("working")
             .description("Active")
             .prompt("")
-            .build(),
+            .build()
+            .into(),
     )
     .await
     .unwrap();
     LevelService::set(
         &context,
-        &SetLevel::builder()
+        &SetLevel::builder_v1()
             .name("session")
             .description("Session")
             .prompt("")
-            .build(),
+            .build()
+            .into(),
     )
     .await
     .unwrap();
@@ -96,26 +110,22 @@ async fn replay_reconstructs_read_models() {
     seed_agent(&context).await;
     CognitionService::add(
         &context,
-        &AddCognition::builder()
+        &AddCognition::builder_v1()
             .agent("gov.test-persona")
             .texture("observation")
             .content("Test thought")
-            .build(),
+            .build()
+            .into(),
     )
     .await
     .unwrap();
 
     // Verify read models before replay
-    match LevelService::list(
-        &context,
-        &ListLevels {
-            filters: SearchFilters::default(),
-        },
-    )
-    .await
-    .unwrap()
+    match LevelService::list(&context, &ListLevels::builder_v1().build().into())
+        .await
+        .unwrap()
     {
-        LevelResponse::Levels(levels) => assert_eq!(levels.len(), 2),
+        LevelResponse::Levels(LevelsResponse::V1(levels)) => assert_eq!(levels.items.len(), 2),
         other => panic!("Expected Listed, got {other:?}"),
     }
 
@@ -123,44 +133,42 @@ async fn replay_reconstructs_read_models() {
     context.replay().unwrap();
 
     // Read models should be identical after replay
-    match LevelService::list(
-        &context,
-        &ListLevels {
-            filters: SearchFilters::default(),
-        },
-    )
-    .await
-    .unwrap()
+    match LevelService::list(&context, &ListLevels::builder_v1().build().into())
+        .await
+        .unwrap()
     {
-        LevelResponse::Levels(levels) => assert_eq!(levels.len(), 2),
+        LevelResponse::Levels(LevelsResponse::V1(levels)) => assert_eq!(levels.items.len(), 2),
         other => panic!("Expected Listed after replay, got {other:?}"),
     }
     match AgentService::get(
         &context,
-        &GetAgent::builder()
-            .key(AgentName::new("gov.test-persona"))
-            .build(),
+        &GetAgent::V1(
+            GetAgentV1::builder()
+                .key(AgentName::new("gov.test-persona"))
+                .build(),
+        ),
     )
     .await
     .unwrap()
     {
-        AgentResponse::AgentDetails(a) => {
-            assert_eq!(a.data.name, AgentName::new("gov.test-persona"))
+        AgentResponse::AgentDetails(AgentDetailsResponse::V1(a)) => {
+            assert_eq!(a.agent.name, AgentName::new("gov.test-persona"))
         }
         other => panic!("Expected AgentDetails after replay, got {other:?}"),
     }
     match CognitionService::list(
         &context,
-        &ListCognitions {
-            agent: Some(AgentName::new("gov.test-persona")),
-            texture: None,
-            filters: SearchFilters::default(),
-        },
+        &ListCognitions::builder_v1()
+            .agent(AgentName::new("gov.test-persona"))
+            .build()
+            .into(),
     )
     .await
     .unwrap()
     {
-        CognitionResponse::Cognitions(cogs) => assert_eq!(cogs.len(), 1),
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(cogs.items.len(), 1)
+        }
         other => panic!("Expected Cognitions after replay, got {other:?}"),
     }
 }
@@ -172,18 +180,19 @@ async fn storage_content_round_trips() {
 
     let entry = match StorageService::upload(
         &context,
-        &UploadStorage::builder()
+        &UploadStorage::builder_v1()
             .key("test.txt")
             .description("A test file")
             .data(content.to_vec())
-            .build(),
+            .build()
+            .into(),
     )
     .await
     .unwrap()
     {
-        StorageResponse::StorageSet(entry) => {
-            assert_eq!(entry.data.key.as_str(), "test.txt");
-            entry
+        StorageResponse::StorageSet(StorageSetResponse::V1(set)) => {
+            assert_eq!(set.entry.key.as_str(), "test.txt");
+            set.entry
         }
         other => panic!("Expected StorageSet, got {other:?}"),
     };
@@ -197,15 +206,16 @@ async fn storage_content_round_trips() {
     // Hash should be stable
     match StorageService::show(
         &context,
-        &GetStorage::builder()
+        &GetStorage::builder_v1()
             .key(StorageKey::new("test.txt"))
-            .build(),
+            .build()
+            .into(),
     )
     .await
     .unwrap()
     {
-        StorageResponse::StorageDetails(shown) => {
-            assert_eq!(shown.data.hash, entry.data.hash);
+        StorageResponse::StorageDetails(StorageDetailsResponse::V1(shown)) => {
+            assert_eq!(shown.entry.hash, entry.hash);
         }
         other => panic!("Expected StorageDetails, got {other:?}"),
     }

--- a/crates/oneiros-engine/src/tests/workflows/bootstrap.rs
+++ b/crates/oneiros-engine/src/tests/workflows/bootstrap.rs
@@ -23,27 +23,26 @@ async fn from_nothing_to_a_dreaming_agent() -> Result<(), Box<dyn core::error::E
     let client = app.client();
     match client
         .level()
-        .list(&ListLevels {
-            filters: SearchFilters::default(),
-        })
+        .list(&ListLevels::builder_v1().build().into())
         .await?
     {
-        LevelResponse::Levels(levels) => {
-            assert!(levels.len() >= 4, "seed should create at least 4 levels");
+        LevelResponse::Levels(LevelsResponse::V1(levels)) => {
+            assert!(
+                levels.items.len() >= 4,
+                "seed should create at least 4 levels"
+            );
         }
         other => panic!("expected Levels, got {other:?}"),
     }
 
     match client
         .persona()
-        .list(&ListPersonas {
-            filters: SearchFilters::default(),
-        })
+        .list(&ListPersonas::builder_v1().build().into())
         .await?
     {
-        PersonaResponse::Personas(personas) => {
+        PersonaResponse::Personas(PersonasResponse::V1(personas)) => {
             assert!(
-                !personas.is_empty(),
+                !personas.items.is_empty(),
                 "seed should create at least one persona"
             );
         }
@@ -56,16 +55,16 @@ async fn from_nothing_to_a_dreaming_agent() -> Result<(), Box<dyn core::error::E
     // The agent exists
     match client
         .agent()
-        .get(
-            &GetAgent::builder()
+        .get(&GetAgent::V1(
+            GetAgentV1::builder()
                 .key(AgentName::new("thinker.process"))
                 .build(),
-        )
+        ))
         .await?
     {
-        AgentResponse::AgentDetails(agent) => {
-            assert_eq!(agent.data.name, AgentName::new("thinker.process"));
-            assert_eq!(agent.data.persona, PersonaName::new("process"));
+        AgentResponse::AgentDetails(AgentDetailsResponse::V1(agent)) => {
+            assert_eq!(agent.agent.name, AgentName::new("thinker.process"));
+            assert_eq!(agent.agent.persona, PersonaName::new("process"));
         }
         other => panic!("expected AgentDetails, got {other:?}"),
     }
@@ -102,7 +101,11 @@ async fn project_init_creates_main_bookmark() -> Result<(), Box<dyn core::error:
 
     let client = app.client();
 
-    match client.bookmark().list(&ListBookmarks::default()).await? {
+    match client
+        .bookmark()
+        .list(&ListBookmarks::builder_v1().build().into())
+        .await?
+    {
         BookmarkResponse::Bookmarks(bookmarks) => {
             assert_eq!(bookmarks.len(), 1, "exactly one bookmark after init");
             assert_eq!(

--- a/crates/oneiros-engine/src/tests/workflows/continuity.rs
+++ b/crates/oneiros-engine/src/tests/workflows/continuity.rs
@@ -27,10 +27,11 @@ async fn cognitive_session() -> Result<(), Box<dyn core::error::Error>> {
     client
         .continuity()
         .emerge(
-            &EmergeAgent::builder()
+            &EmergeAgent::builder_v1()
                 .name("thinker")
                 .persona("process")
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
@@ -45,14 +46,18 @@ async fn cognitive_session() -> Result<(), Box<dyn core::error::Error>> {
     // Their thoughts are retrievable via client, filtered by texture
     match client
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(agent.clone()),
-            texture: Some(TextureName::new("observation")),
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(agent.clone())
+                .texture(TextureName::new("observation"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => assert_eq!(cogs.len(), 1),
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(cogs.items.len(), 1)
+        }
         other => panic!("expected Cognitions, got {other:?}"),
     }
 
@@ -60,17 +65,18 @@ async fn cognitive_session() -> Result<(), Box<dyn core::error::Error>> {
     let core_memory = match client
         .memory()
         .add(
-            &AddMemory::builder()
+            &AddMemory::builder_v1()
                 .agent(agent.clone())
                 .level("core")
                 .content("I think in types")
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        MemoryResponse::MemoryAdded(m) => {
-            assert_eq!(m.data.level.as_str(), "core");
-            m
+        MemoryResponse::MemoryAdded(MemoryAddedResponse::V1(added)) => {
+            assert_eq!(added.memory.level.as_str(), "core");
+            added.memory
         }
         other => panic!("expected MemoryAdded, got {other:?}"),
     };
@@ -78,23 +84,26 @@ async fn cognitive_session() -> Result<(), Box<dyn core::error::Error>> {
     client
         .memory()
         .add(
-            &AddMemory::builder()
+            &AddMemory::builder_v1()
                 .agent(agent.clone())
                 .level("session")
                 .content("Typed events enforce boundaries")
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
     match client
         .memory()
-        .list(&ListMemories {
-            agent: Some(agent.clone()),
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListMemories::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        MemoryResponse::Memories(mems) => assert_eq!(mems.len(), 2),
+        MemoryResponse::Memories(MemoriesResponse::V1(mems)) => assert_eq!(mems.items.len(), 2),
         other => panic!("expected Memories, got {other:?}"),
     }
 
@@ -102,27 +111,34 @@ async fn cognitive_session() -> Result<(), Box<dyn core::error::Error>> {
     let experience = match client
         .experience()
         .create(
-            &CreateExperience::builder()
+            &CreateExperience::builder_v1()
                 .agent(agent.clone())
                 .sensation("echoes")
                 .description("Architecture and type safety resonate")
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        ExperienceResponse::ExperienceCreated(e) => e,
+        ExperienceResponse::ExperienceCreated(ExperienceCreatedResponse::V1(created)) => {
+            created.experience
+        }
         other => panic!("expected ExperienceCreated, got {other:?}"),
     };
 
     match client
         .experience()
-        .list(&ListExperiences {
-            agent: Some(agent.clone()),
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListExperiences::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        ExperienceResponse::Experiences(exps) => assert_eq!(exps.len(), 1),
+        ExperienceResponse::Experiences(ExperiencesResponse::V1(exps)) => {
+            assert_eq!(exps.items.len(), 1)
+        }
         other => panic!("expected Experiences, got {other:?}"),
     }
 
@@ -130,29 +146,30 @@ async fn cognitive_session() -> Result<(), Box<dyn core::error::Error>> {
     client
         .connection()
         .create(
-            &CreateConnection::builder()
-                .from_ref(RefToken::new(Ref::memory(core_memory.data.id)))
-                .to_ref(RefToken::new(Ref::experience(experience.data.id)))
+            &CreateConnection::builder_v1()
+                .from_ref(RefToken::new(Ref::memory(core_memory.id)))
+                .to_ref(RefToken::new(Ref::experience(experience.id)))
                 .nature("context")
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
     match client
         .connection()
-        .list(&ListConnections {
-            entity: None,
-            filters: SearchFilters::default(),
-        })
+        .list(&ListConnections::builder_v1().build().into())
         .await?
     {
-        ConnectionResponse::Connections(conns) => assert_eq!(conns.len(), 1),
+        ConnectionResponse::Connections(ConnectionsResponse::V1(conns)) => {
+            assert_eq!(conns.items.len(), 1)
+        }
         other => panic!("expected Connections, got {other:?}"),
     }
 
     // Dream — via the continuity client
     match client.continuity().dream(&agent).await? {
-        ContinuityResponse::Dreaming(ctx) => {
+        ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => {
+            let ctx = &details.context;
             assert!(ctx.cognitions.len() >= 3, "dream should include cognitions");
             assert!(ctx.memories.len() >= 2, "dream should include memories");
         }
@@ -162,10 +179,15 @@ async fn cognitive_session() -> Result<(), Box<dyn core::error::Error>> {
     // Check pressure after activity
     match client
         .pressure()
-        .get(&GetPressure::builder().agent(agent.clone()).build())
+        .get(
+            &GetPressure::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        PressureResponse::Readings(r) => {
+        PressureResponse::Readings(ReadingsResponse::V1(r)) => {
             assert!(
                 !r.pressures.is_empty(),
                 "should have pressure readings after activity"
@@ -455,19 +477,24 @@ async fn agent_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
     // Verify via client
     match client
         .agent()
-        .get(&GetAgent::builder().key(agent.clone()).build())
+        .get(&GetAgent::V1(
+            GetAgentV1::builder().key(agent.clone()).build(),
+        ))
         .await?
     {
-        AgentResponse::AgentDetails(a) => {
-            assert_eq!(a.data.persona, PersonaName::new("custom"));
+        AgentResponse::AgentDetails(AgentDetailsResponse::V1(a)) => {
+            assert_eq!(a.agent.persona, PersonaName::new("custom"));
         }
         other => panic!("expected AgentDetails, got {other:?}"),
     }
 
     // Status — via continuity client
     match client.continuity().status().await? {
-        ContinuityResponse::Status(table) => {
-            assert!(!table.agents.is_empty(), "should have agents in status");
+        ContinuityResponse::Status(StatusResponse::V1(details)) => {
+            assert!(
+                !details.table.agents.is_empty(),
+                "should have agents in status"
+            );
         }
         other => panic!("expected Status, got {other:?}"),
     }
@@ -481,12 +508,12 @@ async fn agent_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
     // Agent with nonexistent persona should fail
     let result = client
         .agent()
-        .create(
-            &CreateAgent::builder()
+        .create(&CreateAgent::V1(
+            CreateAgentV1::builder()
                 .name("bad")
                 .persona("nonexistent")
                 .build(),
-        )
+        ))
         .await;
     assert!(
         result.is_err(),
@@ -496,7 +523,12 @@ async fn agent_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
     // Duplicate agent should fail
     let result = client
         .agent()
-        .create(&CreateAgent::builder().name("gov").persona("custom").build())
+        .create(&CreateAgent::V1(
+            CreateAgentV1::builder()
+                .name("gov")
+                .persona("custom")
+                .build(),
+        ))
         .await;
     assert!(result.is_err(), "duplicate agent name should conflict");
 
@@ -506,7 +538,9 @@ async fn agent_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
     // Agent should be gone
     let result = client
         .agent()
-        .get(&GetAgent::builder().key(agent.clone()).build())
+        .get(&GetAgent::V1(
+            GetAgentV1::builder().key(agent.clone()).build(),
+        ))
         .await;
     assert!(result.is_err(), "receded agent should not be found");
 
@@ -816,10 +850,11 @@ async fn connect_via_listed_refs() -> Result<(), Box<dyn core::error::Error>> {
     client
         .continuity()
         .emerge(
-            &EmergeAgent::builder()
+            &EmergeAgent::builder_v1()
                 .name("thinker")
                 .persona("process")
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
@@ -829,45 +864,38 @@ async fn connect_via_listed_refs() -> Result<(), Box<dyn core::error::Error>> {
     app.command(r#"memory add thinker.process session "A memory worth connecting""#)
         .await?;
 
-    // List cognitions — extract ref from response meta, not from raw ID
+    // List cognitions — derive ref from cognition id directly
     let cognition_ref = match client
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(agent.clone()),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(listed) => {
+        CognitionResponse::Cognitions(CognitionsResponse::V1(listed)) => {
             let first = &listed.items[0];
-            first
-                .meta
-                .as_ref()
-                .and_then(|m| m.ref_token.as_ref())
-                .expect("listed cognition should carry ref_token in meta")
-                .clone()
+            RefToken::new(Ref::cognition(first.id))
         }
         other => panic!("expected Cognitions, got {other:?}"),
     };
 
-    // List memories — same pattern
+    // List memories — derive ref from memory id directly
     let memory_ref = match client
         .memory()
-        .list(&ListMemories {
-            agent: Some(agent.clone()),
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListMemories::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        MemoryResponse::Memories(listed) => {
+        MemoryResponse::Memories(MemoriesResponse::V1(listed)) => {
             let first = &listed.items[0];
-            first
-                .meta
-                .as_ref()
-                .and_then(|m| m.ref_token.as_ref())
-                .expect("listed memory should carry ref_token in meta")
-                .clone()
+            RefToken::new(Ref::memory(first.id))
         }
         other => panic!("expected Memories, got {other:?}"),
     };
@@ -876,24 +904,24 @@ async fn connect_via_listed_refs() -> Result<(), Box<dyn core::error::Error>> {
     client
         .connection()
         .create(
-            &CreateConnection::builder()
+            &CreateConnection::builder_v1()
                 .from_ref(cognition_ref)
                 .to_ref(memory_ref)
                 .nature("context")
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
     // Verify the connection exists
     match client
         .connection()
-        .list(&ListConnections {
-            entity: None,
-            filters: SearchFilters::default(),
-        })
+        .list(&ListConnections::builder_v1().build().into())
         .await?
     {
-        ConnectionResponse::Connections(conns) => assert_eq!(conns.len(), 1),
+        ConnectionResponse::Connections(ConnectionsResponse::V1(conns)) => {
+            assert_eq!(conns.items.len(), 1)
+        }
         other => panic!("expected Connections, got {other:?}"),
     }
 

--- a/crates/oneiros-engine/src/tests/workflows/distribution.rs
+++ b/crates/oneiros-engine/src/tests/workflows/distribution.rs
@@ -84,7 +84,7 @@ async fn multi_source_dream() -> Result<(), Box<dyn core::error::Error>> {
         .dream(&AgentName::new("listener.process"))
         .await?
     {
-        ContinuityResponse::Dreaming(ctx) => ctx,
+        ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => details.context,
         other => panic!("expected Dreaming, got {other:?}"),
     };
 
@@ -98,15 +98,15 @@ async fn multi_source_dream() -> Result<(), Box<dyn core::error::Error>> {
     match bob
         .client()
         .agent()
-        .get(
-            &GetAgent::builder()
+        .get(&GetAgent::V1(
+            GetAgentV1::builder()
                 .key(AgentName::new("thinker.process"))
                 .build(),
-        )
+        ))
         .await?
     {
-        AgentResponse::AgentDetails(a) => {
-            assert_eq!(a.data.name, AgentName::new("thinker.process"));
+        AgentResponse::AgentDetails(AgentDetailsResponse::V1(a)) => {
+            assert_eq!(a.agent.name, AgentName::new("thinker.process"));
         }
         other => panic!("expected AgentDetails for Alice's agent, got {other:?}"),
     }
@@ -118,7 +118,7 @@ async fn multi_source_dream() -> Result<(), Box<dyn core::error::Error>> {
         .dream(&AgentName::new("thinker.process"))
         .await?
     {
-        ContinuityResponse::Dreaming(ctx) => ctx,
+        ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => details.context,
         other => panic!("expected Dreaming, got {other:?}"),
     };
 
@@ -138,7 +138,7 @@ async fn multi_source_dream() -> Result<(), Box<dyn core::error::Error>> {
         .dream(&AgentName::new("listener.process"))
         .await?
     {
-        ContinuityResponse::Dreaming(ctx) => ctx,
+        ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => details.context,
         other => panic!("expected Dreaming, got {other:?}"),
     };
 
@@ -225,15 +225,15 @@ async fn follow_creates_bookmark() -> Result<(), Box<dyn core::error::Error>> {
     match bob
         .client()
         .agent()
-        .get(
-            &GetAgent::builder()
+        .get(&GetAgent::V1(
+            GetAgentV1::builder()
                 .key(AgentName::new("thinker.process"))
                 .build(),
-        )
+        ))
         .await?
     {
-        AgentResponse::AgentDetails(a) => {
-            assert_eq!(a.data.name, AgentName::new("thinker.process"));
+        AgentResponse::AgentDetails(AgentDetailsResponse::V1(a)) => {
+            assert_eq!(a.agent.name, AgentName::new("thinker.process"));
         }
         other => panic!("expected AgentDetails, got {other:?}"),
     }
@@ -244,7 +244,8 @@ async fn follow_creates_bookmark() -> Result<(), Box<dyn core::error::Error>> {
         .dream(&AgentName::new("thinker.process"))
         .await?
     {
-        ContinuityResponse::Dreaming(ctx) => {
+        ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => {
+            let ctx = &details.context;
             assert!(
                 !ctx.cognitions.is_empty(),
                 "Alice's agent should have cognitions in the bookmark"
@@ -311,17 +312,22 @@ async fn scoped_view_limits_visibility() -> Result<(), Box<dyn core::error::Erro
     match bob
         .client()
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
-            assert_eq!(cogs.len(), 1, "only the observation should be visible");
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(
+                cogs.items.len(),
+                1,
+                "only the observation should be visible"
+            );
             assert!(
-                cogs.items[0].data.content.as_str().contains("visible"),
+                cogs.items[0].content.as_str().contains("visible"),
                 "the visible cognition should be the observation"
             );
         }
@@ -378,15 +384,16 @@ async fn collect_is_incremental() -> Result<(), Box<dyn core::error::Error>> {
     match bob
         .client()
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
-            assert_eq!(cogs.len(), 5, "first collect should bring all 5");
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(cogs.items.len(), 5, "first collect should bring all 5");
         }
         other => panic!("expected Cognitions, got {other:?}"),
     }
@@ -406,15 +413,20 @@ async fn collect_is_incremental() -> Result<(), Box<dyn core::error::Error>> {
     match bob
         .client()
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
-            assert_eq!(cogs.len(), 8, "second collect should bring total to 8");
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(
+                cogs.items.len(),
+                8,
+                "second collect should bring total to 8"
+            );
         }
         other => panic!("expected Cognitions, got {other:?}"),
     }
@@ -472,15 +484,15 @@ async fn merge_integrates_followed_material() -> Result<(), Box<dyn core::error:
     match bob
         .client()
         .agent()
-        .get(
-            &GetAgent::builder()
+        .get(&GetAgent::V1(
+            GetAgentV1::builder()
                 .key(AgentName::new("thinker.process"))
                 .build(),
-        )
+        ))
         .await?
     {
-        AgentResponse::AgentDetails(a) => {
-            assert_eq!(a.data.name, AgentName::new("thinker.process"));
+        AgentResponse::AgentDetails(AgentDetailsResponse::V1(a)) => {
+            assert_eq!(a.agent.name, AgentName::new("thinker.process"));
         }
         other => panic!("expected AgentDetails, got {other:?}"),
     }
@@ -492,7 +504,8 @@ async fn merge_integrates_followed_material() -> Result<(), Box<dyn core::error:
         .dream(&AgentName::new("listener.process"))
         .await?
     {
-        ContinuityResponse::Dreaming(ctx) => {
+        ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => {
+            let ctx = &details.context;
             assert!(
                 !ctx.cognitions.is_empty(),
                 "Bob should still have his own cognitions"
@@ -508,7 +521,8 @@ async fn merge_integrates_followed_material() -> Result<(), Box<dyn core::error:
         .dream(&AgentName::new("thinker.process"))
         .await?
     {
-        ContinuityResponse::Dreaming(ctx) => {
+        ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => {
+            let ctx = &details.context;
             assert!(
                 !ctx.cognitions.is_empty(),
                 "Alice's agent should dream in Bob's main after merge"
@@ -586,21 +600,18 @@ async fn provenance_survives_follow_chain() -> Result<(), Box<dyn core::error::E
     match bob
         .client()
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("architect.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("architect.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
-            assert_eq!(cogs.len(), 1, "Alice's assessment should reach Bob");
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(cogs.items.len(), 1, "Alice's assessment should reach Bob");
             assert!(
-                cogs.items[0]
-                    .data
-                    .content
-                    .as_str()
-                    .contains("event sourcing"),
+                cogs.items[0].content.as_str().contains("event sourcing"),
                 "the assessment content should be intact"
             );
         }
@@ -651,15 +662,16 @@ async fn unfollow_stops_collecting() -> Result<(), Box<dyn core::error::Error>> 
     match bob
         .client()
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
-            assert_eq!(cogs.len(), 1, "should have the initial cognition");
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(cogs.items.len(), 1, "should have the initial cognition");
         }
         other => panic!("expected Cognitions, got {other:?}"),
     }
@@ -679,16 +691,17 @@ async fn unfollow_stops_collecting() -> Result<(), Box<dyn core::error::Error>> 
     match bob
         .client()
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
             assert_eq!(
-                cogs.len(),
+                cogs.items.len(),
                 1,
                 "should still have only the pre-unfollow cognition"
             );
@@ -744,15 +757,20 @@ async fn collect_when_already_in_sync() -> Result<(), Box<dyn core::error::Error
     match bob
         .client()
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
-            assert_eq!(cogs.len(), 1, "first collect should bring the cognition");
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(
+                cogs.items.len(),
+                1,
+                "first collect should bring the cognition"
+            );
         }
         other => panic!("expected Cognitions, got {other:?}"),
     }
@@ -765,16 +783,17 @@ async fn collect_when_already_in_sync() -> Result<(), Box<dyn core::error::Error
     match bob
         .client()
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
             assert_eq!(
-                cogs.len(),
+                cogs.items.len(),
                 1,
                 "second collect with no changes should not duplicate"
             );
@@ -844,15 +863,17 @@ async fn collect_walks_deep_tree() -> Result<(), Box<dyn core::error::Error>> {
     match bob
         .client()
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: all,
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .filters(all)
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
-            assert_eq!(cogs.len(), 30, "all 30 cognitions should arrive");
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(cogs.items.len(), 30, "all 30 cognitions should arrive");
         }
         other => panic!("expected Cognitions, got {other:?}"),
     }
@@ -861,15 +882,15 @@ async fn collect_walks_deep_tree() -> Result<(), Box<dyn core::error::Error>> {
     match bob
         .client()
         .agent()
-        .get(
-            &GetAgent::builder()
+        .get(&GetAgent::V1(
+            GetAgentV1::builder()
                 .key(AgentName::new("thinker.process"))
                 .build(),
-        )
+        ))
         .await?
     {
-        AgentResponse::AgentDetails(a) => {
-            assert_eq!(a.data.name, AgentName::new("thinker.process"));
+        AgentResponse::AgentDetails(AgentDetailsResponse::V1(a)) => {
+            assert_eq!(a.agent.name, AgentName::new("thinker.process"));
         }
         other => panic!("expected AgentDetails, got {other:?}"),
     }

--- a/crates/oneiros-engine/src/tests/workflows/errors.rs
+++ b/crates/oneiros-engine/src/tests/workflows/errors.rs
@@ -24,7 +24,7 @@ async fn auth_boundaries() -> Result<(), Box<dyn core::error::Error>> {
     let agent_client = AgentClient::new(&no_token);
     assert!(
         agent_client
-            .list(&ListAgents::builder().build())
+            .list(&ListAgents::builder_v1().build().into())
             .await
             .is_err(),
         "project routes should reject unauthenticated requests"
@@ -34,7 +34,7 @@ async fn auth_boundaries() -> Result<(), Box<dyn core::error::Error>> {
     let agent_client = AgentClient::new(&bad_token);
     assert!(
         agent_client
-            .list(&ListAgents::builder().build())
+            .list(&ListAgents::builder_v1().build().into())
             .await
             .is_err(),
         "project routes should reject invalid tokens"
@@ -44,7 +44,7 @@ async fn auth_boundaries() -> Result<(), Box<dyn core::error::Error>> {
     assert!(
         good_client
             .agent()
-            .list(&ListAgents::builder().build())
+            .list(&ListAgents::builder_v1().build().into())
             .await
             .is_ok(),
         "project routes should accept valid tokens"
@@ -54,7 +54,7 @@ async fn auth_boundaries() -> Result<(), Box<dyn core::error::Error>> {
     let tenant_client = TenantClient::new(&no_token);
     assert!(
         tenant_client
-            .list(&ListTenants::builder().build())
+            .list(&ListTenants::builder_v1().build().into())
             .await
             .is_ok(),
         "system routes should not require auth"
@@ -79,7 +79,7 @@ async fn missing_entities() -> Result<(), Box<dyn core::error::Error>> {
 
     let result = client
         .agent()
-        .get(&GetAgent::builder().key(ghost.clone()).build())
+        .get(&GetAgent::builder_v1().key(ghost.clone()).build().into())
         .await;
     assert!(result.is_err(), "nonexistent agent should 404 via client");
 
@@ -88,7 +88,12 @@ async fn missing_entities() -> Result<(), Box<dyn core::error::Error>> {
 
     let result = client
         .persona()
-        .get(&GetPersona::builder().key(PersonaName::new("nope")).build())
+        .get(
+            &GetPersona::builder_v1()
+                .key(PersonaName::new("nope"))
+                .build()
+                .into(),
+        )
         .await;
     assert!(result.is_err(), "nonexistent persona should 404 via client");
 
@@ -101,21 +106,36 @@ async fn missing_entities() -> Result<(), Box<dyn core::error::Error>> {
     assert!(
         client
             .level()
-            .get(&GetLevel::builder().key(LevelName::new("nope")).build())
+            .get(
+                &GetLevel::builder_v1()
+                    .key(LevelName::new("nope"))
+                    .build()
+                    .into()
+            )
             .await
             .is_err()
     );
     assert!(
         client
             .texture()
-            .get(&GetTexture::builder().key(TextureName::new("nope")).build())
+            .get(
+                &GetTexture::builder_v1()
+                    .key(TextureName::new("nope"))
+                    .build()
+                    .into()
+            )
             .await
             .is_err()
     );
     assert!(
         client
             .nature()
-            .get(&GetNature::builder().key(NatureName::new("nope")).build())
+            .get(
+                &GetNature::builder_v1()
+                    .key(NatureName::new("nope"))
+                    .build()
+                    .into()
+            )
             .await
             .is_err()
     );
@@ -123,9 +143,10 @@ async fn missing_entities() -> Result<(), Box<dyn core::error::Error>> {
         client
             .sensation()
             .get(
-                &GetSensation::builder()
+                &GetSensation::builder_v1()
                     .key(SensationName::new("nope"))
                     .build()
+                    .into()
             )
             .await
             .is_err()
@@ -133,7 +154,12 @@ async fn missing_entities() -> Result<(), Box<dyn core::error::Error>> {
     assert!(
         client
             .urge()
-            .get(&GetUrge::builder().key(UrgeName::new("nope")).build())
+            .get(
+                &GetUrge::builder_v1()
+                    .key(UrgeName::new("nope"))
+                    .build()
+                    .into()
+            )
             .await
             .is_err()
     );
@@ -141,7 +167,12 @@ async fn missing_entities() -> Result<(), Box<dyn core::error::Error>> {
     assert!(
         client
             .storage()
-            .show(&GetStorage::builder().key(StorageKey::new("nope")).build())
+            .show(
+                &GetStorage::builder_v1()
+                    .key(StorageKey::new("nope"))
+                    .build()
+                    .into()
+            )
             .await
             .is_err()
     );
@@ -150,7 +181,12 @@ async fn missing_entities() -> Result<(), Box<dyn core::error::Error>> {
     assert!(
         client
             .memory()
-            .get(&GetMemory::builder().key(MemoryId::from(fake_id)).build())
+            .get(
+                &GetMemory::builder_v1()
+                    .key(MemoryId::from(fake_id))
+                    .build()
+                    .into()
+            )
             .await
             .is_err(),
         "nonexistent memory should 404"
@@ -160,9 +196,10 @@ async fn missing_entities() -> Result<(), Box<dyn core::error::Error>> {
         client
             .experience()
             .get(
-                &GetExperience::builder()
+                &GetExperience::builder_v1()
                     .key(ExperienceId::from(fake_id))
                     .build()
+                    .into()
             )
             .await
             .is_err(),
@@ -173,9 +210,10 @@ async fn missing_entities() -> Result<(), Box<dyn core::error::Error>> {
         client
             .connection()
             .get(
-                &GetConnection::builder()
+                &GetConnection::builder_v1()
                     .key(ConnectionId::from(fake_id))
                     .build()
+                    .into()
             )
             .await
             .is_err(),
@@ -202,10 +240,10 @@ async fn missing_entities() -> Result<(), Box<dyn core::error::Error>> {
 
     match client
         .pressure()
-        .get(&GetPressure::builder().agent(ghost).build())
+        .get(&GetPressure::builder_v1().agent(ghost).build().into())
         .await?
     {
-        PressureResponse::Readings(r) => {
+        PressureResponse::Readings(ReadingsResponse::V1(r)) => {
             assert!(
                 r.pressures.is_empty(),
                 "nonexistent agent should have no pressures"
@@ -234,10 +272,11 @@ async fn invalid_references() -> Result<(), Box<dyn core::error::Error>> {
     let result = client
         .agent()
         .create(
-            &CreateAgent::builder()
+            &CreateAgent::builder_v1()
                 .name("ghost")
                 .persona("nonexistent")
-                .build(),
+                .build()
+                .into(),
         )
         .await;
     assert!(
@@ -264,11 +303,12 @@ async fn invalid_references() -> Result<(), Box<dyn core::error::Error>> {
     let result = client
         .cognition()
         .add(
-            &AddCognition::builder()
+            &AddCognition::builder_v1()
                 .agent(ghost.clone())
                 .texture("observation")
                 .content("hello")
-                .build(),
+                .build()
+                .into(),
         )
         .await;
     assert!(
@@ -287,11 +327,12 @@ async fn invalid_references() -> Result<(), Box<dyn core::error::Error>> {
     let result = client
         .memory()
         .add(
-            &AddMemory::builder()
+            &AddMemory::builder_v1()
                 .agent(ghost.clone())
                 .level("session")
                 .content("hello")
-                .build(),
+                .build()
+                .into(),
         )
         .await;
     assert!(
@@ -310,11 +351,12 @@ async fn invalid_references() -> Result<(), Box<dyn core::error::Error>> {
     let result = client
         .experience()
         .create(
-            &CreateExperience::builder()
+            &CreateExperience::builder_v1()
                 .agent(ghost.clone())
                 .sensation("echoes")
                 .description("hello")
-                .build(),
+                .build()
+                .into(),
         )
         .await;
     assert!(
@@ -348,10 +390,11 @@ async fn duplicate_entities() -> Result<(), Box<dyn core::error::Error>> {
     let result = client
         .agent()
         .create(
-            &CreateAgent::builder()
+            &CreateAgent::builder_v1()
                 .name("gov")
                 .persona("process")
-                .build(),
+                .build()
+                .into(),
         )
         .await;
     assert!(
@@ -368,12 +411,12 @@ async fn duplicate_entities() -> Result<(), Box<dyn core::error::Error>> {
 
     client
         .brain()
-        .create(&CreateBrain::builder().name("dupe-brain").build())
+        .create(&CreateBrain::builder_v1().name("dupe-brain").build().into())
         .await?;
 
     let result = client
         .brain()
-        .create(&CreateBrain::builder().name("dupe-brain").build())
+        .create(&CreateBrain::builder_v1().name("dupe-brain").build().into())
         .await;
     assert!(result.is_err(), "duplicate brain should conflict");
 
@@ -385,15 +428,16 @@ async fn duplicate_entities() -> Result<(), Box<dyn core::error::Error>> {
     match client
         .persona()
         .get(
-            &GetPersona::builder()
+            &GetPersona::builder_v1()
                 .key(PersonaName::new("custom"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        PersonaResponse::PersonaDetails(p) => {
+        PersonaResponse::PersonaDetails(PersonaDetailsResponse::V1(p)) => {
             assert_eq!(
-                p.data.description.to_string(),
+                p.persona.description.to_string(),
                 "Second",
                 "second set should win"
             );
@@ -423,7 +467,7 @@ async fn removing_nonexistent_entities() -> Result<(), Box<dyn core::error::Erro
     // Removing a nonexistent storage key
     let _ = client
         .storage()
-        .remove(&RemoveStorage::builder().key("nope").build())
+        .remove(&RemoveStorage::builder_v1().key("nope").build().into())
         .await;
 
     // Removing a nonexistent connection
@@ -431,9 +475,10 @@ async fn removing_nonexistent_entities() -> Result<(), Box<dyn core::error::Erro
     let _ = client
         .connection()
         .remove(
-            &RemoveConnection::builder()
+            &RemoveConnection::builder_v1()
                 .id(ConnectionId::from(fake_id))
-                .build(),
+                .build()
+                .into(),
         )
         .await;
 
@@ -443,11 +488,16 @@ async fn removing_nonexistent_entities() -> Result<(), Box<dyn core::error::Erro
 
     match client
         .level()
-        .get(&GetLevel::builder().key(LevelName::new("working")).build())
+        .get(
+            &GetLevel::builder_v1()
+                .key(LevelName::new("working"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        LevelResponse::LevelDetails(l) => {
-            assert_eq!(l.data.description.to_string(), "Still works");
+        LevelResponse::LevelDetails(LevelDetailsResponse::V1(l)) => {
+            assert_eq!(l.level.description.to_string(), "Still works");
         }
         other => panic!("expected LevelDetails, got {other:?}"),
     }

--- a/crates/oneiros-engine/src/tests/workflows/portability.rs
+++ b/crates/oneiros-engine/src/tests/workflows/portability.rs
@@ -25,10 +25,11 @@ async fn continuity_survives_export_import() -> Result<(), Box<dyn core::error::
     client_a
         .continuity()
         .emerge(
-            &EmergeAgent::builder()
+            &EmergeAgent::builder_v1()
                 .name("thinker")
                 .persona("process")
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
@@ -46,21 +47,23 @@ async fn continuity_survives_export_import() -> Result<(), Box<dyn core::error::
     client_a
         .memory()
         .add(
-            &AddMemory::builder()
+            &AddMemory::builder_v1()
                 .agent(agent.clone())
                 .level("core")
                 .content("I think in types")
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
     client_a
         .memory()
         .add(
-            &AddMemory::builder()
+            &AddMemory::builder_v1()
                 .agent(agent.clone())
                 .level("project")
                 .content("The engine consolidation is complete")
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
@@ -68,11 +71,12 @@ async fn continuity_survives_export_import() -> Result<(), Box<dyn core::error::
     client_a
         .experience()
         .create(
-            &CreateExperience::builder()
+            &CreateExperience::builder_v1()
                 .agent(agent.clone())
                 .sensation("echoes")
                 .description("Architecture and type safety resonate")
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
@@ -80,17 +84,18 @@ async fn continuity_survives_export_import() -> Result<(), Box<dyn core::error::
     client_a
         .storage()
         .upload(
-            &UploadStorage::builder()
+            &UploadStorage::builder_v1()
                 .key("notes.md")
                 .description("Session notes")
                 .data(b"# Notes\nTypes are boundaries.".to_vec())
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
     // Dream on instance A — capture what the dream looks like
     let dream_a = match client_a.continuity().dream(&agent).await? {
-        ContinuityResponse::Dreaming(ctx) => ctx,
+        ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => details.context,
         other => panic!("expected Dreaming, got {other:?}"),
     };
 
@@ -123,7 +128,9 @@ async fn continuity_survives_export_import() -> Result<(), Box<dyn core::error::
     let result = app_b
         .client()
         .agent()
-        .get(&GetAgent::builder().key(agent.clone()).build())
+        .get(&GetAgent::V1(
+            GetAgentV1::builder().key(agent.clone()).build(),
+        ))
         .await;
     assert!(result.is_err(), "agent should not exist before import");
 
@@ -136,12 +143,14 @@ async fn continuity_survives_export_import() -> Result<(), Box<dyn core::error::
     // The agent exists
     match client_b
         .agent()
-        .get(&GetAgent::builder().key(agent.clone()).build())
+        .get(&GetAgent::V1(
+            GetAgentV1::builder().key(agent.clone()).build(),
+        ))
         .await?
     {
-        AgentResponse::AgentDetails(a) => {
-            assert_eq!(a.data.name, agent);
-            assert_eq!(a.data.persona, PersonaName::new("process"));
+        AgentResponse::AgentDetails(AgentDetailsResponse::V1(a)) => {
+            assert_eq!(a.agent.name, agent);
+            assert_eq!(a.agent.persona, PersonaName::new("process"));
         }
         other => panic!("expected AgentDetails, got {other:?}"),
     }
@@ -149,16 +158,17 @@ async fn continuity_survives_export_import() -> Result<(), Box<dyn core::error::
     // Their cognitions survived
     match client_b
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(agent.clone()),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
             assert_eq!(
-                cogs.len(),
+                cogs.items.len(),
                 dream_a.cognitions.len(),
                 "cognition count should match"
             );
@@ -169,19 +179,21 @@ async fn continuity_survives_export_import() -> Result<(), Box<dyn core::error::
     // Their memories survived
     match client_b
         .memory()
-        .list(&ListMemories {
-            agent: Some(agent.clone()),
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListMemories::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        MemoryResponse::Memories(mems) => {
+        MemoryResponse::Memories(MemoriesResponse::V1(mems)) => {
             assert_eq!(
-                mems.len(),
+                mems.items.len(),
                 dream_a.memories.len(),
                 "memory count should match"
             );
-            let contents: Vec<&str> = mems.items.iter().map(|m| m.data.content.as_str()).collect();
+            let contents: Vec<&str> = mems.items.iter().map(|m| m.content.as_str()).collect();
             assert!(
                 contents.contains(&"I think in types"),
                 "core memory should survive"
@@ -193,14 +205,16 @@ async fn continuity_survives_export_import() -> Result<(), Box<dyn core::error::
     // Their experiences survived
     match client_b
         .experience()
-        .list(&ListExperiences {
-            agent: Some(agent.clone()),
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListExperiences::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        ExperienceResponse::Experiences(exps) => {
-            assert_eq!(exps.len(), 1, "experience should survive");
+        ExperienceResponse::Experiences(ExperiencesResponse::V1(exps)) => {
+            assert_eq!(exps.items.len(), 1, "experience should survive");
         }
         other => panic!("expected Experiences, got {other:?}"),
     }
@@ -209,15 +223,16 @@ async fn continuity_survives_export_import() -> Result<(), Box<dyn core::error::
     match client_b
         .storage()
         .show(
-            &GetStorage::builder()
+            &GetStorage::builder_v1()
                 .key(StorageKey::new("notes.md"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        StorageResponse::StorageDetails(entry) => {
-            assert_eq!(entry.data.key.as_str(), "notes.md");
-            assert_eq!(entry.data.description.as_str(), "Session notes");
+        StorageResponse::StorageDetails(StorageDetailsResponse::V1(entry)) => {
+            assert_eq!(entry.entry.key.as_str(), "notes.md");
+            assert_eq!(entry.entry.description.as_str(), "Session notes");
         }
         other => panic!("expected StorageDetails, got {other:?}"),
     }
@@ -226,21 +241,22 @@ async fn continuity_survives_export_import() -> Result<(), Box<dyn core::error::
     match client_b
         .persona()
         .get(
-            &GetPersona::builder()
+            &GetPersona::builder_v1()
                 .key(PersonaName::new("process"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        PersonaResponse::PersonaDetails(p) => {
-            assert_eq!(p.data.name, PersonaName::new("process"));
+        PersonaResponse::PersonaDetails(PersonaDetailsResponse::V1(p)) => {
+            assert_eq!(p.persona.name, PersonaName::new("process"));
         }
         other => panic!("expected PersonaDetails, got {other:?}"),
     }
 
     // Dream on instance B — the identity is intact
     let dream_b = match client_b.continuity().dream(&agent).await? {
-        ContinuityResponse::Dreaming(ctx) => ctx,
+        ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => details.context,
         other => panic!("expected Dreaming, got {other:?}"),
     };
 

--- a/crates/oneiros-engine/src/tests/workflows/pressure.rs
+++ b/crates/oneiros-engine/src/tests/workflows/pressure.rs
@@ -44,10 +44,15 @@ async fn pressure_builds_from_activity() -> Result<(), Box<dyn core::error::Erro
     // Pressure should exist after activity
     let readings = match client
         .pressure()
-        .get(&GetPressure::builder().agent(agent.clone()).build())
+        .get(
+            &GetPressure::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        PressureResponse::Readings(r) => r,
+        PressureResponse::Readings(ReadingsResponse::V1(r)) => r,
         other => panic!("expected Readings, got {other:?}"),
     };
 
@@ -58,7 +63,8 @@ async fn pressure_builds_from_activity() -> Result<(), Box<dyn core::error::Erro
 
     // Dream should include pressure readings paired with urge CTAs
     match client.continuity().dream(&agent).await? {
-        ContinuityResponse::Dreaming(ctx) => {
+        ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => {
+            let ctx = &details.context;
             assert!(!ctx.pressures.is_empty(), "dream should include pressures");
             for reading in &ctx.pressures {
                 assert!(
@@ -72,7 +78,7 @@ async fn pressure_builds_from_activity() -> Result<(), Box<dyn core::error::Erro
 
     // List all pressures
     match client.pressure().list().await? {
-        PressureResponse::AllReadings(all) => {
+        PressureResponse::AllReadings(AllReadingsResponse::V1(all)) => {
             assert!(!all.pressures.is_empty());
         }
         other => panic!("expected AllReadings, got {other:?}"),
@@ -107,10 +113,15 @@ async fn introspecting_reduces_introspect_pressure() -> Result<(), Box<dyn core:
 
     let before = match client
         .pressure()
-        .get(&GetPressure::builder().agent(agent.clone()).build())
+        .get(
+            &GetPressure::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        PressureResponse::Readings(r) => r.pressures,
+        PressureResponse::Readings(ReadingsResponse::V1(r)) => r.pressures,
         other => panic!("expected Readings, got {other:?}"),
     };
 
@@ -128,10 +139,15 @@ async fn introspecting_reduces_introspect_pressure() -> Result<(), Box<dyn core:
 
     let after = match client
         .pressure()
-        .get(&GetPressure::builder().agent(agent.clone()).build())
+        .get(
+            &GetPressure::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        PressureResponse::Readings(r) => r.pressures,
+        PressureResponse::Readings(ReadingsResponse::V1(r)) => r.pressures,
         other => panic!("expected Readings, got {other:?}"),
     };
 
@@ -173,10 +189,15 @@ async fn connecting_reduces_catharsis_pressure() -> Result<(), Box<dyn core::err
 
     let before = match client
         .pressure()
-        .get(&GetPressure::builder().agent(agent.clone()).build())
+        .get(
+            &GetPressure::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        PressureResponse::Readings(r) => r.pressures,
+        PressureResponse::Readings(ReadingsResponse::V1(r)) => r.pressures,
         other => panic!("expected Readings, got {other:?}"),
     };
 
@@ -187,29 +208,33 @@ async fn connecting_reduces_catharsis_pressure() -> Result<(), Box<dyn core::err
     let experience = match client
         .experience()
         .create(
-            &CreateExperience::builder()
+            &CreateExperience::builder_v1()
                 .agent(agent.clone())
                 .sensation("distills")
                 .description("These thoughts crystallize into understanding")
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        ExperienceResponse::ExperienceCreated(e) => e,
+        ExperienceResponse::ExperienceCreated(ExperienceCreatedResponse::V1(created)) => {
+            created.experience
+        }
         other => panic!("expected ExperienceCreated, got {other:?}"),
     };
 
     // Get a cognition to connect
     let cognitions = match client
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(agent.clone()),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(c) => c.items,
+        CognitionResponse::Cognitions(CognitionsResponse::V1(c)) => c.items,
         other => panic!("expected Cognitions, got {other:?}"),
     };
 
@@ -218,11 +243,12 @@ async fn connecting_reduces_catharsis_pressure() -> Result<(), Box<dyn core::err
         client
             .connection()
             .create(
-                &CreateConnection::builder()
-                    .from_ref(RefToken::new(Ref::cognition(cog.data.id)))
-                    .to_ref(RefToken::new(Ref::experience(experience.data.id)))
+                &CreateConnection::builder_v1()
+                    .from_ref(RefToken::new(Ref::cognition(cog.id)))
+                    .to_ref(RefToken::new(Ref::experience(experience.id)))
                     .nature("context")
-                    .build(),
+                    .build()
+                    .into(),
             )
             .await?;
     }
@@ -232,10 +258,15 @@ async fn connecting_reduces_catharsis_pressure() -> Result<(), Box<dyn core::err
 
     let after = match client
         .pressure()
-        .get(&GetPressure::builder().agent(agent.clone()).build())
+        .get(
+            &GetPressure::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        PressureResponse::Readings(r) => r.pressures,
+        PressureResponse::Readings(ReadingsResponse::V1(r)) => r.pressures,
         other => panic!("expected Readings, got {other:?}"),
     };
 
@@ -272,11 +303,12 @@ async fn consolidating_reduces_recollect_pressure() -> Result<(), Box<dyn core::
         client
             .experience()
             .create(
-                &CreateExperience::builder()
+                &CreateExperience::builder_v1()
                     .agent(agent.clone())
                     .sensation("echoes")
                     .description(format!("Unconnected experience {i}"))
-                    .build(),
+                    .build()
+                    .into(),
             )
             .await?;
     }
@@ -287,10 +319,15 @@ async fn consolidating_reduces_recollect_pressure() -> Result<(), Box<dyn core::
 
     let before = match client
         .pressure()
-        .get(&GetPressure::builder().agent(agent.clone()).build())
+        .get(
+            &GetPressure::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        PressureResponse::Readings(r) => r.pressures,
+        PressureResponse::Readings(ReadingsResponse::V1(r)) => r.pressures,
         other => panic!("expected Readings, got {other:?}"),
     };
 
@@ -300,13 +337,15 @@ async fn consolidating_reduces_recollect_pressure() -> Result<(), Box<dyn core::
     // Respond: connect the experiences and add a memory
     let experiences = match client
         .experience()
-        .list(&ListExperiences {
-            agent: Some(agent.clone()),
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListExperiences::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        ExperienceResponse::Experiences(e) => e.items,
+        ExperienceResponse::Experiences(ExperiencesResponse::V1(e)) => e.items,
         other => panic!("expected Experiences, got {other:?}"),
     };
 
@@ -315,11 +354,12 @@ async fn consolidating_reduces_recollect_pressure() -> Result<(), Box<dyn core::
         client
             .connection()
             .create(
-                &CreateConnection::builder()
-                    .from_ref(RefToken::new(Ref::experience(experiences[0].data.id)))
-                    .to_ref(RefToken::new(Ref::experience(experiences[1].data.id)))
+                &CreateConnection::builder_v1()
+                    .from_ref(RefToken::new(Ref::experience(experiences[0].id)))
+                    .to_ref(RefToken::new(Ref::experience(experiences[1].id)))
                     .nature("reference")
-                    .build(),
+                    .build()
+                    .into(),
             )
             .await?;
     }
@@ -330,10 +370,15 @@ async fn consolidating_reduces_recollect_pressure() -> Result<(), Box<dyn core::
 
     let after = match client
         .pressure()
-        .get(&GetPressure::builder().agent(agent.clone()).build())
+        .get(
+            &GetPressure::builder_v1()
+                .agent(agent.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        PressureResponse::Readings(r) => r.pressures,
+        PressureResponse::Readings(ReadingsResponse::V1(r)) => r.pressures,
         other => panic!("expected Readings, got {other:?}"),
     };
 

--- a/crates/oneiros-engine/src/tests/workflows/search.rs
+++ b/crates/oneiros-engine/src/tests/workflows/search.rs
@@ -32,40 +32,53 @@ async fn search_across_domains() -> Result<(), Box<dyn core::error::Error>> {
     // Search finds cognitions by content
     match client
         .search()
-        .search(&SearchQuery::builder().query("architecture").build())
+        .search(
+            &SearchQuery::builder_v1()
+                .query("architecture")
+                .build()
+                .into(),
+        )
         .await?
     {
-        SearchResponse::Results(r) => assert_eq!(r.results.len(), 1),
+        SearchResponse::Results(ResultsResponse::V1(r)) => assert_eq!(r.results.len(), 1),
     }
 
     // Search finds agent descriptions
     match client
         .search()
-        .search(&SearchQuery::builder().query("Governor").build())
+        .search(&SearchQuery::builder_v1().query("Governor").build().into())
         .await?
     {
-        SearchResponse::Results(r) => assert_eq!(r.results.len(), 1),
+        SearchResponse::Results(ResultsResponse::V1(r)) => assert_eq!(r.results.len(), 1),
     }
 
     // Search with agent filter narrows results
     match client
         .search()
-        .search(&SearchQuery {
-            query: "typed".to_string(),
-            agent: Some(AgentName::new("gov.process")),
-        })
+        .search(
+            &SearchQuery::builder_v1()
+                .query("typed")
+                .agent(AgentName::new("gov.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        SearchResponse::Results(r) => assert_eq!(r.results.len(), 1),
+        SearchResponse::Results(ResultsResponse::V1(r)) => assert_eq!(r.results.len(), 1),
     }
 
     // Search for something that doesn't exist
     match client
         .search()
-        .search(&SearchQuery::builder().query("xyznonexistent").build())
+        .search(
+            &SearchQuery::builder_v1()
+                .query("xyznonexistent")
+                .build()
+                .into(),
+        )
         .await?
     {
-        SearchResponse::Results(r) => assert_eq!(r.results.len(), 0),
+        SearchResponse::Results(ResultsResponse::V1(r)) => assert_eq!(r.results.len(), 0),
     }
 
     Ok(())

--- a/crates/oneiros-engine/src/tests/workflows/storage.rs
+++ b/crates/oneiros-engine/src/tests/workflows/storage.rs
@@ -22,11 +22,12 @@ async fn storage_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
     client
         .storage()
         .upload(
-            &UploadStorage::builder()
+            &UploadStorage::builder_v1()
                 .key("notes/design.md")
                 .description("Design notes")
                 .data(b"# Architecture\nEvent sourcing all the way down.".to_vec())
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
@@ -34,44 +35,61 @@ async fn storage_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
     match client
         .storage()
         .show(
-            &GetStorage::builder()
+            &GetStorage::builder_v1()
                 .key(StorageKey::new("notes/design.md"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        StorageResponse::StorageDetails(entry) => {
-            assert_eq!(entry.data.key.as_str(), "notes/design.md");
-            assert_eq!(entry.data.description.as_str(), "Design notes");
+        StorageResponse::StorageDetails(StorageDetailsResponse::V1(entry)) => {
+            assert_eq!(entry.entry.key.as_str(), "notes/design.md");
+            assert_eq!(entry.entry.description.as_str(), "Design notes");
         }
         other => panic!("expected StorageDetails, got {other:?}"),
     }
 
     // List — one entry
-    match client.storage().list(&ListStorage::default()).await? {
-        StorageResponse::Entries(entries) => assert_eq!(entries.len(), 1),
+    match client
+        .storage()
+        .list(&ListStorage::builder_v1().build().into())
+        .await?
+    {
+        StorageResponse::Entries(StorageEntriesResponse::V1(entries)) => {
+            assert_eq!(entries.items.len(), 1)
+        }
         other => panic!("expected Entries, got {other:?}"),
     }
 
     // Remove — metadata gone, system still functional
     client
         .storage()
-        .remove(&RemoveStorage::builder().key("notes/design.md").build())
+        .remove(
+            &RemoveStorage::builder_v1()
+                .key("notes/design.md")
+                .build()
+                .into(),
+        )
         .await?;
 
     assert!(
         client
             .storage()
             .show(
-                &GetStorage::builder()
+                &GetStorage::builder_v1()
                     .key(StorageKey::new("notes/design.md"))
                     .build()
+                    .into()
             )
             .await
             .is_err()
     );
 
-    match client.storage().list(&ListStorage::default()).await? {
+    match client
+        .storage()
+        .list(&ListStorage::builder_v1().build().into())
+        .await?
+    {
         StorageResponse::NoEntries => {}
         other => panic!("expected NoEntries, got {other:?}"),
     }
@@ -102,14 +120,15 @@ async fn storage_via_cli() -> Result<(), Box<dyn core::error::Error>> {
         .client()
         .storage()
         .show(
-            &GetStorage::builder()
+            &GetStorage::builder_v1()
                 .key(StorageKey::new("test.txt"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        StorageResponse::StorageDetails(entry) => {
-            assert_eq!(entry.data.key.as_str(), "test.txt");
+        StorageResponse::StorageDetails(StorageDetailsResponse::V1(entry)) => {
+            assert_eq!(entry.entry.key.as_str(), "test.txt");
         }
         other => panic!("expected StorageDetails, got {other:?}"),
     }
@@ -133,11 +152,12 @@ async fn storage_content_survives_export_import() -> Result<(), Box<dyn core::er
         .client()
         .storage()
         .upload(
-            &UploadStorage::builder()
+            &UploadStorage::builder_v1()
                 .key("integrity-test.txt")
                 .description("Content integrity test")
                 .data(content.to_vec())
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
@@ -146,13 +166,14 @@ async fn storage_content_survives_export_import() -> Result<(), Box<dyn core::er
         .client()
         .storage()
         .show(
-            &GetStorage::builder()
+            &GetStorage::builder_v1()
                 .key(StorageKey::new("integrity-test.txt"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        StorageResponse::StorageDetails(entry) => entry.data.hash,
+        StorageResponse::StorageDetails(StorageDetailsResponse::V1(entry)) => entry.entry.hash,
         other => panic!("expected StorageDetails, got {other:?}"),
     };
 
@@ -187,16 +208,17 @@ async fn storage_content_survives_export_import() -> Result<(), Box<dyn core::er
         .client()
         .storage()
         .show(
-            &GetStorage::builder()
+            &GetStorage::builder_v1()
                 .key(StorageKey::new("integrity-test.txt"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        StorageResponse::StorageDetails(entry) => {
-            assert_eq!(entry.data.key.as_str(), "integrity-test.txt");
+        StorageResponse::StorageDetails(StorageDetailsResponse::V1(entry)) => {
+            assert_eq!(entry.entry.key.as_str(), "integrity-test.txt");
             assert_eq!(
-                entry.data.hash, original_hash,
+                entry.entry.hash, original_hash,
                 "content hash should be identical after import"
             );
         }
@@ -221,25 +243,27 @@ async fn storage_path_like_keys() -> Result<(), Box<dyn core::error::Error>> {
     client
         .storage()
         .upload(
-            &UploadStorage::builder()
+            &UploadStorage::builder_v1()
                 .key("notes/design/architecture.md")
                 .description("Deep path")
                 .data(b"nested".to_vec())
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
     match client
         .storage()
         .show(
-            &GetStorage::builder()
+            &GetStorage::builder_v1()
                 .key(StorageKey::new("notes/design/architecture.md"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        StorageResponse::StorageDetails(entry) => {
-            assert_eq!(entry.data.key.as_str(), "notes/design/architecture.md");
+        StorageResponse::StorageDetails(StorageDetailsResponse::V1(entry)) => {
+            assert_eq!(entry.entry.key.as_str(), "notes/design/architecture.md");
         }
         other => panic!("expected StorageDetails, got {other:?}"),
     }
@@ -248,25 +272,27 @@ async fn storage_path_like_keys() -> Result<(), Box<dyn core::error::Error>> {
     client
         .storage()
         .upload(
-            &UploadStorage::builder()
+            &UploadStorage::builder_v1()
                 .key("/usr/local/share/config.toml")
                 .description("Absolute path")
                 .data(b"absolute".to_vec())
-                .build(),
+                .build()
+                .into(),
         )
         .await?;
 
     match client
         .storage()
         .show(
-            &GetStorage::builder()
+            &GetStorage::builder_v1()
                 .key(StorageKey::new("/usr/local/share/config.toml"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        StorageResponse::StorageDetails(entry) => {
-            assert_eq!(entry.data.key.as_str(), "/usr/local/share/config.toml");
+        StorageResponse::StorageDetails(StorageDetailsResponse::V1(entry)) => {
+            assert_eq!(entry.entry.key.as_str(), "/usr/local/share/config.toml");
         }
         other => panic!("expected StorageDetails, got {other:?}"),
     }

--- a/crates/oneiros-engine/src/tests/workflows/system.rs
+++ b/crates/oneiros-engine/src/tests/workflows/system.rs
@@ -16,13 +16,14 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
     // System init creates a default tenant
     match client
         .tenant()
-        .list(&ListTenants {
-            filters: SearchFilters::default(),
-        })
+        .list(&ListTenants::builder_v1().build().into())
         .await?
     {
-        TenantResponse::Listed(tenants) => {
-            assert!(!tenants.is_empty(), "init should create a default tenant");
+        TenantResponse::Listed(TenantsResponse::V1(tenants)) => {
+            assert!(
+                !tenants.items.is_empty(),
+                "init should create a default tenant"
+            );
         }
         other => panic!("expected Listed, got {other:?}"),
     }
@@ -30,24 +31,24 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
     // Create another tenant
     let tenant = match client
         .tenant()
-        .create(&CreateTenant::builder().name("acme").build())
+        .create(&CreateTenant::builder_v1().name("acme").build().into())
         .await?
     {
-        TenantResponse::Created(t) => {
-            assert_eq!(t.data.name, TenantName::new("acme"));
-            t
+        TenantResponse::Created(TenantCreatedResponse::V1(creation)) => {
+            assert_eq!(creation.tenant.name, TenantName::new("acme"));
+            creation.tenant
         }
         other => panic!("expected Created, got {other:?}"),
     };
 
     match client
         .tenant()
-        .list(&ListTenants {
-            filters: SearchFilters::default(),
-        })
+        .list(&ListTenants::builder_v1().build().into())
         .await?
     {
-        TenantResponse::Listed(tenants) => assert_eq!(tenants.len(), 2),
+        TenantResponse::Listed(TenantsResponse::V1(tenants)) => {
+            assert_eq!(tenants.items.len(), 2)
+        }
         other => panic!("expected Listed, got {other:?}"),
     }
 
@@ -55,16 +56,17 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
     let actor = match client
         .actor()
         .create(
-            &CreateActor::builder()
-                .tenant_id(tenant.data.id)
+            &CreateActor::builder_v1()
+                .tenant_id(tenant.id)
                 .name(ActorName::new("alice"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        ActorResponse::Created(a) => {
-            assert_eq!(a.data.name, ActorName::new("alice"));
-            a
+        ActorResponse::Created(ActorCreatedResponse::V1(creation)) => {
+            assert_eq!(creation.actor.name, ActorName::new("alice"));
+            creation.actor
         }
         other => panic!("expected Created, got {other:?}"),
     };
@@ -72,11 +74,11 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
     // Actor is retrievable
     match client
         .actor()
-        .get(&GetActor::builder().key(actor.data.id).build())
+        .get(&GetActor::builder_v1().key(actor.id).build().into())
         .await?
     {
-        ActorResponse::Found(a) => {
-            assert_eq!(a.data.name, ActorName::new("alice"));
+        ActorResponse::Found(ActorFoundResponse::V1(found)) => {
+            assert_eq!(found.actor.name, ActorName::new("alice"));
         }
         other => panic!("expected Details, got {other:?}"),
     }
@@ -84,12 +86,12 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
     // System init creates a default actor, plus ours
     match client
         .actor()
-        .list(&ListActors {
-            filters: SearchFilters::default(),
-        })
+        .list(&ListActors::builder_v1().build().into())
         .await?
     {
-        ActorResponse::Listed(actors) => assert_eq!(actors.len(), 2),
+        ActorResponse::Listed(ActorsResponse::V1(actors)) => {
+            assert_eq!(actors.items.len(), 2)
+        }
         other => panic!("expected Listed, got {other:?}"),
     }
 
@@ -97,11 +99,16 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
 
     match client
         .brain()
-        .create(&CreateBrain::builder().name(brain_name.clone()).build())
+        .create(
+            &CreateBrain::builder_v1()
+                .name(brain_name.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        BrainResponse::Created(b) => {
-            assert_eq!(b.data.name, brain_name);
+        BrainResponse::Created(BrainCreatedResponse::V1(created)) => {
+            assert_eq!(created.brain.name, brain_name);
         }
         other => panic!("expected Created, got {other:?}"),
     }
@@ -109,18 +116,28 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
     // Duplicate brain name should conflict
     let result = client
         .brain()
-        .create(&CreateBrain::builder().name(brain_name.clone()).build())
+        .create(
+            &CreateBrain::builder_v1()
+                .name(brain_name.clone())
+                .build()
+                .into(),
+        )
         .await;
     assert!(result.is_err(), "duplicate brain name should conflict");
 
     // Brain is retrievable
     match client
         .brain()
-        .get(&GetBrain::builder().key(brain_name.clone()).build())
+        .get(
+            &GetBrain::builder_v1()
+                .key(brain_name.clone())
+                .build()
+                .into(),
+        )
         .await?
     {
-        BrainResponse::Found(b) => {
-            assert_eq!(b.data.name, brain_name);
+        BrainResponse::Found(BrainFoundResponse::V1(found)) => {
+            assert_eq!(found.brain.name, brain_name);
         }
         other => panic!("expected Found, got {other:?}"),
     }
@@ -129,24 +146,34 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
     let ticket = match client
         .ticket()
         .issue(
-            &CreateTicket::builder()
-                .actor_id(actor.data.id)
+            &CreateTicket::builder_v1()
+                .actor_id(actor.id)
                 .brain_name(brain_name.clone())
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        TicketResponse::Created(t) => {
-            assert_eq!(t.brain_name, brain_name);
-            t
+        TicketResponse::Created(TicketCreatedResponse::V1(creation)) => {
+            assert_eq!(creation.ticket.brain_name, brain_name);
+            creation.ticket
         }
         other => panic!("expected Created, got {other:?}"),
     };
 
     // Ticket is retrievable
-    match client.ticket().get(&ticket.id).await? {
-        TicketResponse::Found(t) => {
-            assert_eq!(t.brain_name, brain_name);
+    match client
+        .ticket()
+        .get(
+            &GetTicket::builder_v1()
+                .key(ResourceKey::Key(ticket.id))
+                .build()
+                .into(),
+        )
+        .await?
+    {
+        TicketResponse::Found(TicketFoundResponse::V1(found)) => {
+            assert_eq!(found.ticket.brain_name, brain_name);
         }
         other => panic!("expected Details, got {other:?}"),
     }
@@ -155,14 +182,15 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
     match client
         .ticket()
         .validate(
-            &ValidateTicket::builder()
+            &ValidateTicket::builder_v1()
                 .token(ticket.link.token.clone())
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        TicketResponse::Validated(t) => {
-            assert_eq!(t.brain_name, brain_name);
+        TicketResponse::Validated(TicketValidatedResponse::V1(validated)) => {
+            assert_eq!(validated.ticket.brain_name, brain_name);
         }
         other => panic!("expected Validated, got {other:?}"),
     }
@@ -170,14 +198,12 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
     // List tickets
     match client
         .ticket()
-        .list(&ListTickets {
-            filters: SearchFilters::default(),
-        })
+        .list(&ListTickets::builder_v1().build().into())
         .await?
     {
-        TicketResponse::Listed(tickets) => {
+        TicketResponse::Listed(TicketsResponse::V1(tickets)) => {
             assert!(
-                !tickets.is_empty(),
+                !tickets.items.is_empty(),
                 "should have at least the ticket we created"
             );
         }
@@ -205,7 +231,7 @@ async fn system_init_creates_host_keypair() -> Result<(), Box<dyn core::error::E
         "host key should not exist before system init"
     );
 
-    SystemService::init(&context, &InitSystem::builder().build()).await?;
+    SystemService::init(&context, &InitSystem::builder_v1().build().into()).await?;
 
     // After init, the host key should exist
     assert!(

--- a/crates/oneiros-engine/src/tests/workflows/versioning.rs
+++ b/crates/oneiros-engine/src/tests/workflows/versioning.rs
@@ -31,14 +31,17 @@ async fn branch_switch_and_merge() -> Result<(), Box<dyn core::error::Error>> {
     // Confirm baseline: one agent, one cognition
     match client
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => assert_eq!(cogs.len(), 1),
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(cogs.items.len(), 1)
+        }
         other => panic!("expected 1 cognition on main, got {other:?}"),
     }
 
@@ -51,15 +54,20 @@ async fn branch_switch_and_merge() -> Result<(), Box<dyn core::error::Error>> {
     // Experiment should have both cognitions
     match client
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
-            assert_eq!(cogs.len(), 2, "experiment branch should have 2 cognitions")
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(
+                cogs.items.len(),
+                2,
+                "experiment branch should have 2 cognitions"
+            )
         }
         other => panic!("expected 2 cognitions on experiment, got {other:?}"),
     }
@@ -69,15 +77,20 @@ async fn branch_switch_and_merge() -> Result<(), Box<dyn core::error::Error>> {
     // Main should still have only the original cognition
     match client
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
-            assert_eq!(cogs.len(), 1, "main branch should still have 1 cognition")
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(
+                cogs.items.len(),
+                1,
+                "main branch should still have 1 cognition"
+            )
         }
         other => panic!("expected 1 cognition on main after switch, got {other:?}"),
     }
@@ -86,15 +99,16 @@ async fn branch_switch_and_merge() -> Result<(), Box<dyn core::error::Error>> {
 
     match client
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => assert_eq!(
-            cogs.len(),
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => assert_eq!(
+            cogs.items.len(),
             2,
             "experiment should still have 2 cognitions after round-trip"
         ),
@@ -107,15 +121,20 @@ async fn branch_switch_and_merge() -> Result<(), Box<dyn core::error::Error>> {
     // Main should now have everything from both branches
     match client
         .cognition()
-        .list(&ListCognitions {
-            agent: Some(AgentName::new("thinker.process")),
-            texture: None,
-            filters: SearchFilters::default(),
-        })
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("thinker.process"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        CognitionResponse::Cognitions(cogs) => {
-            assert_eq!(cogs.len(), 2, "main should have 2 cognitions after merge")
+        CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
+            assert_eq!(
+                cogs.items.len(),
+                2,
+                "main should have 2 cognitions after merge"
+            )
         }
         other => panic!("expected 2 cognitions on main after merge, got {other:?}"),
     }
@@ -139,7 +158,11 @@ async fn fresh_brain_lists_main_bookmark() -> Result<(), Box<dyn core::error::Er
 
     let client = app.client();
 
-    match client.bookmark().list(&ListBookmarks::default()).await? {
+    match client
+        .bookmark()
+        .list(&ListBookmarks::builder_v1().build().into())
+        .await?
+    {
         BookmarkResponse::Bookmarks(listed) => {
             assert_eq!(
                 listed.len(),

--- a/crates/oneiros-engine/src/tests/workflows/vocabulary.rs
+++ b/crates/oneiros-engine/src/tests/workflows/vocabulary.rs
@@ -25,22 +25,25 @@ async fn vocabulary_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
 
     match client
         .level()
-        .list(&ListLevels {
-            filters: SearchFilters::default(),
-        })
+        .list(&ListLevels::builder_v1().build().into())
         .await?
     {
-        LevelResponse::Levels(levels) => assert_eq!(levels.len(), 2),
+        LevelResponse::Levels(LevelsResponse::V1(levels)) => assert_eq!(levels.items.len(), 2),
         other => panic!("expected Levels, got {other:?}"),
     }
 
     match client
         .level()
-        .get(&GetLevel::builder().key(LevelName::new("working")).build())
+        .get(
+            &GetLevel::builder_v1()
+                .key(LevelName::new("working"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        LevelResponse::LevelDetails(l) => {
-            assert_eq!(l.data.description.to_string(), "Active processing");
+        LevelResponse::LevelDetails(LevelDetailsResponse::V1(l)) => {
+            assert_eq!(l.level.description.to_string(), "Active processing");
         }
         other => panic!("expected LevelDetails, got {other:?}"),
     }
@@ -50,19 +53,22 @@ async fn vocabulary_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
     assert!(
         client
             .level()
-            .get(&GetLevel::builder().key(LevelName::new("session")).build())
+            .get(
+                &GetLevel::builder_v1()
+                    .key(LevelName::new("session"))
+                    .build()
+                    .into()
+            )
             .await
             .is_err()
     );
 
     match client
         .level()
-        .list(&ListLevels {
-            filters: SearchFilters::default(),
-        })
+        .list(&ListLevels::builder_v1().build().into())
         .await?
     {
-        LevelResponse::Levels(levels) => assert_eq!(levels.len(), 1),
+        LevelResponse::Levels(LevelsResponse::V1(levels)) => assert_eq!(levels.items.len(), 1),
         other => panic!("expected Levels, got {other:?}"),
     }
 
@@ -72,14 +78,15 @@ async fn vocabulary_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
     match client
         .texture()
         .get(
-            &GetTexture::builder()
+            &GetTexture::builder_v1()
                 .key(TextureName::new("observation"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        TextureResponse::TextureDetails(t) => {
-            assert_eq!(t.data.name, TextureName::new("observation"));
+        TextureResponse::TextureDetails(TextureDetailsResponse::V1(t)) => {
+            assert_eq!(t.texture.name, TextureName::new("observation"));
         }
         other => panic!("expected TextureDetails, got {other:?}"),
     }
@@ -90,14 +97,15 @@ async fn vocabulary_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
     match client
         .sensation()
         .get(
-            &GetSensation::builder()
+            &GetSensation::builder_v1()
                 .key(SensationName::new("echoes"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        SensationResponse::SensationDetails(s) => {
-            assert_eq!(s.data.name, SensationName::new("echoes"));
+        SensationResponse::SensationDetails(SensationDetailsResponse::V1(s)) => {
+            assert_eq!(s.sensation.name, SensationName::new("echoes"));
         }
         other => panic!("expected SensationDetails, got {other:?}"),
     }
@@ -108,14 +116,15 @@ async fn vocabulary_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
     match client
         .nature()
         .get(
-            &GetNature::builder()
+            &GetNature::builder_v1()
                 .key(NatureName::new("reference"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        NatureResponse::NatureDetails(n) => {
-            assert_eq!(n.data.name, NatureName::new("reference"));
+        NatureResponse::NatureDetails(NatureDetailsResponse::V1(n)) => {
+            assert_eq!(n.nature.name, NatureName::new("reference"));
         }
         other => panic!("expected NatureDetails, got {other:?}"),
     }
@@ -132,14 +141,15 @@ async fn vocabulary_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
     match client
         .persona()
         .get(
-            &GetPersona::builder()
+            &GetPersona::builder_v1()
                 .key(PersonaName::new("process"))
-                .build(),
+                .build()
+                .into(),
         )
         .await?
     {
-        PersonaResponse::PersonaDetails(p) => {
-            assert_eq!(cmd_json["data"]["name"], p.data.name.to_string());
+        PersonaResponse::PersonaDetails(PersonaDetailsResponse::V1(p)) => {
+            assert_eq!(cmd_json["data"]["name"], p.persona.name.to_string());
         }
         other => panic!("expected PersonaDetails, got {other:?}"),
     }
@@ -149,11 +159,16 @@ async fn vocabulary_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
 
     match client
         .urge()
-        .get(&GetUrge::builder().key(UrgeName::new("introspect")).build())
+        .get(
+            &GetUrge::builder_v1()
+                .key(UrgeName::new("introspect"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        UrgeResponse::UrgeDetails(u) => {
-            assert_eq!(u.name, UrgeName::new("introspect"));
+        UrgeResponse::UrgeDetails(UrgeDetailsResponse::V1(u)) => {
+            assert_eq!(u.urge.name, UrgeName::new("introspect"));
         }
         other => panic!("expected UrgeDetails, got {other:?}"),
     }
@@ -164,11 +179,16 @@ async fn vocabulary_lifecycle() -> Result<(), Box<dyn core::error::Error>> {
 
     match client
         .level()
-        .get(&GetLevel::builder().key(LevelName::new("working")).build())
+        .get(
+            &GetLevel::builder_v1()
+                .key(LevelName::new("working"))
+                .build()
+                .into(),
+        )
         .await?
     {
-        LevelResponse::LevelDetails(l) => {
-            assert_eq!(l.data.description.to_string(), "Updated description");
+        LevelResponse::LevelDetails(LevelDetailsResponse::V1(l)) => {
+            assert_eq!(l.level.description.to_string(), "Updated description");
         }
         other => panic!("expected LevelDetails, got {other:?}"),
     }

--- a/crates/oneiros-engine/src/values/chronicle.rs
+++ b/crates/oneiros-engine/src/values/chronicle.rs
@@ -177,16 +177,20 @@ mod tests {
     }
 
     fn test_event(seq: i64) -> StoredEvent {
+        let cognition = Cognition::builder()
+            .agent_id(AgentId::new())
+            .texture("observation")
+            .content(format!("thought {seq}"))
+            .build();
         StoredEvent::builder()
             .id(EventId::new())
             .sequence(seq)
             .data(Event::Known(Events::Cognition(
                 CognitionEvents::CognitionAdded(
-                    Cognition::builder()
-                        .agent_id(AgentId::new())
-                        .texture("observation")
-                        .content(format!("thought {seq}"))
-                        .build(),
+                    CognitionAdded::builder_v1()
+                        .cognition(cognition)
+                        .build()
+                        .into(),
                 ),
             )))
             .source(Source::default())

--- a/crates/oneiros-engine/src/values/resource_uri.rs
+++ b/crates/oneiros-engine/src/values/resource_uri.rs
@@ -150,83 +150,97 @@ impl ResourcePath {
     pub fn as_request(&self) -> Option<ResourceRequest> {
         match self {
             ResourcePath::Agents => Some(ResourceRequest::Agent(AgentRequest::ListAgents(
-                ListAgents::default(),
+                ListAgents::builder_v1().build().into(),
             ))),
-            ResourcePath::Agent(name) => {
-                Some(ResourceRequest::Agent(AgentRequest::GetAgent(GetAgent {
-                    key: ResourceKey::Key(name.clone()),
-                })))
-            }
+            ResourcePath::Agent(name) => Some(ResourceRequest::Agent(AgentRequest::GetAgent(
+                GetAgent::builder_v1()
+                    .key(ResourceKey::Key(name.clone()))
+                    .build()
+                    .into(),
+            ))),
             ResourcePath::AgentCognitions(name) => Some(ResourceRequest::Cognition(
-                CognitionRequest::ListCognitions(ListCognitions {
-                    agent: Some(name.clone()),
-                    texture: None,
-                    filters: SearchFilters::default(),
-                }),
+                CognitionRequest::ListCognitions(
+                    ListCognitions::builder_v1()
+                        .agent(name.clone())
+                        .build()
+                        .into(),
+                ),
             )),
-            ResourcePath::AgentMemories(name) => Some(ResourceRequest::Memory(
-                MemoryRequest::ListMemories(ListMemories {
-                    agent: Some(name.clone()),
-                    filters: SearchFilters::default(),
-                }),
-            )),
+            ResourcePath::AgentMemories(name) => {
+                Some(ResourceRequest::Memory(MemoryRequest::ListMemories(
+                    ListMemories::builder_v1()
+                        .agent(name.clone())
+                        .build()
+                        .into(),
+                )))
+            }
             ResourcePath::AgentExperiences(name) => Some(ResourceRequest::Experience(
-                ExperienceRequest::ListExperiences(ListExperiences {
-                    agent: Some(name.clone()),
-                    filters: SearchFilters::default(),
-                }),
+                ExperienceRequest::ListExperiences(
+                    ListExperiences::builder_v1()
+                        .agent(name.clone())
+                        .build()
+                        .into(),
+                ),
             )),
             ResourcePath::AgentConnections(_) => None,
-            ResourcePath::AgentPressure(name) => Some(ResourceRequest::Pressure(
-                PressureRequest::GetPressure(GetPressure {
-                    agent: name.clone(),
-                }),
-            )),
-            ResourcePath::Cognition(id) => Some(ResourceRequest::Cognition(
-                CognitionRequest::GetCognition(GetCognition {
-                    key: ResourceKey::Key(*id),
-                }),
-            )),
+            ResourcePath::AgentPressure(name) => {
+                Some(ResourceRequest::Pressure(PressureRequest::GetPressure(
+                    GetPressure::builder_v1().agent(name.clone()).build().into(),
+                )))
+            }
+            ResourcePath::Cognition(id) => {
+                Some(ResourceRequest::Cognition(CognitionRequest::GetCognition(
+                    GetCognition::builder_v1()
+                        .key(ResourceKey::Key(*id))
+                        .build()
+                        .into(),
+                )))
+            }
             ResourcePath::Memory(id) => Some(ResourceRequest::Memory(MemoryRequest::GetMemory(
-                GetMemory {
-                    key: ResourceKey::Key(*id),
-                },
+                GetMemory::builder_v1()
+                    .key(ResourceKey::Key(*id))
+                    .build()
+                    .into(),
             ))),
             ResourcePath::Experience(id) => Some(ResourceRequest::Experience(
-                ExperienceRequest::GetExperience(GetExperience {
-                    key: ResourceKey::Key(*id),
-                }),
+                ExperienceRequest::GetExperience(
+                    GetExperience::builder_v1()
+                        .key(ResourceKey::Key(*id))
+                        .build()
+                        .into(),
+                ),
             )),
             ResourcePath::Connection(id) => Some(ResourceRequest::Connection(
-                ConnectionRequest::GetConnection(GetConnection {
-                    key: ResourceKey::Key(*id),
-                }),
+                ConnectionRequest::GetConnection(
+                    GetConnection::builder_v1()
+                        .key(ResourceKey::Key(*id))
+                        .build()
+                        .into(),
+                ),
             )),
             ResourcePath::Levels => Some(ResourceRequest::Level(LevelRequest::ListLevels(
-                ListLevels::builder().build(),
+                ListLevels::builder_v1().build().into(),
             ))),
             ResourcePath::Textures => Some(ResourceRequest::Texture(TextureRequest::ListTextures(
-                ListTextures::builder().build(),
+                ListTextures::builder_v1().build().into(),
             ))),
             ResourcePath::Sensations => Some(ResourceRequest::Sensation(
-                SensationRequest::ListSensations(ListSensations::builder().build()),
+                SensationRequest::ListSensations(ListSensations::builder_v1().build().into()),
             )),
             ResourcePath::Natures => Some(ResourceRequest::Nature(NatureRequest::ListNatures(
-                ListNatures::builder().build(),
+                ListNatures::builder_v1().build().into(),
             ))),
             ResourcePath::Personas => Some(ResourceRequest::Persona(PersonaRequest::ListPersonas(
-                ListPersonas::builder().build(),
+                ListPersonas::builder_v1().build().into(),
             ))),
             ResourcePath::Urges => Some(ResourceRequest::Urge(UrgeRequest::ListUrges(
-                ListUrges::builder().build(),
+                ListUrges::builder_v1().build().into(),
             ))),
             ResourcePath::Pressure => {
                 Some(ResourceRequest::Pressure(PressureRequest::ListPressures))
             }
             ResourcePath::Status => Some(ResourceRequest::Continuity(
-                ContinuityRequest::StatusAgent(StatusAgent {
-                    filters: SearchFilters::default(),
-                }),
+                ContinuityRequest::StatusAgent(StatusAgent::builder_v1().build().into()),
             )),
         }
     }

--- a/crates/oneiros-engine/src/values/tool_def.rs
+++ b/crates/oneiros-engine/src/values/tool_def.rs
@@ -152,9 +152,9 @@ mod tests {
     /// A struct with newtype fields should have properties inlined, no $ref.
     #[test]
     fn struct_with_newtype_fields_is_inlined() {
-        use crate::GetPressure;
+        use crate::GetPressureV1;
 
-        let schema = schema_for::<GetPressure>();
+        let schema = schema_for::<GetPressureV1>();
         let obj = schema.as_object().expect("schema should be an object");
 
         assert_eq!(obj.get("type").and_then(|v| v.as_str()), Some("object"));


### PR DESCRIPTION
This sweeping change is something we've been needing to do for a while, now: versioning our protocol to a large degree.

Here's the problem: we've got an event sourcing adjacent system and it needs to be malleable. Until now, it hasn't been. That means every single time I edit it (and I do), we wind up in a space where I have to manually fix things up.

In the wild, this means broken user experience. Not great.

In order to create a way for us to actually provide maintainable code for ourselves while letting our users more or less not care about it, we needed to create some concept of versioning in the protocol. That's what you're looking at here.

This commit:

- Institutes a `versioned!` macro that lets us construct several related structs at once, the topmost one being the current one, and instrument a "super enum" on top of them.
- Replaces all of our lazily concocted envelopes with versioned ones, using the naming pattern we've made elsewhere.
- Splits apart the CLI commands from our protocol, so that the protocol doesn't necessarily need to contaminate our CLI with its versioning knowledge.

All in all this is an incredibly big change but no actual tests were meaningfully altered, in terms of behavior. So, the corpus of the system should be intact.