### PR TITLE
Platform determines layout.

### DIFF
--- a/crates/oneiros-engine/src/config.rs
+++ b/crates/oneiros-engine/src/config.rs
@@ -17,7 +17,7 @@ fn detect_brain_name() -> BrainName {
 
 /// Resolve the default data directory from the platform.
 fn default_data_dir() -> PathBuf {
-    Platform::default().data_dir()
+    Platform::default().data_dir().to_path_buf()
 }
 
 /// Configuration for the engine.
@@ -87,38 +87,42 @@ impl Config {
         format!("http://{}", self.service.address)
     }
 
+    /// A Platform bound to this config's data directory.
+    pub fn platform(&self) -> Platform {
+        Platform::new(&self.data_dir)
+    }
+
     /// Path to the brain's data directory.
     pub fn brain_dir(&self) -> PathBuf {
-        self.data_dir.join(self.brain.as_str())
+        self.platform().brain_dir(&self.brain)
     }
 
     /// Path to the config file in the data directory.
     pub fn config_path(&self) -> PathBuf {
-        self.data_dir.join("config.toml")
+        self.platform().config_path()
     }
 
     /// Open the system database.
     pub fn system_db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        let conn = rusqlite::Connection::open(self.data_dir.join("system.db"))?;
+        let conn = rusqlite::Connection::open(self.platform().system_db_path())?;
         conn.pragma_update(None, "journal_mode", "wal")?;
         Ok(conn)
     }
 
     /// Path to the brain's event log database.
     pub fn events_db_path(&self) -> PathBuf {
-        self.brain_dir().join("events.db")
+        self.platform().events_db_path(&self.brain)
     }
 
     /// Path to the bookmark's projection database.
     pub fn bookmark_db_path(&self) -> PathBuf {
-        self.brain_dir()
-            .join("bookmarks")
-            .join(format!("{}.db", self.bookmark))
+        self.platform()
+            .bookmark_db_path(&self.brain, &self.bookmark)
     }
 
     /// Directory containing all bookmark databases for this brain.
     pub fn bookmarks_dir(&self) -> PathBuf {
-        self.brain_dir().join("bookmarks")
+        self.platform().bookmarks_dir(&self.brain)
     }
 
     /// Open the bookmark DB as base with the events DB ATTACHed.
