### PR TITLE
MCP sessions.

### DIFF
--- a/crates/oneiros-engine/src/mcp.rs
+++ b/crates/oneiros-engine/src/mcp.rs
@@ -3,10 +3,11 @@
 //! Tools are write operations (8 total). Resources are read operations
 //! rendered as markdown. Prompts assemble identity context.
 //!
-//! Session authentication: if the MCP client sends an `Authorization:
-//! Bearer <token>` header during the initialize handshake, the session
-//! resolves to the brain associated with that token. Without a token,
-//! the session uses the server's default brain.
+//! Session authentication: every MCP session must provide a valid
+//! `Authorization: Bearer <token>` header during the initialize handshake.
+//! The token resolves to the brain associated with the project. Sessions
+//! that fail to authenticate receive an informative error directing the
+//! agent to run `oneiros mcp init` in its project directory.
 
 use std::sync::OnceLock;
 
@@ -227,13 +228,38 @@ impl ServerHandler for EngineToolBox {
         request: rmcp::model::InitializeRequestParams,
         context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<rmcp::model::InitializeResult, ErrorData> {
-        if let Some(parts) = context.extensions.get::<axum::http::request::Parts>()
-            && let Some(auth) = parts.headers.get("authorization")
-            && let Some(token_str) = auth.to_str().ok().and_then(|s| s.strip_prefix("Bearer "))
-            && let Some(config) = resolve_config_from_token(&self.state, token_str).await
-        {
-            let _ = self.session_config.set(config);
-        }
+        let parts = context.extensions.get::<axum::http::request::Parts>();
+        let auth_header = parts.and_then(|p| p.headers.get("authorization"));
+
+        let Some(header_value) = auth_header else {
+            return Err(ErrorData::invalid_params(
+                "No authorization token. Run `oneiros mcp init` in your project directory to configure MCP access.",
+                None,
+            ));
+        };
+
+        let Ok(header_str) = header_value.to_str() else {
+            return Err(ErrorData::invalid_params(
+                "Invalid authorization header encoding. Expected format: `Authorization: Bearer <token>`.",
+                None,
+            ));
+        };
+
+        let Some(token_str) = header_str.strip_prefix("Bearer ") else {
+            return Err(ErrorData::invalid_params(
+                "Invalid authorization scheme. Expected `Bearer <token>` — got something else. Run `oneiros mcp init` to generate a valid token.",
+                None,
+            ));
+        };
+
+        let Some(config) = resolve_config_from_token(&self.state, token_str).await else {
+            return Err(ErrorData::invalid_params(
+                "Invalid or unrecognized token. It may be expired, from a different server, or for a deleted project. Run `oneiros mcp init` to regenerate it.",
+                None,
+            ));
+        };
+
+        let _ = self.session_config.set(config);
 
         if context.peer.peer_info().is_none() {
             context.peer.set_peer_info(request);

--- a/crates/oneiros-engine/src/tests/workflows/mcp.rs
+++ b/crates/oneiros-engine/src/tests/workflows/mcp.rs
@@ -23,39 +23,28 @@ fn extract_sse_json(body: &str) -> serde_json::Value {
     serde_json::from_str(json_str).expect("data: line should be valid JSON")
 }
 
-async fn mcp_initialize(http: &reqwest::Client, url: &str) -> Option<String> {
-    let init_resp = mcp_post(http, url)
-        .json(&serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": { "name": "test", "version": "0.1.0" }
-            }
-        }))
-        .send()
-        .await
-        .unwrap();
-
-    assert!(init_resp.status().is_success());
-
-    let session_id = init_resp
-        .headers()
-        .get("mcp-session-id")
-        .map(|v| v.to_str().unwrap().to_string());
-
-    let mut notif = mcp_post(http, url).json(&serde_json::json!({
+async fn mcp_initialize_raw(
+    http: &reqwest::Client,
+    url: &str,
+    auth_header: Option<(&str, &str)>,
+) -> serde_json::Value {
+    let mut req = mcp_post(http, url).json(&serde_json::json!({
         "jsonrpc": "2.0",
-        "method": "notifications/initialized"
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "test", "version": "0.1.0" }
+        }
     }));
-    if let Some(ref sid) = session_id {
-        notif = notif.header("mcp-session-id", sid);
+    if let Some((name, value)) = auth_header {
+        req = req.header(name, value);
     }
-    notif.send().await.unwrap();
-
-    session_id
+    let resp = req.send().await.unwrap();
+    assert!(resp.status().is_success());
+    let body = resp.text().await.unwrap();
+    extract_sse_json(&body)
 }
 
 async fn mcp_initialize_with_token(
@@ -96,6 +85,25 @@ async fn mcp_initialize_with_token(
     notif.send().await.unwrap();
 
     session_id
+}
+
+async fn initialize_should_fail(
+    http: &reqwest::Client,
+    url: &str,
+    auth_header: Option<(&str, &str)>,
+    expected_substr: &str,
+) {
+    let json = mcp_initialize_raw(http, url, auth_header).await;
+    let error = json
+        .get("error")
+        .unwrap_or_else(|| panic!("expected JSON-RPC error, got: {json}"));
+    let message = error["message"]
+        .as_str()
+        .unwrap_or_else(|| panic!("error should have message, got: {error}"));
+    assert!(
+        message.contains(expected_substr),
+        "error message should contain '{expected_substr}', got: '{message}'"
+    );
 }
 
 async fn mcp_call_tool(
@@ -174,9 +182,10 @@ async fn tools_discovery() -> Result<(), Box<dyn core::error::Error>> {
         .seed_core()
         .await?;
 
+    let token = app.token().expect("project should have a token");
     let http = reqwest::Client::new();
     let url = app.mcp_url();
-    let session_id = mcp_initialize(&http, &url).await;
+    let session_id = mcp_initialize_with_token(&http, &url, &token).await;
 
     let json = mcp_rpc(
         &http,
@@ -233,9 +242,10 @@ async fn tool_responses_are_markdown_with_hints() -> Result<(), Box<dyn core::er
         .seed_core()
         .await?;
 
+    let token = app.token().expect("project should have a token");
     let http = reqwest::Client::new();
     let url = app.mcp_url();
-    let session_id = mcp_initialize(&http, &url).await;
+    let session_id = mcp_initialize_with_token(&http, &url, &token).await;
 
     let result = mcp_call_tool(
         &http,
@@ -304,9 +314,10 @@ async fn resources_discovery() -> Result<(), Box<dyn core::error::Error>> {
         .seed_core()
         .await?;
 
+    let token = app.token().expect("project should have a token");
     let http = reqwest::Client::new();
     let url = app.mcp_url();
-    let session_id = mcp_initialize(&http, &url).await;
+    let session_id = mcp_initialize_with_token(&http, &url, &token).await;
 
     let json = mcp_rpc(
         &http,
@@ -375,9 +386,10 @@ async fn resource_reads_return_markdown_with_hints() -> Result<(), Box<dyn core:
         .seed_core()
         .await?;
 
+    let token = app.token().expect("project should have a token");
     let http = reqwest::Client::new();
     let url = app.mcp_url();
-    let session_id = mcp_initialize(&http, &url).await;
+    let session_id = mcp_initialize_with_token(&http, &url, &token).await;
 
     let json = mcp_rpc(
         &http,
@@ -454,9 +466,10 @@ async fn prompts_discovery() -> Result<(), Box<dyn core::error::Error>> {
         .seed_core()
         .await?;
 
+    let token = app.token().expect("project should have a token");
     let http = reqwest::Client::new();
     let url = app.mcp_url();
-    let session_id = mcp_initialize(&http, &url).await;
+    let session_id = mcp_initialize_with_token(&http, &url, &token).await;
 
     let json = mcp_rpc(
         &http,
@@ -492,9 +505,10 @@ async fn dream_prompt_returns_agent_context() -> Result<(), Box<dyn core::error:
 
     app.command("seed agents").await?;
 
+    let token = app.token().expect("project should have a token");
     let http = reqwest::Client::new();
     let url = app.mcp_url();
-    let session_id = mcp_initialize(&http, &url).await;
+    let session_id = mcp_initialize_with_token(&http, &url, &token).await;
 
     #[expect(
         unused_assignments,
@@ -559,9 +573,10 @@ async fn error_responses_include_hints() -> Result<(), Box<dyn core::error::Erro
         .init_project()
         .await?;
 
+    let token = app.token().expect("project should have a token");
     let http = reqwest::Client::new();
     let url = app.mcp_url();
-    let session_id = mcp_initialize(&http, &url).await;
+    let session_id = mcp_initialize_with_token(&http, &url, &token).await;
 
     let result = mcp_call_tool(
         &http,
@@ -613,9 +628,10 @@ async fn invalid_resource_uri_returns_error() -> Result<(), Box<dyn core::error:
         .init_project()
         .await?;
 
+    let token = app.token().expect("project should have a token");
     let http = reqwest::Client::new();
     let url = app.mcp_url();
-    let session_id = mcp_initialize(&http, &url).await;
+    let session_id = mcp_initialize_with_token(&http, &url, &token).await;
 
     let json = mcp_rpc(
         &http,
@@ -631,6 +647,71 @@ async fn invalid_resource_uri_returns_error() -> Result<(), Box<dyn core::error:
         json["error"].is_object(),
         "invalid resource URI should return an error, got: {json}"
     );
+
+    Ok(())
+}
+
+// ── Auth failure paths ──────────────────────────────────────────
+
+#[tokio::test]
+async fn initialize_without_token_fails() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_system()
+        .await?
+        .init_project()
+        .await?;
+
+    let http = reqwest::Client::new();
+    let url = app.mcp_url();
+
+    initialize_should_fail(&http, &url, None, "oneiros mcp init").await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn initialize_with_bad_token_fails() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_system()
+        .await?
+        .init_project()
+        .await?;
+
+    let http = reqwest::Client::new();
+    let url = app.mcp_url();
+
+    initialize_should_fail(
+        &http,
+        &url,
+        Some(("authorization", "Bearer garbage-token")),
+        "Invalid or unrecognized",
+    )
+    .await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn initialize_with_non_bearer_scheme_fails() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_system()
+        .await?
+        .init_project()
+        .await?;
+
+    let http = reqwest::Client::new();
+    let url = app.mcp_url();
+
+    initialize_should_fail(
+        &http,
+        &url,
+        Some(("authorization", "Basic dXNlcjpwYXNz")),
+        "Invalid authorization scheme",
+    )
+    .await;
 
     Ok(())
 }


### PR DESCRIPTION
We had MCP set up to default to oneiros (lol) if it didn't find a project from the session. This is, to say the least, a bad choice. This commit changes our setup so that instead we fail the user and send them to `oneiros mcp init` hints, instead.