### PR TITLE
Database extraction.

### DIFF
--- a/crates/oneiros-engine/src/db.rs
+++ b/crates/oneiros-engine/src/db.rs
@@ -1,0 +1,173 @@
+//! Typed database primitives.
+//!
+//! Each DB the engine opens has its own type that owns a connection,
+//! handles its own pragmas, and reports its own errors. Types deref to
+//! `rusqlite::Connection` so existing query code keeps working while
+//! the seams migrate.
+//!
+//! `open` methods are `async fn` even though their bodies are sync —
+//! the signature is the migration seam for sqlx.
+
+use std::ops::Deref;
+
+use crate::*;
+
+// ─────────────────────────────────────────────────────────────────────
+// Errors
+// ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum HostDbError {
+    #[error(transparent)]
+    Connection(#[from] rusqlite::Error),
+    #[error(transparent)]
+    Platform(#[from] PlatformError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EventsDbError {
+    #[error(transparent)]
+    Connection(#[from] rusqlite::Error),
+    #[error(transparent)]
+    Platform(#[from] PlatformError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BookmarkDbError {
+    #[error(transparent)]
+    Connection(#[from] rusqlite::Error),
+    #[error(transparent)]
+    Platform(#[from] PlatformError),
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// HostDb — system.db (host-wide projections: brains, bookmarks,
+// chronicle, tickets, tenants, actors, peers, follows).
+// ─────────────────────────────────────────────────────────────────────
+
+pub struct HostDb {
+    connection: rusqlite::Connection,
+}
+
+impl HostDb {
+    pub async fn open(platform: &Platform) -> Result<Self, HostDbError> {
+        platform.ensure_data_dir()?;
+        let connection = rusqlite::Connection::open(platform.system_db_path())?;
+        connection.pragma_update(None, "journal_mode", "wal")?;
+        Ok(Self { connection })
+    }
+}
+
+impl Deref for HostDb {
+    type Target = rusqlite::Connection;
+    fn deref(&self) -> &Self::Target {
+        &self.connection
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// EventsDb — append-only event log per brain.
+// ─────────────────────────────────────────────────────────────────────
+
+pub struct EventsDb {
+    connection: rusqlite::Connection,
+}
+
+impl EventsDb {
+    pub async fn open(platform: &Platform, brain: &BrainName) -> Result<Self, EventsDbError> {
+        platform.ensure_brain_dir(brain)?;
+        let connection = rusqlite::Connection::open(platform.events_db_path(brain))?;
+        connection.pragma_update(None, "journal_mode", "wal")?;
+        Ok(Self { connection })
+    }
+}
+
+impl Deref for EventsDb {
+    type Target = rusqlite::Connection;
+    fn deref(&self) -> &Self::Target {
+        &self.connection
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// BookmarkDb — per-bookmark projection database with the brain's
+// events DB ATTACHed at `events`. Unqualified table names resolve to
+// the bookmark DB; event-log queries use the `events` schema.
+// ─────────────────────────────────────────────────────────────────────
+
+pub struct BookmarkDb {
+    connection: rusqlite::Connection,
+}
+
+impl BookmarkDb {
+    pub async fn open(
+        platform: &Platform,
+        brain: &BrainName,
+        bookmark: &BookmarkName,
+    ) -> Result<Self, BookmarkDbError> {
+        platform.ensure_bookmarks_dir(brain)?;
+        let connection = rusqlite::Connection::open(platform.bookmark_db_path(brain, bookmark))?;
+        connection.pragma_update(None, "journal_mode", "wal")?;
+        connection.pragma_update(None, "limit_attached", "125")?;
+        connection.execute_batch(&format!(
+            "ATTACH DATABASE '{}' AS events",
+            platform.events_db_path(brain).display(),
+        ))?;
+        Ok(Self { connection })
+    }
+}
+
+impl Deref for BookmarkDb {
+    type Target = rusqlite::Connection;
+    fn deref(&self) -> &Self::Target {
+        &self.connection
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_platform() -> (tempfile::TempDir, Platform) {
+        let dir = tempfile::tempdir().unwrap();
+        let platform = Platform::new(dir.path());
+        (dir, platform)
+    }
+
+    #[tokio::test]
+    async fn host_db_opens_and_creates_system_db() {
+        let (_dir, platform) = test_platform();
+        let _db = HostDb::open(&platform).await.unwrap();
+        assert!(platform.system_db_path().exists());
+    }
+
+    #[tokio::test]
+    async fn events_db_opens_and_creates_brain_dir() {
+        let (_dir, platform) = test_platform();
+        let brain = BrainName::new("alpha");
+        let _db = EventsDb::open(&platform, &brain).await.unwrap();
+        assert!(platform.brain_dir(&brain).is_dir());
+        assert!(platform.events_db_path(&brain).exists());
+    }
+
+    #[tokio::test]
+    async fn bookmark_db_opens_with_events_attached() {
+        let (_dir, platform) = test_platform();
+        let brain = BrainName::new("alpha");
+        let bookmark = BookmarkName::main();
+
+        // Pre-create events db so ATTACH points at a real file.
+        let _events = EventsDb::open(&platform, &brain).await.unwrap();
+        let db = BookmarkDb::open(&platform, &brain, &bookmark)
+            .await
+            .unwrap();
+
+        // Attached schema is queryable.
+        let count: i64 = db
+            .query_row("select count(*) from events.sqlite_master", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert!(count >= 0);
+    }
+}

--- a/crates/oneiros-engine/src/domains/actor/repo.rs
+++ b/crates/oneiros-engine/src/domains/actor/repo.rs
@@ -13,7 +13,7 @@ impl<'a> ActorRepo<'a> {
     }
 
     pub async fn get(&self, id: ActorId) -> Result<Option<Actor>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
         let mut statement =
             db.prepare("select id, tenant_id, name, created_at from actors where id = ?1")?;
 
@@ -41,7 +41,7 @@ impl<'a> ActorRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Actor>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM actors")?;

--- a/crates/oneiros-engine/src/domains/agent/repo.rs
+++ b/crates/oneiros-engine/src/domains/agent/repo.rs
@@ -15,7 +15,7 @@ impl<'a> AgentRepo<'a> {
     }
 
     pub async fn get(&self, name: &AgentName) -> Result<Option<Agent>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt = db
             .prepare("select id, name, persona, description, prompt from agents where name = ?1")?;
 
@@ -47,7 +47,7 @@ impl<'a> AgentRepo<'a> {
     }
 
     pub async fn get_by_id(&self, id: AgentId) -> Result<Option<Agent>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt =
             db.prepare("select id, name, persona, description, prompt from agents where id = ?1")?;
 
@@ -84,7 +84,7 @@ impl<'a> AgentRepo<'a> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let placeholders = (1..=ids.len())
             .map(|i| format!("?{i}"))
             .collect::<Vec<_>>()
@@ -122,7 +122,7 @@ impl<'a> AgentRepo<'a> {
     }
 
     pub async fn name_exists(&self, name: &AgentName) -> Result<bool, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let count: i64 = db.query_row(
             "select count(*) from agents where name = ?1",
             params![name.to_string()],

--- a/crates/oneiros-engine/src/domains/bookmark/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/protocol/errors.rs
@@ -45,6 +45,12 @@ pub enum BookmarkError {
     Database(#[from] rusqlite::Error),
 
     #[error(transparent)]
+    HostDb(#[from] HostDbError),
+
+    #[error(transparent)]
+    BookmarkDb(#[from] BookmarkDbError),
+
+    #[error(transparent)]
     Compose(#[from] crate::ComposeError),
 
     #[error(transparent)]
@@ -70,6 +76,8 @@ impl IntoResponse for BookmarkError {
             BookmarkError::InvalidUri(_) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
             BookmarkError::NoActor
             | BookmarkError::Database(_)
+            | BookmarkError::HostDb(_)
+            | BookmarkError::BookmarkDb(_)
             | BookmarkError::Event(_)
             | BookmarkError::IdParse(_)
             | BookmarkError::TimestampParse(_)

--- a/crates/oneiros-engine/src/domains/bookmark/repo.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/repo.rs
@@ -14,7 +14,7 @@ impl<'a> BookmarkRepo<'a> {
         brain: &BrainName,
         filters: &SearchFilters,
     ) -> Result<Listed<Bookmark>, BookmarkError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
 
         let count_sql = "SELECT COUNT(*) FROM bookmarks WHERE brain = ?1";
         let total = {

--- a/crates/oneiros-engine/src/domains/brain/repo.rs
+++ b/crates/oneiros-engine/src/domains/brain/repo.rs
@@ -13,7 +13,7 @@ impl<'a> BrainRepo<'a> {
     }
 
     pub async fn get(&self, name: &BrainName) -> Result<Option<Brain>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
         let mut stmt = db.prepare("select id, name, created_at from brains where name = ?1")?;
 
         let raw = stmt.query_row(params![name.to_string()], |row| {
@@ -37,7 +37,7 @@ impl<'a> BrainRepo<'a> {
     }
 
     pub async fn get_by_id(&self, id: &BrainId) -> Result<Option<Brain>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
         let mut stmt = db.prepare("select id, name, created_at from brains where id = ?1")?;
 
         let raw = stmt.query_row(params![id.to_string()], |row| {
@@ -61,7 +61,7 @@ impl<'a> BrainRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Brain>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM brains")?;
@@ -93,7 +93,7 @@ impl<'a> BrainRepo<'a> {
     }
 
     pub async fn name_exists(&self, name: &BrainName) -> Result<bool, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
         let count: i64 = db.query_row(
             "select count(*) from brains where name = ?1",
             params![name.to_string()],

--- a/crates/oneiros-engine/src/domains/bridge/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/bridge/protocol/errors.rs
@@ -50,6 +50,12 @@ pub enum BridgeError {
     #[error(transparent)]
     Database(#[from] rusqlite::Error),
 
+    #[error(transparent)]
+    HostDb(#[from] HostDbError),
+
+    #[error(transparent)]
+    EventsDb(#[from] EventsDbError),
+
     /// A scope hydration error during sync handling.
     #[error(transparent)]
     Scope(#[from] ScopeError),

--- a/crates/oneiros-engine/src/domains/bridge/service.rs
+++ b/crates/oneiros-engine/src/domains/bridge/service.rs
@@ -56,7 +56,7 @@ impl SyncHandler {
         };
 
         // Chronicle objects live in the system DB.
-        let system_db = scope.host_db()?;
+        let system_db = scope.host_db().await?;
         let store = ChronicleStore::new(&system_db);
         let resolve = store.resolver();
 
@@ -78,7 +78,7 @@ impl SyncHandler {
         let _ticket = self.validate_ticket(&scope, &resolve_req.link).await?;
 
         // Chronicle objects live in the system DB.
-        let system_db = scope.host_db()?;
+        let system_db = scope.host_db().await?;
         let store = ChronicleStore::new(&system_db);
         let resolve = store.resolver();
 
@@ -104,7 +104,7 @@ impl SyncHandler {
             ComposeScope::new(self.config.clone()).project(ticket.brain_name.clone())?;
 
         // Event log lives in events.db (standalone, no ATTACH).
-        let db = project_scope.events_db()?;
+        let db = project_scope.events_db().await?;
 
         let ids: Vec<EventId> = fetch
             .event_ids

--- a/crates/oneiros-engine/src/domains/cognition/repo.rs
+++ b/crates/oneiros-engine/src/domains/cognition/repo.rs
@@ -15,7 +15,7 @@ impl<'a> CognitionRepo<'a> {
     }
 
     pub async fn get(&self, id: &CognitionId) -> Result<Option<Cognition>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt = db.prepare(
             "SELECT id, agent_id, texture, content, created_at
              FROM cognitions WHERE id = ?1",
@@ -53,7 +53,7 @@ impl<'a> CognitionRepo<'a> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let placeholders = (1..=ids.len())
             .map(|i| format!("?{i}"))
             .collect::<Vec<_>>()
@@ -96,7 +96,7 @@ impl<'a> CognitionRepo<'a> {
         agent_id: &AgentId,
         limit: usize,
     ) -> Result<Vec<Cognition>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt = db.prepare(
             "SELECT id, agent_id, texture, content, created_at
              FROM cognitions

--- a/crates/oneiros-engine/src/domains/connection/repo.rs
+++ b/crates/oneiros-engine/src/domains/connection/repo.rs
@@ -13,7 +13,7 @@ impl<'a> ConnectionRepo<'a> {
     }
 
     pub async fn get(&self, id: &ConnectionId) -> Result<Option<Connection>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt = db.prepare(
             "SELECT id, from_ref, to_ref, nature, created_at
              FROM connections WHERE id = ?1",
@@ -49,7 +49,7 @@ impl<'a> ConnectionRepo<'a> {
         entity_ref: Option<&str>,
         filters: &SearchFilters,
     ) -> Result<Listed<Connection>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
 
         // Build WHERE clause from filters.
         let mut conditions = Vec::new();

--- a/crates/oneiros-engine/src/domains/doctor/service.rs
+++ b/crates/oneiros-engine/src/domains/doctor/service.rs
@@ -22,7 +22,7 @@ impl DoctorService {
             }
         };
 
-        let db = match scope.host_db() {
+        let db = match scope.host_db().await {
             Ok(db) => db,
             Err(_) => {
                 checks.push(DoctorCheck::NotInitialized);

--- a/crates/oneiros-engine/src/domains/event/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/event/protocol/errors.rs
@@ -1,4 +1,7 @@
-use crate::{BlobError, IdParseError, TimestampParseError, UpcastError};
+use crate::{
+    BlobError, BookmarkDbError, EventsDbError, HostDbError, IdParseError, TimestampParseError,
+    UpcastError,
+};
 
 /// Event infrastructure errors.
 #[derive(Debug, thiserror::Error)]
@@ -20,6 +23,15 @@ pub enum EventError {
 
     #[error(transparent)]
     Upcast(#[from] UpcastError),
+
+    #[error(transparent)]
+    HostDb(#[from] HostDbError),
+
+    #[error(transparent)]
+    EventsDb(#[from] EventsDbError),
+
+    #[error(transparent)]
+    BookmarkDb(#[from] BookmarkDbError),
 
     #[error("Import error: {0}")]
     Import(String),

--- a/crates/oneiros-engine/src/domains/experience/repo.rs
+++ b/crates/oneiros-engine/src/domains/experience/repo.rs
@@ -15,7 +15,7 @@ impl<'a> ExperienceRepo<'a> {
     }
 
     pub async fn get(&self, id: &ExperienceId) -> Result<Option<Experience>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt = db.prepare(
             "SELECT id, agent_id, sensation, description, created_at
              FROM experiences WHERE id = ?1",
@@ -53,7 +53,7 @@ impl<'a> ExperienceRepo<'a> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let placeholders = (1..=ids.len())
             .map(|i| format!("?{i}"))
             .collect::<Vec<_>>()
@@ -96,7 +96,7 @@ impl<'a> ExperienceRepo<'a> {
         agent_id: &str,
         limit: usize,
     ) -> Result<Vec<Experience>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt = db.prepare(
             "SELECT id, agent_id, sensation, description, created_at
              FROM experiences

--- a/crates/oneiros-engine/src/domains/follow/repo.rs
+++ b/crates/oneiros-engine/src/domains/follow/repo.rs
@@ -13,7 +13,7 @@ impl<'a> FollowRepo<'a> {
     }
 
     pub async fn get(&self, id: FollowId) -> Result<Option<Follow>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
         let mut stmt = db.prepare(
             "select id, brain, bookmark, source, checkpoint, created_at \
              from follows where id = ?1",
@@ -29,7 +29,7 @@ impl<'a> FollowRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Follow>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM follows")?;
@@ -58,7 +58,7 @@ impl<'a> FollowRepo<'a> {
         brain: &BrainName,
         bookmark: &BookmarkName,
     ) -> Result<Option<Follow>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
         let mut stmt = db.prepare(
             "select id, brain, bookmark, source, checkpoint, created_at \
              from follows where brain = ?1 and bookmark = ?2",

--- a/crates/oneiros-engine/src/domains/level/repo.rs
+++ b/crates/oneiros-engine/src/domains/level/repo.rs
@@ -12,7 +12,7 @@ impl<'a> LevelRepo<'a> {
     }
 
     pub async fn get(&self, name: &LevelName) -> Result<Option<Level>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt =
             db.prepare("SELECT name, description, prompt FROM levels WHERE name = ?1")?;
 
@@ -38,7 +38,7 @@ impl<'a> LevelRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Level>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM levels")?;

--- a/crates/oneiros-engine/src/domains/memory/repo.rs
+++ b/crates/oneiros-engine/src/domains/memory/repo.rs
@@ -15,7 +15,7 @@ impl<'a> MemoryRepo<'a> {
     }
 
     pub async fn get(&self, id: &MemoryId) -> Result<Option<Memory>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt = db.prepare(
             "SELECT id, agent_id, level, content, created_at
              FROM memories WHERE id = ?1",
@@ -53,7 +53,7 @@ impl<'a> MemoryRepo<'a> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let placeholders = (1..=ids.len())
             .map(|i| format!("?{i}"))
             .collect::<Vec<_>>()

--- a/crates/oneiros-engine/src/domains/nature/repo.rs
+++ b/crates/oneiros-engine/src/domains/nature/repo.rs
@@ -12,7 +12,7 @@ impl<'a> NatureRepo<'a> {
     }
 
     pub async fn get(&self, name: &NatureName) -> Result<Option<Nature>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt =
             db.prepare("SELECT name, description, prompt FROM natures WHERE name = ?1")?;
 
@@ -38,7 +38,7 @@ impl<'a> NatureRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Nature>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM natures")?;

--- a/crates/oneiros-engine/src/domains/peer/repo.rs
+++ b/crates/oneiros-engine/src/domains/peer/repo.rs
@@ -13,7 +13,7 @@ impl<'a> PeerRepo<'a> {
     }
 
     pub async fn get(&self, id: PeerId) -> Result<Option<Peer>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
         let mut statement =
             db.prepare("select id, key, address, name, created_at from peers where id = ?1")?;
 
@@ -37,7 +37,7 @@ impl<'a> PeerRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Peer>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM peers")?;

--- a/crates/oneiros-engine/src/domains/persona/repo.rs
+++ b/crates/oneiros-engine/src/domains/persona/repo.rs
@@ -12,7 +12,7 @@ impl<'a> PersonaRepo<'a> {
     }
 
     pub async fn get(&self, name: &PersonaName) -> Result<Option<Persona>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt =
             db.prepare("SELECT name, description, prompt FROM personas WHERE name = ?1")?;
 
@@ -38,7 +38,7 @@ impl<'a> PersonaRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Persona>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM personas")?;

--- a/crates/oneiros-engine/src/domains/pressure/repo.rs
+++ b/crates/oneiros-engine/src/domains/pressure/repo.rs
@@ -14,7 +14,7 @@ impl<'a> PressureRepo<'a> {
     }
 
     pub async fn get(&self, agent_name: &AgentName) -> Result<Vec<Pressure>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
 
         // Look up agent by name to get the ID
         let agent = match AgentStore::new(&db).get(agent_name)? {
@@ -60,7 +60,7 @@ impl<'a> PressureRepo<'a> {
     }
 
     pub async fn list(&self) -> Result<Vec<Pressure>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
 
         let mut stmt = db.prepare(
             "SELECT id, agent_id, urge, data, updated_at FROM pressures ORDER BY agent_id, urge",

--- a/crates/oneiros-engine/src/domains/search/repo.rs
+++ b/crates/oneiros-engine/src/domains/search/repo.rs
@@ -32,7 +32,7 @@ impl<'a> SearchRepo<'a> {
         query: &SearchQueryV1,
         agent_id: Option<&AgentId>,
     ) -> Result<SearchHits, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
 
         let has_query = query.query.is_some();
         let where_clause = query.where_clause(agent_id);

--- a/crates/oneiros-engine/src/domains/sensation/repo.rs
+++ b/crates/oneiros-engine/src/domains/sensation/repo.rs
@@ -12,7 +12,7 @@ impl<'a> SensationRepo<'a> {
     }
 
     pub async fn get(&self, name: &SensationName) -> Result<Option<Sensation>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt =
             db.prepare("SELECT name, description, prompt FROM sensations WHERE name = ?1")?;
 
@@ -38,7 +38,7 @@ impl<'a> SensationRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Sensation>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM sensations")?;

--- a/crates/oneiros-engine/src/domains/storage/repo.rs
+++ b/crates/oneiros-engine/src/domains/storage/repo.rs
@@ -13,7 +13,7 @@ impl<'a> StorageRepo<'a> {
     }
 
     pub async fn get_storage(&self, key: &StorageKey) -> Result<Option<StorageEntry>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt = db.prepare("SELECT key, description, hash FROM storage WHERE key = ?1")?;
 
         let result = stmt.query_row(params![key.as_str()], |row| {
@@ -38,7 +38,7 @@ impl<'a> StorageRepo<'a> {
         &self,
         filters: &SearchFilters,
     ) -> Result<Listed<StorageEntry>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
 
         let total: usize = db.query_row("SELECT COUNT(*) FROM storage", [], |row| row.get(0))?;
 
@@ -68,7 +68,7 @@ impl<'a> StorageRepo<'a> {
     }
 
     pub async fn get_blob(&self, hash: &ContentHash) -> Result<Option<BlobContent>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt = db.prepare("SELECT hash, data, size FROM blob WHERE hash = ?1")?;
 
         let result = stmt.query_row(params![hash.as_str()], |row| {

--- a/crates/oneiros-engine/src/domains/tenant/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/tenant/protocol/errors.rs
@@ -21,6 +21,9 @@ pub enum TenantError {
     Database(#[from] rusqlite::Error),
 
     #[error(transparent)]
+    HostDb(#[from] crate::HostDbError),
+
+    #[error(transparent)]
     Event(#[from] crate::EventError),
 
     #[error(transparent)]
@@ -44,6 +47,7 @@ impl IntoResponse for TenantError {
             TenantError::TimestampParse(_)
             | TenantError::Event(_)
             | TenantError::Database(_)
+            | TenantError::HostDb(_)
             | TenantError::Client(_)
             | TenantError::Compose(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };

--- a/crates/oneiros-engine/src/domains/tenant/repo.rs
+++ b/crates/oneiros-engine/src/domains/tenant/repo.rs
@@ -13,7 +13,7 @@ impl<'a> TenantRepo<'a> {
     }
 
     pub async fn get(&self, id: &TenantId) -> Result<Option<Tenant>, TenantError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
         let mut stmt = db.prepare("select id, name, created_at from tenants where id = ?1")?;
 
         let raw = stmt.query_row(params![id.to_string()], |row| {
@@ -35,7 +35,7 @@ impl<'a> TenantRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Tenant>, TenantError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
 
         let count_sql = "SELECT COUNT(*) FROM tenants";
         let total = {

--- a/crates/oneiros-engine/src/domains/texture/repo.rs
+++ b/crates/oneiros-engine/src/domains/texture/repo.rs
@@ -12,7 +12,7 @@ impl<'a> TextureRepo<'a> {
     }
 
     pub async fn get(&self, name: &TextureName) -> Result<Option<Texture>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt =
             db.prepare("SELECT name, description, prompt FROM textures WHERE name = ?1")?;
 
@@ -38,7 +38,7 @@ impl<'a> TextureRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Texture>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM textures")?;

--- a/crates/oneiros-engine/src/domains/ticket/repo.rs
+++ b/crates/oneiros-engine/src/domains/ticket/repo.rs
@@ -98,7 +98,7 @@ impl<'a> TicketRepo<'a> {
     }
 
     pub async fn get(&self, id: &TicketId) -> Result<Option<Ticket>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
         let sql = format!("SELECT {SELECT_COLUMNS} FROM tickets WHERE id = ?1");
         let mut stmt = db.prepare(&sql)?;
 
@@ -112,7 +112,7 @@ impl<'a> TicketRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Ticket>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM tickets")?;
@@ -141,7 +141,7 @@ impl<'a> TicketRepo<'a> {
     }
 
     pub async fn get_by_token(&self, token: &str) -> Result<Option<Ticket>, EventError> {
-        let db = self.scope.host_db()?;
+        let db = self.scope.host_db().await?;
         let sql = format!("SELECT {SELECT_COLUMNS} FROM tickets WHERE token = ?1");
         let mut stmt = db.prepare(&sql)?;
 

--- a/crates/oneiros-engine/src/domains/urge/repo.rs
+++ b/crates/oneiros-engine/src/domains/urge/repo.rs
@@ -12,7 +12,7 @@ impl<'a> UrgeRepo<'a> {
     }
 
     pub async fn get(&self, name: &UrgeName) -> Result<Option<Urge>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
         let mut stmt = db.prepare("SELECT name, description, prompt FROM urges WHERE name = ?1")?;
 
         let result = stmt.query_row(params![name.to_string()], |row| {
@@ -37,7 +37,7 @@ impl<'a> UrgeRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Urge>, EventError> {
-        let db = self.scope.bookmark_db()?;
+        let db = self.scope.bookmark_db().await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM urges")?;

--- a/crates/oneiros-engine/src/lib.rs
+++ b/crates/oneiros-engine/src/lib.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod client;
 mod config;
+mod db;
 mod docs;
 mod domains;
 mod engine;
@@ -24,6 +25,7 @@ mod values;
 pub use cli::*;
 pub use client::*;
 pub use config::*;
+pub use db::*;
 pub use docs::*;
 pub use domains::*;
 pub use engine::*;

--- a/crates/oneiros-engine/src/scope.rs
+++ b/crates/oneiros-engine/src/scope.rs
@@ -209,8 +209,8 @@ impl Scope<AtProject> {
 impl Scope<AtHost> {
     /// Open the system database. Each tier names the DB it touches —
     /// `host_db` opens system.db, never the bookmark DB.
-    pub fn host_db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        self.inner.config.system_db()
+    pub async fn host_db(&self) -> Result<HostDb, HostDbError> {
+        HostDb::open(&self.inner.config.platform()).await
     }
 
     /// Strangler bridge — produce a legacy `HostLog`. Shrinks as
@@ -229,10 +229,8 @@ impl Scope<AtHost> {
 
 impl Scope<AtProject> {
     /// Open this project's events database.
-    pub fn events_db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        let conn = rusqlite::Connection::open(&self.inner.project.events_db_path)?;
-        conn.pragma_update(None, "journal_mode", "wal")?;
-        Ok(conn)
+    pub async fn events_db(&self) -> Result<EventsDb, EventsDbError> {
+        EventsDb::open(&self.inner.config.platform(), &self.inner.project.name).await
     }
 
     pub fn config(&self) -> &Config {
@@ -247,25 +245,19 @@ impl Scope<AtProject> {
 }
 
 impl Scope<AtBookmark> {
-    /// Open the bookmark DB with the events DB ATTACHed. Mirrors
-    /// `Config::bookmark_conn` but uses paths resolved at climb time.
-    pub fn bookmark_db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        let platform = self.inner.config.platform();
-        let _ = platform.ensure_bookmarks_dir(&self.inner.project.name);
-
-        let conn = rusqlite::Connection::open(&self.inner.bookmark.bookmark_db_path)?;
-        conn.pragma_update(None, "journal_mode", "wal")?;
-        conn.pragma_update(None, "limit_attached", "125")?;
-        conn.execute_batch(&format!(
-            "ATTACH DATABASE '{}' AS events",
-            self.inner.project.events_db_path.display(),
-        ))?;
-        Ok(conn)
+    /// Open the bookmark DB with the events DB ATTACHed.
+    pub async fn bookmark_db(&self) -> Result<BookmarkDb, BookmarkDbError> {
+        BookmarkDb::open(
+            &self.inner.config.platform(),
+            &self.inner.project.name,
+            &self.inner.bookmark.name,
+        )
+        .await
     }
 
     /// Open the system DB from the bookmark tier (shared host DB).
-    pub fn host_db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        self.inner.config.system_db()
+    pub async fn host_db(&self) -> Result<HostDb, HostDbError> {
+        HostDb::open(&self.inner.config.platform()).await
     }
 
     /// Strangler bridge — produce a legacy `ProjectLog` with fresh

--- a/crates/oneiros-engine/src/support/mod.rs
+++ b/crates/oneiros-engine/src/support/mod.rs
@@ -2,6 +2,6 @@ mod logging;
 mod platform;
 mod project_detection;
 
-pub use logging::Logging;
-pub use platform::Platform;
-pub use project_detection::{ProjectDetector, ProjectRoot};
+pub use logging::*;
+pub use platform::*;
+pub use project_detection::*;


### PR DESCRIPTION
As part of the clean-up work surrounding the scopes update, we need to tidy the database access patterns. For now, that means just wrapping rusqlite and giving it some fn notation we can tolerate. But, in the long term, we'll want to actually scour rusqlite signatures from our lib overall and restructure how we're managing db access, so that it only comes from wrappers we manage and we can rotate things out.

Database objects are in charge of: making sure they exist, pragma setup, and general configuration. Migration access is a follow-up pass because we actually migrate several different schemas, and our type safety setup isn't exactly to the point now where we can concretely say which migration runs where. Soon!