@@ -127,19 +131,17 @@ impl Config {
     /// Event log operations use the `events` schema qualifier.
     /// Both share one connection and transaction for atomicity.
     pub fn bookmark_conn(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        let bookmark_path = self.bookmark_db_path();
-        if let Some(parent) = bookmark_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
+        let platform = self.platform();
+        let _ = platform.ensure_bookmarks_dir(&self.brain);
 
-        let conn = rusqlite::Connection::open(&bookmark_path)?;
+        let conn =
+            rusqlite::Connection::open(platform.bookmark_db_path(&self.brain, &self.bookmark))?;
         conn.pragma_update(None, "journal_mode", "wal")?;
         conn.pragma_update(None, "limit_attached", "125")?;
 
-        let events_path = self.events_db_path();
         conn.execute_batch(&format!(
             "ATTACH DATABASE '{}' AS events",
-            events_path.display(),
+            platform.events_db_path(&self.brain).display(),
         ))?;
 
         Ok(conn)
@@ -147,9 +149,7 @@ impl Config {
 
     /// Path to the token file for the current brain.
     pub fn token_path(&self) -> PathBuf {
-        self.data_dir
-            .join("tickets")
-            .join(format!("{}.token", self.brain))
+        self.platform().token_path(&self.brain)
     }
 
     /// Read the token for the current brain, if one exists.

--- a/crates/oneiros-engine/src/scope.rs
+++ b/crates/oneiros-engine/src/scope.rs
@@ -250,17 +250,15 @@ impl Scope<AtBookmark> {
     /// Open the bookmark DB with the events DB ATTACHed. Mirrors
     /// `Config::bookmark_conn` but uses paths resolved at climb time.
     pub fn bookmark_db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        let bookmark_path = &self.inner.bookmark.bookmark_db_path;
-        if let Some(parent) = bookmark_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        let conn = rusqlite::Connection::open(bookmark_path)?;
+        let platform = self.inner.config.platform();
+        let _ = platform.ensure_bookmarks_dir(&self.inner.project.name);
+
+        let conn = rusqlite::Connection::open(&self.inner.bookmark.bookmark_db_path)?;
         conn.pragma_update(None, "journal_mode", "wal")?;
         conn.pragma_update(None, "limit_attached", "125")?;
-        let events_path = &self.inner.project.events_db_path;
         conn.execute_batch(&format!(
             "ATTACH DATABASE '{}' AS events",
-            events_path.display(),
+            self.inner.project.events_db_path.display(),
         ))?;
         Ok(conn)
     }
@@ -355,10 +353,11 @@ impl ComposeScope {
     }
 
     fn build_host_infra(&self) -> Result<HostInfra, ComposeError> {
-        if !self.config.data_dir.is_dir() {
+        let platform = self.config.platform();
+        if !platform.data_dir().is_dir() {
             return Err(ComposeError::HostHydrationFailed(format!(
                 "data_dir does not exist: {}",
-                self.config.data_dir.display()
+                platform.data_dir().display()
             )));
         }
 
@@ -371,26 +370,25 @@ impl ComposeScope {
 
         let mut projects = HashMap::new();
         for name in projection_names {
-            let brain_dir = self.config.data_dir.join(name.as_str());
             // System says the brain exists; verify it's actually
             // reachable on disk. Mismatch = orphan, exclude.
-            if !brain_dir.join("events.db").exists() {
+            if !platform.events_db_path(&name).exists() {
                 continue;
             }
             let project = ProjectInfra {
                 name: name.clone(),
-                brain_dir: brain_dir.clone(),
-                events_db_path: brain_dir.join("events.db"),
-                bookmarks_dir: brain_dir.join("bookmarks"),
+                brain_dir: platform.brain_dir(&name),
+                events_db_path: platform.events_db_path(&name),
+                bookmarks_dir: platform.bookmarks_dir(&name),
                 bookmarks: HashMap::new(),
             };
             projects.insert(name, Arc::new(project));
         }
 
         Ok(HostInfra {
-            data_dir: self.config.data_dir.clone(),
-            system_db_path: self.config.data_dir.join("system.db"),
-            host_key_path: HostKey::new(&self.config.data_dir).path(),
+            data_dir: platform.data_dir().to_path_buf(),
+            system_db_path: platform.system_db_path(),
+            host_key_path: platform.host_key_path(),
             projects,
         })
     }
@@ -398,12 +396,13 @@ impl ComposeScope {
     fn populate_bookmarks(&self, project: &ProjectInfra) -> Result<ProjectInfra, ComposeError> {
         // Authoritative source: `bookmarks` projection scoped to
         // brain. Filesystem must agree.
+        let platform = self.config.platform();
         let conn = self.config.system_db()?;
         let projection_names = BookmarkStore::new(&conn).list_for_brain(&project.name)?;
 
         let mut bookmarks = HashMap::new();
         for name in projection_names {
-            let bookmark_db_path = project.bookmarks_dir.join(format!("{name}.db"));
+            let bookmark_db_path = platform.bookmark_db_path(&project.name, &name);
             if !bookmark_db_path.exists() {
                 // Orphan: projection knows the bookmark but no DB on
                 // disk. Exclude.

--- a/crates/oneiros-engine/src/support/platform.rs
+++ b/crates/oneiros-engine/src/support/platform.rs
@@ -1,26 +1,50 @@
-use std::path::PathBuf;
-
 use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_app_strategy};
+use std::path::{Path, PathBuf};
+
+use crate::*;
 
 const TLD: &str = "com";
 const AUTHOR: &str = "esmevane";
 const APP: &str = "oneiros";
 
-/// Platform-aware path resolution for the application.
+const CONFIG_FILE: &str = "config.toml";
+const SYSTEM_DB: &str = "system.db";
+const HOST_KEY_FILE: &str = "host.key";
+const TICKETS_DIR: &str = "tickets";
+const BOOKMARKS_DIR: &str = "bookmarks";
+const EVENTS_DB: &str = "events.db";
+
+#[derive(Debug, thiserror::Error)]
+pub enum PlatformError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+/// Platform — the steward of where things live and the keeper of the
+/// directories they live in.
 ///
-/// Resolves platform-appropriate paths for data, config, and cache
-/// directories using etcetera's XDG/platform strategy. The same
-/// identity is used for OS service registration (via `label()`).
+/// Holds a single `data_dir` and answers all layout questions about
+/// the host: where the system DB lives, where each brain's events log
+/// goes, where bookmark databases sit. Also owns the side of the
+/// substrate that touches the filesystem to ensure those directories
+/// exist.
 ///
-/// Config uses this for its defaults — CLI args, env vars, and
-/// config files can override any of them.
+/// Construct explicitly with [`Platform::new`] or via OS detection
+/// with [`Platform::resolve`] / [`Platform::default`].
+#[derive(Clone, Debug)]
 pub struct Platform {
     data_dir: PathBuf,
-    config_dir: PathBuf,
-    cache_dir: PathBuf,
 }
 
 impl Platform {
+    /// Construct a Platform bound to an explicit data directory.
+    pub fn new(data_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            data_dir: data_dir.into(),
+        }
+    }
+
+    /// Resolve a Platform from OS conventions (XDG / Apple / Windows).
     pub fn resolve() -> Self {
         let args = AppStrategyArgs {
             top_level_domain: TLD.into(),
@@ -32,26 +56,81 @@ impl Platform {
 
         Self {
             data_dir: strategy.data_dir(),
-            config_dir: strategy.config_dir(),
-            cache_dir: strategy.cache_dir(),
         }
     }
 
-    /// The application's data directory (e.g., `~/.local/share/oneiros`).
-    ///
-    /// This is where brain databases, event logs, and tokens live.
-    pub fn data_dir(&self) -> PathBuf {
-        self.data_dir.clone()
+    /// The application's data directory.
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
     }
 
-    /// The application's config directory (e.g., `~/.config/oneiros`).
-    pub fn config_dir(&self) -> PathBuf {
-        self.config_dir.clone()
+    /// Path to the user-editable config file.
+    pub fn config_path(&self) -> PathBuf {
+        self.data_dir.join(CONFIG_FILE)
     }
 
-    /// The application's cache directory (e.g., `~/.cache/oneiros`).
-    pub fn cache_dir(&self) -> PathBuf {
-        self.cache_dir.clone()
+    /// Path to the host's projection database.
+    pub fn system_db_path(&self) -> PathBuf {
+        self.data_dir.join(SYSTEM_DB)
+    }
+
+    /// Path to the host's persistent ed25519 secret key file.
+    pub fn host_key_path(&self) -> PathBuf {
+        self.data_dir.join(HOST_KEY_FILE)
+    }
+
+    /// Directory where issued ticket tokens are persisted.
+    pub fn tickets_dir(&self) -> PathBuf {
+        self.data_dir.join(TICKETS_DIR)
+    }
+
+    /// Path to the cached token for a given brain.
+    pub fn token_path(&self, brain: &BrainName) -> PathBuf {
+        self.tickets_dir().join(format!("{brain}.token"))
+    }
+
+    /// Directory holding all data for a given brain.
+    pub fn brain_dir(&self, brain: &BrainName) -> PathBuf {
+        self.data_dir.join(brain.as_str())
+    }
+
+    /// Path to a brain's append-only event log database.
+    pub fn events_db_path(&self, brain: &BrainName) -> PathBuf {
+        self.brain_dir(brain).join(EVENTS_DB)
+    }
+
+    /// Directory holding all bookmark databases for a given brain.
+    pub fn bookmarks_dir(&self, brain: &BrainName) -> PathBuf {
+        self.brain_dir(brain).join(BOOKMARKS_DIR)
+    }
+
+    /// Path to a specific bookmark's projection database.
+    pub fn bookmark_db_path(&self, brain: &BrainName, bookmark: &BookmarkName) -> PathBuf {
+        self.bookmarks_dir(brain).join(format!("{bookmark}.db"))
+    }
+
+    /// Ensure the data directory exists.
+    pub fn ensure_data_dir(&self) -> Result<(), PlatformError> {
+        std::fs::create_dir_all(&self.data_dir)?;
+        Ok(())
+    }
+
+    /// Ensure a brain's directory exists.
+    pub fn ensure_brain_dir(&self, brain: &BrainName) -> Result<(), PlatformError> {
+        std::fs::create_dir_all(self.brain_dir(brain))?;
+        Ok(())
+    }
+
+    /// Ensure a brain's bookmarks directory exists.
+    pub fn ensure_bookmarks_dir(&self, brain: &BrainName) -> Result<(), PlatformError> {
+        std::fs::create_dir_all(self.bookmarks_dir(brain))?;
+        Ok(())
+    }
+
+    /// Ensure the tickets directory exists.
+    pub fn ensure_tickets_dir(&self) -> Result<(), PlatformError> {
+        std::fs::create_dir_all(self.tickets_dir())?;
+        Ok(())
     }
 
     /// The service label for OS registration (e.g., `com.esmevane.oneiros`).
@@ -71,19 +150,73 @@ mod tests {
     use super::*;
 
     #[test]
-    fn data_dir_ends_with_app_name() {
+    fn resolved_data_dir_ends_with_app_name() {
         let platform = Platform::resolve();
-        let data = platform.data_dir();
         assert!(
-            data.ends_with(APP),
+            platform.data_dir().ends_with(APP),
             "data_dir should end with app name, got: {}",
-            data.display()
+            platform.data_dir().display()
         );
     }
 
     #[test]
     fn service_label_is_reverse_domain() {
-        let platform = Platform::resolve();
-        assert_eq!(platform.service_label(), "com.esmevane.oneiros");
+        assert_eq!(Platform::resolve().service_label(), "com.esmevane.oneiros");
+    }
+
+    #[test]
+    fn explicit_data_dir_drives_layout() {
+        let platform = Platform::new("/tmp/oneiros-test");
+        let brain = BrainName::new("alpha");
+        let bookmark = BookmarkName::main();
+
+        assert_eq!(
+            platform.system_db_path(),
+            Path::new("/tmp/oneiros-test/system.db")
+        );
+        assert_eq!(
+            platform.host_key_path(),
+            Path::new("/tmp/oneiros-test/host.key")
+        );
+        assert_eq!(
+            platform.brain_dir(&brain),
+            Path::new("/tmp/oneiros-test/alpha")
+        );
+        assert_eq!(
+            platform.events_db_path(&brain),
+            Path::new("/tmp/oneiros-test/alpha/events.db")
+        );
+        assert_eq!(
+            platform.bookmark_db_path(&brain, &bookmark),
+            Path::new("/tmp/oneiros-test/alpha/bookmarks/main.db")
+        );
+    }
+
+    #[test]
+    fn ensure_data_dir_creates_missing_directory() -> Result<(), PlatformError> {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("a/b/c");
+        let platform = Platform::new(&nested);
+
+        assert!(!nested.exists());
+        platform.ensure_data_dir()?;
+        assert!(nested.is_dir());
+        Ok(())
+    }
+
+    #[test]
+    fn ensure_brain_and_bookmarks_dirs_are_idempotent() -> Result<(), PlatformError> {
+        let dir = tempfile::tempdir().unwrap();
+        let platform = Platform::new(dir.path());
+        let brain = BrainName::new("alpha");
+
+        platform.ensure_brain_dir(&brain)?;
+        platform.ensure_brain_dir(&brain)?; // idempotent
+        platform.ensure_bookmarks_dir(&brain)?;
+        platform.ensure_bookmarks_dir(&brain)?; // idempotent
+
+        assert!(platform.brain_dir(&brain).is_dir());
+        assert!(platform.bookmarks_dir(&brain).is_dir());
+        Ok(())
     }
 }


### PR DESCRIPTION
Lots of layout and directory placement questions were being shunted into inline code because we weren't leveraging the platform structure. Now, we are. This is an incomplete pass because we need to do some follow-up moves before we turn off `config.data_dir`, but it's much of the way there.