### PR TITLE
Inits pass through http.

### DIFF
--- a/crates/oneiros-engine/src/docs.rs
+++ b/crates/oneiros-engine/src/docs.rs
@@ -44,6 +44,7 @@ impl AppDocs {
             SeedDocs::SeedCore.tag(),
             SensationDocs::List.tag(),
             StorageDocs::Upload.tag(),
+            SystemDocs::Init.tag(),
             TenantDocs::Create.tag(),
             TextureDocs::List.tag(),
             TicketDocs::Create.tag(),

--- a/crates/oneiros-engine/src/domains/continuity/client.rs
+++ b/crates/oneiros-engine/src/domains/continuity/client.rs
@@ -46,12 +46,26 @@ impl<'a> ContinuityClient<'a> {
 
     /// Run the dream continuity operation for the given agent.
     pub async fn dream(&self, agent: &AgentName) -> Result<ContinuityResponse, ClientError> {
-        self.client
-            .post(
-                &format!("/continuity/{agent}/dream"),
-                &serde_json::Value::Null,
-            )
-            .await
+        self.dream_with(agent, &DreamOverrides::default()).await
+    }
+
+    /// Run the dream continuity operation with explicit per-request overrides.
+    ///
+    /// Overrides serialize into the URL query string. Only `Some(_)` fields
+    /// are emitted, so passing `DreamOverrides::default()` is equivalent to
+    /// `dream(agent)`.
+    pub async fn dream_with(
+        &self,
+        agent: &AgentName,
+        overrides: &DreamOverrides,
+    ) -> Result<ContinuityResponse, ClientError> {
+        let query = encode_dream_overrides(overrides);
+        let path = if query.is_empty() {
+            format!("/continuity/{agent}/dream")
+        } else {
+            format!("/continuity/{agent}/dream?{query}")
+        };
+        self.client.post(&path, &serde_json::Value::Null).await
     }
 
     /// Run the introspect continuity operation for the given agent.
@@ -94,4 +108,27 @@ impl<'a> ContinuityClient<'a> {
             )
             .await
     }
+}
+
+fn encode_dream_overrides(overrides: &DreamOverrides) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(value) = overrides.recent_window {
+        parts.push(format!("recent_window={value}"));
+    }
+    if let Some(value) = overrides.dream_depth {
+        parts.push(format!("dream_depth={value}"));
+    }
+    if let Some(value) = overrides.cognition_size {
+        parts.push(format!("cognition_size={value}"));
+    }
+    if let Some(value) = &overrides.recollection_level {
+        parts.push(format!("recollection_level={value}"));
+    }
+    if let Some(value) = overrides.recollection_size {
+        parts.push(format!("recollection_size={value}"));
+    }
+    if let Some(value) = overrides.experience_size {
+        parts.push(format!("experience_size={value}"));
+    }
+    parts.join("&")
 }

--- a/crates/oneiros-engine/src/domains/project/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/project/features/cli.rs
@@ -14,7 +14,8 @@ impl ProjectCommands {
     pub async fn execute(&self, config: &Config) -> Result<Rendered<Responses>, ProjectError> {
         let response: ProjectResponse = match self {
             ProjectCommands::Init(initialization) => {
-                ProjectService::init(&config.system(), initialization).await?
+                let client = config.system().client();
+                ProjectClient::new(&client).init(initialization).await?
             }
             ProjectCommands::Export(exporting) => {
                 ProjectService::export(&config.project(), exporting)?

--- a/crates/oneiros-engine/src/domains/setup/service.rs
+++ b/crates/oneiros-engine/src/domains/setup/service.rs
@@ -7,15 +7,74 @@ impl SetupService {
         let details = request.current()?;
         let mut steps = Vec::new();
 
-        // 1. System init (always, idempotent)
-        let system_ctx = config.system();
+        // 1. Server reachability is the precondition. Setup talks to a running
+        //    server; if there isn't one, offer to install and start it.
+        let server_ready = matches!(
+            ServiceService::status(config).await,
+            ServiceResponse::ServiceRunning(_)
+        );
+
+        if !server_ready {
+            let do_service = details.yes
+                || inquire::Confirm::new(
+                    "The oneiros service isn't running. Install and start it now?",
+                )
+                .with_default(true)
+                .prompt()
+                .unwrap_or(false);
+
+            if !do_service {
+                steps.push(SetupStep::ServiceSkipped);
+                return Ok(SetupResponse::SetupComplete(
+                    SetupCompleteResponse::builder_v1()
+                        .steps(steps)
+                        .build()
+                        .into(),
+                ));
+            }
+
+            match ServiceService::install(config) {
+                Ok(_) => steps.push(SetupStep::ServiceInstalled),
+                Err(e) => {
+                    steps.push(SetupStep::StepFailed {
+                        step: "service install".into(),
+                        reason: e.to_string(),
+                    });
+                    return Ok(SetupResponse::SetupComplete(
+                        SetupCompleteResponse::builder_v1()
+                            .steps(steps)
+                            .build()
+                            .into(),
+                    ));
+                }
+            }
+
+            match ServiceService::start(config).await {
+                Ok(_) => steps.push(SetupStep::ServiceStarted),
+                Err(e) => {
+                    steps.push(SetupStep::StepFailed {
+                        step: "service start".into(),
+                        reason: e.to_string(),
+                    });
+                    return Ok(SetupResponse::SetupComplete(
+                        SetupCompleteResponse::builder_v1()
+                            .steps(steps)
+                            .build()
+                            .into(),
+                    ));
+                }
+            }
+        }
+
+        // 2. System init (always, idempotent) — over HTTP.
+        let host_client = Client::new(config.base_url());
         let system_request: InitSystem = InitSystem::builder_v1()
             .maybe_name(details.name.clone())
             .yes(true)
             .build()
             .into();
 
-        match SystemService::init(&system_ctx, &system_request).await {
+        match SystemClient::new(&host_client).init(&system_request).await {
             Ok(SystemResponse::SystemInitialized(_)) => {
                 steps.push(SetupStep::SystemInitialized);
             }
@@ -36,16 +95,22 @@ impl SetupService {
             }
         }
 
-        // 2. Project init (always, idempotent)
+        // 3. Project init (always, idempotent) — over HTTP. Capture the token
+        //    from the response so the seed calls can authenticate.
         let project_request: InitProject = InitProject::builder_v1().yes(true).build().into();
-
-        match ProjectService::init(&system_ctx, &project_request).await {
+        let project_token: Option<Token> = match ProjectClient::new(&host_client)
+            .init(&project_request)
+            .await
+        {
             Ok(ProjectResponse::Initialized(InitializedResponse::V1(result))) => {
                 steps.push(SetupStep::ProjectInitialized(result.brain_name));
+                Some(result.token)
             }
             Ok(ProjectResponse::BrainAlreadyExists(BrainAlreadyExistsResponse::V1(details))) => {
                 steps.push(SetupStep::ProjectAlreadyExists(details.brain_name));
+                None
             }
+            Ok(_) => None,
             Err(e) => {
                 steps.push(SetupStep::StepFailed {
                     step: "project init".into(),
@@ -58,13 +123,45 @@ impl SetupService {
                         .into(),
                 ));
             }
-            _ => {}
-        }
+        };
 
-        // 3. Seed core (always, idempotent)
-        let project_ctx = config.project();
+        // Resolve the token for the seed calls: prefer a freshly-issued one,
+        // fall back to whatever's already on disk (for repeat runs).
+        let token = project_token.or_else(|| config.token());
 
-        match SeedService::core(&project_ctx).await {
+        let Some(token) = token else {
+            steps.push(SetupStep::StepFailed {
+                step: "seed".into(),
+                reason: "no project token available — cannot authenticate seed calls".into(),
+            });
+            return Ok(SetupResponse::SetupComplete(
+                SetupCompleteResponse::builder_v1()
+                    .steps(steps)
+                    .build()
+                    .into(),
+            ));
+        };
+
+        let project_client = match Client::with_token(config.base_url(), token) {
+            Ok(client) => client,
+            Err(e) => {
+                steps.push(SetupStep::StepFailed {
+                    step: "seed".into(),
+                    reason: e.to_string(),
+                });
+                return Ok(SetupResponse::SetupComplete(
+                    SetupCompleteResponse::builder_v1()
+                        .steps(steps)
+                        .build()
+                        .into(),
+                ));
+            }
+        };
+
+        let seed = SeedClient::new(&project_client);
+
+        // 4. Seed core (always, idempotent) — over HTTP.
+        match seed.core().await {
             Ok(_) => steps.push(SetupStep::VocabularySeeded),
             Err(e) => {
                 steps.push(SetupStep::StepFailed {
@@ -74,8 +171,8 @@ impl SetupService {
             }
         }
 
-        // 4. Seed agents (always, idempotent)
-        match SeedService::agents(&project_ctx).await {
+        // 5. Seed agents (always, idempotent) — over HTTP.
+        match seed.agents().await {
             Ok(_) => steps.push(SetupStep::AgentsSeeded),
             Err(e) => {
                 steps.push(SetupStep::StepFailed {
@@ -85,7 +182,7 @@ impl SetupService {
             }
         }
 
-        // 5. MCP config (prompt unless --yes)
+        // 6. MCP config (prompt unless --yes) — local file write.
         let do_mcp = details.yes
             || inquire::Confirm::new("Set up MCP config for Claude Code?")
                 .with_default(true)
@@ -99,7 +196,6 @@ impl SetupService {
                     steps.push(SetupStep::McpConfigured);
                 }
                 Ok(McpConfigResponse::McpConfigExists(_)) => {
-                    // With yes=true this shouldn't happen, but handle it
                     steps.push(SetupStep::McpConfigured);
                 }
                 Err(e) => {
@@ -111,37 +207,6 @@ impl SetupService {
             }
         } else {
             steps.push(SetupStep::McpSkipped);
-        }
-
-        // 6. Service install + start (prompt unless --yes)
-        let do_service = details.yes
-            || inquire::Confirm::new("Install and start the oneiros service?")
-                .with_default(true)
-                .prompt()
-                .unwrap_or(false);
-
-        if do_service {
-            match ServiceService::install(config) {
-                Ok(_) => steps.push(SetupStep::ServiceInstalled),
-                Err(e) => {
-                    steps.push(SetupStep::StepFailed {
-                        step: "service install".into(),
-                        reason: e.to_string(),
-                    });
-                }
-            }
-
-            match ServiceService::start(config).await {
-                Ok(_) => steps.push(SetupStep::ServiceStarted),
-                Err(e) => {
-                    steps.push(SetupStep::StepFailed {
-                        step: "service start".into(),
-                        reason: e.to_string(),
-                    });
-                }
-            }
-        } else {
-            steps.push(SetupStep::ServiceSkipped);
         }
 
         Ok(SetupResponse::SetupComplete(

--- a/crates/oneiros-engine/src/domains/system/client.rs
+++ b/crates/oneiros-engine/src/domains/system/client.rs
@@ -1,0 +1,15 @@
+use crate::*;
+
+pub struct SystemClient<'a> {
+    client: &'a Client,
+}
+
+impl<'a> SystemClient<'a> {
+    pub fn new(client: &'a Client) -> Self {
+        Self { client }
+    }
+
+    pub async fn init(&self, request: &InitSystem) -> Result<SystemResponse, ClientError> {
+        self.client.post("/system", request).await
+    }
+}

--- a/crates/oneiros-engine/src/domains/system/docs.rs
+++ b/crates/oneiros-engine/src/domains/system/docs.rs
@@ -1,0 +1,28 @@
+use crate::*;
+
+pub enum SystemDocs {
+    Init,
+}
+
+impl SystemDocs {
+    pub fn tag(&self) -> Tag {
+        Tag::builder()
+            .name("system")
+            .description("Host-level initialization and bootstrap")
+            .build()
+    }
+
+    pub fn resource_docs(&self) -> ResourceDocs {
+        let tag = self.tag();
+        match self {
+            Self::Init => ResourceDocs::builder()
+                .tag(tag)
+                .nickname("init-system")
+                .summary("Initialize host")
+                .description(
+                    "Create the host data directory, generate the host keypair, and seed the default tenant and actor. Refuses once a tenant exists.",
+                )
+                .build(),
+        }
+    }
+}

--- a/crates/oneiros-engine/src/domains/system/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/system/features/cli.rs
@@ -9,10 +9,11 @@ pub enum SystemCommands {
 
 impl SystemCommands {
     pub async fn execute(&self, context: HostLog) -> Result<Rendered<Responses>, SystemError> {
+        let client = context.client();
+        let system_client = SystemClient::new(&client);
+
         let response = match self {
-            SystemCommands::Init(initialization) => {
-                SystemService::init(&context, initialization).await?
-            }
+            SystemCommands::Init(initialization) => system_client.init(initialization).await?,
         };
 
         Ok(SystemView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/system/features/http.rs
+++ b/crates/oneiros-engine/src/domains/system/features/http.rs
@@ -1,0 +1,25 @@
+use aide::axum::{ApiRouter, routing};
+use axum::{Json, http::StatusCode};
+
+use crate::*;
+
+pub struct SystemRouter;
+
+impl SystemRouter {
+    pub fn routes(&self) -> ApiRouter<ServerState> {
+        ApiRouter::new().api_route(
+            "/system",
+            routing::post_with(init, |op| {
+                resource_op!(op, SystemDocs::Init).response::<201, Json<SystemResponse>>()
+            }),
+        )
+    }
+}
+
+async fn init(
+    context: HostLog,
+    Json(body): Json<InitSystem>,
+) -> Result<(StatusCode, Json<SystemResponse>), SystemError> {
+    let response = SystemService::init(&context, &body).await?;
+    Ok((StatusCode::CREATED, Json(response)))
+}

--- a/crates/oneiros-engine/src/domains/system/features/mod.rs
+++ b/crates/oneiros-engine/src/domains/system/features/mod.rs
@@ -1,5 +1,7 @@
 mod cli;
+mod http;
 mod skills;
 
 pub use cli::*;
+pub use http::*;
 pub use skills::*;

--- a/crates/oneiros-engine/src/domains/system/mod.rs
+++ b/crates/oneiros-engine/src/domains/system/mod.rs
@@ -1,8 +1,12 @@
+mod client;
+mod docs;
 mod features;
 mod protocol;
 mod service;
 mod view;
 
+pub use client::*;
+pub use docs::*;
 pub use features::*;
 pub use protocol::*;
 pub use service::*;

--- a/crates/oneiros-engine/src/domains/system/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/system/protocol/errors.rs
@@ -29,7 +29,12 @@ pub enum SystemError {
 
     #[error(transparent)]
     Compose(#[from] ComposeError),
+
+    #[error(transparent)]
+    Client(#[from] ClientError),
 }
+
+resource_op_error!(SystemError);
 
 impl IntoResponse for SystemError {
     fn into_response(self) -> Response {
@@ -43,6 +48,7 @@ impl IntoResponse for SystemError {
             | SystemError::HostKey(_)
             | SystemError::Upcast(_)
             | SystemError::Compose(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            SystemError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
         };
         (status, Json(ErrorResponse::new(message))).into_response()
     }

--- a/crates/oneiros-engine/src/http/server.rs
+++ b/crates/oneiros-engine/src/http/server.rs
@@ -114,6 +114,7 @@ impl Server {
             .merge(SeedRouter.routes())
             .merge(SensationRouter.routes())
             .merge(StorageRouter.routes())
+            .merge(SystemRouter.routes())
             .merge(TenantRouter.routes())
             .merge(TextureRouter.routes())
             .merge(TicketRouter.routes())

--- a/crates/oneiros-engine/src/tests/dream_context.rs
+++ b/crates/oneiros-engine/src/tests/dream_context.rs
@@ -1,10 +1,10 @@
 use std::collections::HashSet;
 
-use crate::tests::harness::TestApp;
+use crate::tests::harness::{TestApp, TestClient};
 use crate::*;
 
-async fn seeded_context() -> (ProjectLog, TestApp) {
-    let app = TestApp::new()
+async fn seeded_app() -> TestApp {
+    TestApp::new()
         .await
         .expect("boot test app")
         .init_system()
@@ -15,41 +15,38 @@ async fn seeded_context() -> (ProjectLog, TestApp) {
         .expect("init project")
         .seed_core()
         .await
-        .expect("seed core");
-
-    let context = app.config().project();
-    (context, app)
+        .expect("seed core")
 }
 
-async fn seed_agent(context: &ProjectLog) -> AgentName {
-    AgentService::create(
-        context,
-        &CreateAgent::V1(
+async fn seed_agent(client: &TestClient) -> AgentName {
+    client
+        .agent()
+        .create(&CreateAgent::V1(
             CreateAgentV1::builder()
                 .name("thinker")
                 .persona("process")
                 .description("A thinking agent")
                 .prompt("You think")
                 .build(),
-        ),
-    )
-    .await
-    .unwrap();
+        ))
+        .await
+        .expect("create agent");
     AgentName::new("thinker.process")
 }
 
-async fn add_cognition(context: &ProjectLog, agent: &AgentName, content: &str) -> CognitionId {
-    match CognitionService::add(
-        context,
-        &AddCognition::builder_v1()
-            .agent(agent.clone())
-            .texture("observation")
-            .content(content)
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap()
+async fn add_cognition(client: &TestClient, agent: &AgentName, content: &str) -> CognitionId {
+    match client
+        .cognition()
+        .add(
+            &AddCognition::builder_v1()
+                .agent(agent.clone())
+                .texture("observation")
+                .content(content)
+                .build()
+                .into(),
+        )
+        .await
+        .expect("add cognition")
     {
         CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(added)) => added.cognition.id,
         other => panic!("expected CognitionAdded, got {other:?}"),
@@ -57,44 +54,42 @@ async fn add_cognition(context: &ProjectLog, agent: &AgentName, content: &str) -
 }
 
 async fn add_memory(
-    context: &ProjectLog,
+    client: &TestClient,
     agent: &AgentName,
     level: &str,
     content: &str,
 ) -> MemoryId {
-    match MemoryService::add(
-        context,
-        &AddMemory::builder_v1()
-            .agent(agent.clone())
-            .level(level)
-            .content(content)
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap()
+    match client
+        .memory()
+        .add(
+            &AddMemory::builder_v1()
+                .agent(agent.clone())
+                .level(level)
+                .content(content)
+                .build()
+                .into(),
+        )
+        .await
+        .expect("add memory")
     {
         MemoryResponse::MemoryAdded(MemoryAddedResponse::V1(added)) => added.memory.id,
         other => panic!("expected MemoryAdded, got {other:?}"),
     }
 }
 
-async fn add_experience(
-    context: &ProjectLog,
-    agent: &AgentName,
-    description: &str,
-) -> ExperienceId {
-    match ExperienceService::create(
-        context,
-        &CreateExperience::builder_v1()
-            .agent(agent.clone())
-            .sensation("echoes")
-            .description(description)
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap()
+async fn add_experience(client: &TestClient, agent: &AgentName, description: &str) -> ExperienceId {
+    match client
+        .experience()
+        .create(
+            &CreateExperience::builder_v1()
+                .agent(agent.clone())
+                .sensation("echoes")
+                .description(description)
+                .build()
+                .into(),
+        )
+        .await
+        .expect("create experience")
     {
         ExperienceResponse::ExperienceCreated(ExperienceCreatedResponse::V1(created)) => {
             created.experience.id
@@ -103,18 +98,19 @@ async fn add_experience(
     }
 }
 
-async fn connect(context: &ProjectLog, from: &Ref, to: &Ref) -> ConnectionId {
-    match ConnectionService::create(
-        context,
-        &CreateConnection::builder_v1()
-            .from_ref(RefToken::from(from.clone()))
-            .to_ref(RefToken::from(to.clone()))
-            .nature("reference")
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap()
+async fn connect(client: &TestClient, from: &Ref, to: &Ref) -> ConnectionId {
+    match client
+        .connection()
+        .create(
+            &CreateConnection::builder_v1()
+                .from_ref(RefToken::from(from.clone()))
+                .to_ref(RefToken::from(to.clone()))
+                .nature("reference")
+                .build()
+                .into(),
+        )
+        .await
+        .expect("create connection")
     {
         ConnectionResponse::ConnectionCreated(ConnectionCreatedResponse::V1(created)) => {
             created.connection.id
@@ -123,22 +119,20 @@ async fn connect(context: &ProjectLog, from: &Ref, to: &Ref) -> ConnectionId {
     }
 }
 
-async fn dream(context: &ProjectLog, agent: &AgentName) -> DreamContext {
-    dream_with(context, agent, &DreamOverrides::default()).await
+async fn dream(client: &TestClient, agent: &AgentName) -> DreamContext {
+    dream_with(client, agent, &DreamOverrides::default()).await
 }
 
 async fn dream_with(
-    context: &ProjectLog,
+    client: &TestClient,
     agent: &AgentName,
     overrides: &DreamOverrides,
 ) -> DreamContext {
-    match ContinuityService::dream(
-        context,
-        &DreamAgent::builder_v1().agent(agent.clone()).build().into(),
-        overrides,
-    )
-    .await
-    .unwrap()
+    match client
+        .continuity()
+        .dream_with(agent, overrides)
+        .await
+        .expect("dream agent")
     {
         ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => details.context,
         other => panic!("expected Dreaming, got {other:?}"),
@@ -149,10 +143,11 @@ async fn dream_with(
 
 #[tokio::test]
 async fn dream_includes_all_vocabulary() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
 
     assert_eq!(context.textures.len(), 10, "seed creates 10 textures");
     assert_eq!(context.levels.len(), 5, "seed creates 5 levels");
@@ -163,10 +158,11 @@ async fn dream_includes_all_vocabulary() {
 
 #[tokio::test]
 async fn dream_includes_persona() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
 
     let persona = context.persona.expect("persona should be present");
     assert_eq!(persona.name, PersonaName::new("process"));
@@ -176,13 +172,14 @@ async fn dream_includes_persona() {
 
 #[tokio::test]
 async fn core_memories_always_included() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    add_memory(&context, &agent, "core", "identity fundament").await;
-    add_memory(&context, &agent, "archival", "old history").await;
+    add_memory(&client, &agent, "core", "identity fundament").await;
+    add_memory(&client, &agent, "archival", "old history").await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
 
     let memory_contents: Vec<&str> = context
         .memories
@@ -201,16 +198,17 @@ async fn core_memories_always_included() {
 
 #[tokio::test]
 async fn level_threshold_filters_lower_priority() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    add_memory(&context, &agent, "core", "core memory").await;
-    add_memory(&context, &agent, "project", "project memory").await;
-    add_memory(&context, &agent, "session", "session memory").await;
-    add_memory(&context, &agent, "working", "working memory").await;
-    add_memory(&context, &agent, "archival", "archival memory").await;
+    add_memory(&client, &agent, "core", "core memory").await;
+    add_memory(&client, &agent, "project", "project memory").await;
+    add_memory(&client, &agent, "session", "session memory").await;
+    add_memory(&client, &agent, "working", "working memory").await;
+    add_memory(&client, &agent, "archival", "archival memory").await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
 
     let levels: Vec<&str> = context.memories.iter().map(|m| m.level.as_str()).collect();
     assert!(levels.contains(&"core"), "core always included");
@@ -225,20 +223,21 @@ async fn level_threshold_filters_lower_priority() {
 
 #[tokio::test]
 async fn level_threshold_override_changes_filter() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    add_memory(&context, &agent, "core", "core memory").await;
-    add_memory(&context, &agent, "project", "project memory").await;
-    add_memory(&context, &agent, "session", "session memory").await;
-    add_memory(&context, &agent, "working", "working memory").await;
-    add_memory(&context, &agent, "archival", "archival memory").await;
+    add_memory(&client, &agent, "core", "core memory").await;
+    add_memory(&client, &agent, "project", "project memory").await;
+    add_memory(&client, &agent, "session", "session memory").await;
+    add_memory(&client, &agent, "working", "working memory").await;
+    add_memory(&client, &agent, "archival", "archival memory").await;
 
     let overrides = DreamOverrides {
         recollection_level: Some(LevelName::new("core")),
         ..Default::default()
     };
-    let context = dream_with(&context, &agent, &overrides).await;
+    let context = dream_with(&client, &agent, &overrides).await;
 
     let levels: Vec<&str> = context.memories.iter().map(|m| m.level.as_str()).collect();
     assert!(levels.contains(&"core"), "core always included");
@@ -251,19 +250,20 @@ async fn level_threshold_override_changes_filter() {
 
 #[tokio::test]
 async fn recollection_size_caps_non_core_memories() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
     for i in 0..5 {
-        add_memory(&context, &agent, "project", &format!("project memory {i}")).await;
+        add_memory(&client, &agent, "project", &format!("project memory {i}")).await;
     }
-    add_memory(&context, &agent, "core", "core memory").await;
+    add_memory(&client, &agent, "core", "core memory").await;
 
     let overrides = DreamOverrides {
         recollection_size: Some(2),
         ..Default::default()
     };
-    let context = dream_with(&context, &agent, &overrides).await;
+    let context = dream_with(&client, &agent, &overrides).await;
 
     let core_count = context
         .memories
@@ -284,14 +284,15 @@ async fn recollection_size_caps_non_core_memories() {
 
 #[tokio::test]
 async fn sparse_graph_includes_all_cognitions() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
     for i in 0..5 {
-        add_cognition(&context, &agent, &format!("thought {i}")).await;
+        add_cognition(&client, &agent, &format!("thought {i}")).await;
     }
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
     assert_eq!(
         context.cognitions.len(),
         5,
@@ -301,18 +302,19 @@ async fn sparse_graph_includes_all_cognitions() {
 
 #[tokio::test]
 async fn cognition_size_cap_keeps_most_recent() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
     for i in 0..10 {
-        add_cognition(&context, &agent, &format!("thought {i}")).await;
+        add_cognition(&client, &agent, &format!("thought {i}")).await;
     }
 
     let overrides = DreamOverrides {
         cognition_size: Some(3),
         ..Default::default()
     };
-    let context = dream_with(&context, &agent, &overrides).await;
+    let context = dream_with(&client, &agent, &overrides).await;
 
     assert_eq!(context.cognitions.len(), 3, "capped at cognition_size");
     let contents: Vec<&str> = context
@@ -338,15 +340,16 @@ async fn cognition_size_cap_keeps_most_recent() {
 
 #[tokio::test]
 async fn bfs_discovers_connected_cognitions() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    let mem_id = add_memory(&context, &agent, "project", "seed memory").await;
-    let connected_cog = add_cognition(&context, &agent, "connected thought").await;
-    let _unconnected_cog = add_cognition(&context, &agent, "unconnected thought").await;
+    let mem_id = add_memory(&client, &agent, "project", "seed memory").await;
+    let connected_cog = add_cognition(&client, &agent, "connected thought").await;
+    let _unconnected_cog = add_cognition(&client, &agent, "unconnected thought").await;
 
     connect(
-        &context,
+        &client,
         &Ref::memory(mem_id),
         &Ref::cognition(connected_cog),
     )
@@ -356,7 +359,7 @@ async fn bfs_discovers_connected_cognitions() {
         cognition_size: Some(100),
         ..Default::default()
     };
-    let context = dream_with(&context, &agent, &overrides).await;
+    let context = dream_with(&client, &agent, &overrides).await;
 
     let cog_ids: HashSet<CognitionId> = context.cognitions.iter().map(|c| c.id).collect();
 
@@ -368,15 +371,16 @@ async fn bfs_discovers_connected_cognitions() {
 
 #[tokio::test]
 async fn bfs_discovers_connected_experiences() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    let mem_id = add_memory(&context, &agent, "project", "seed memory").await;
-    let connected_exp = add_experience(&context, &agent, "connected experience").await;
-    let _unconnected_exp = add_experience(&context, &agent, "unconnected experience").await;
+    let mem_id = add_memory(&client, &agent, "project", "seed memory").await;
+    let connected_exp = add_experience(&client, &agent, "connected experience").await;
+    let _unconnected_exp = add_experience(&client, &agent, "unconnected experience").await;
 
     connect(
-        &context,
+        &client,
         &Ref::memory(mem_id),
         &Ref::experience(connected_exp),
     )
@@ -386,7 +390,7 @@ async fn bfs_discovers_connected_experiences() {
         experience_size: Some(100),
         ..Default::default()
     };
-    let context = dream_with(&context, &agent, &overrides).await;
+    let context = dream_with(&client, &agent, &overrides).await;
 
     let exp_ids: HashSet<ExperienceId> = context.experiences.iter().map(|e| e.id).collect();
     assert!(
@@ -399,18 +403,19 @@ async fn bfs_discovers_connected_experiences() {
 
 #[tokio::test]
 async fn experience_size_cap_keeps_most_recent() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
     for i in 0..8 {
-        add_experience(&context, &agent, &format!("experience {i}")).await;
+        add_experience(&client, &agent, &format!("experience {i}")).await;
     }
 
     let overrides = DreamOverrides {
         experience_size: Some(3),
         ..Default::default()
     };
-    let context = dream_with(&context, &agent, &overrides).await;
+    let context = dream_with(&client, &agent, &overrides).await;
 
     assert_eq!(context.experiences.len(), 3, "capped at experience_size");
 }
@@ -419,24 +424,25 @@ async fn experience_size_cap_keeps_most_recent() {
 
 #[tokio::test]
 async fn connections_pruned_to_included_endpoints() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    let mem_id = add_memory(&context, &agent, "project", "seed memory").await;
-    let cog_id = add_cognition(&context, &agent, "connected thought").await;
-    let orphan_cog = add_cognition(&context, &agent, "orphan thought").await;
+    let mem_id = add_memory(&client, &agent, "project", "seed memory").await;
+    let cog_id = add_cognition(&client, &agent, "connected thought").await;
+    let orphan_cog = add_cognition(&client, &agent, "orphan thought").await;
 
-    let _included_conn = connect(&context, &Ref::memory(mem_id), &Ref::cognition(cog_id)).await;
+    let _included_conn = connect(&client, &Ref::memory(mem_id), &Ref::cognition(cog_id)).await;
 
-    let archival_mem = add_memory(&context, &agent, "archival", "old memory").await;
+    let archival_mem = add_memory(&client, &agent, "archival", "old memory").await;
     let _excluded_conn = connect(
-        &context,
+        &client,
         &Ref::memory(archival_mem),
         &Ref::cognition(orphan_cog),
     )
     .await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
 
     let included_refs: HashSet<Ref> = context
         .memories
@@ -464,14 +470,15 @@ async fn connections_pruned_to_included_endpoints() {
 
 #[tokio::test]
 async fn pressures_paired_with_urge_ctas() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
     for i in 0..10 {
-        add_cognition(&context, &agent, &format!("thought {i}")).await;
+        add_cognition(&client, &agent, &format!("thought {i}")).await;
     }
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
 
     for reading in &context.pressures {
         let urge = context
@@ -491,24 +498,25 @@ async fn pressures_paired_with_urge_ctas() {
 
 #[tokio::test]
 async fn dream_overrides_change_output() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
     for i in 0..10 {
-        add_cognition(&context, &agent, &format!("thought {i}")).await;
+        add_cognition(&client, &agent, &format!("thought {i}")).await;
     }
     for i in 0..10 {
-        add_memory(&context, &agent, "project", &format!("memory {i}")).await;
+        add_memory(&client, &agent, "project", &format!("memory {i}")).await;
     }
 
-    let default_context = dream(&context, &agent).await;
+    let default_context = dream(&client, &agent).await;
 
     let overrides = DreamOverrides {
         cognition_size: Some(2),
         recollection_size: Some(2),
         ..Default::default()
     };
-    let restricted_context = dream_with(&context, &agent, &overrides).await;
+    let restricted_context = dream_with(&client, &agent, &overrides).await;
 
     assert!(
         restricted_context.cognitions.len() <= 2,
@@ -525,15 +533,16 @@ async fn dream_overrides_change_output() {
 
 #[tokio::test]
 async fn memories_sorted_by_created_at() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    add_memory(&context, &agent, "core", "first core").await;
-    add_memory(&context, &agent, "project", "first project").await;
-    add_memory(&context, &agent, "core", "second core").await;
-    add_memory(&context, &agent, "project", "second project").await;
+    add_memory(&client, &agent, "core", "first core").await;
+    add_memory(&client, &agent, "project", "first project").await;
+    add_memory(&client, &agent, "core", "second core").await;
+    add_memory(&client, &agent, "project", "second project").await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
 
     for window in context.memories.windows(2) {
         assert!(
@@ -545,14 +554,15 @@ async fn memories_sorted_by_created_at() {
 
 #[tokio::test]
 async fn cognitions_sorted_by_created_at() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
     for i in 0..5 {
-        add_cognition(&context, &agent, &format!("thought {i}")).await;
+        add_cognition(&client, &agent, &format!("thought {i}")).await;
     }
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
 
     for window in context.cognitions.windows(2) {
         assert!(
@@ -566,10 +576,11 @@ async fn cognitions_sorted_by_created_at() {
 
 #[tokio::test]
 async fn greeting_opens_with_identity_and_date() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
     let rendered = DreamTemplate::new(&context).to_string();
 
     assert!(
@@ -581,12 +592,13 @@ async fn greeting_opens_with_identity_and_date() {
 
 #[tokio::test]
 async fn greeting_includes_core_memories_inline() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    add_memory(&context, &agent, "core", "I am fundamentally a thinker").await;
+    add_memory(&client, &agent, "core", "I am fundamentally a thinker").await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
     let rendered = DreamTemplate::new(&context).to_string();
 
     assert!(
@@ -605,19 +617,20 @@ async fn greeting_includes_core_memories_inline() {
 
 #[tokio::test]
 async fn greeting_omits_non_core_memories() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    add_memory(&context, &agent, "core", "core identity").await;
+    add_memory(&client, &agent, "core", "core identity").await;
     add_memory(
-        &context,
+        &client,
         &agent,
         "project",
         "A very long project memory that should not appear in the greeting",
     )
     .await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
     let rendered = DreamTemplate::new(&context).to_string();
 
     assert!(
@@ -632,13 +645,14 @@ async fn greeting_omits_non_core_memories() {
 
 #[tokio::test]
 async fn greeting_shows_latest_cognitions_with_refs() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    add_cognition(&context, &agent, "first thought").await;
-    add_cognition(&context, &agent, "second thought").await;
+    add_cognition(&client, &agent, "first thought").await;
+    add_cognition(&client, &agent, "second thought").await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
     let rendered = DreamTemplate::new(&context).to_string();
 
     assert!(
@@ -657,14 +671,15 @@ async fn greeting_shows_latest_cognitions_with_refs() {
 
 #[tokio::test]
 async fn greeting_caps_latest_cognitions_to_three() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
     for i in 0..6 {
-        add_cognition(&context, &agent, &format!("thought {i}")).await;
+        add_cognition(&client, &agent, &format!("thought {i}")).await;
     }
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
     let rendered = DreamTemplate::new(&context).to_string();
 
     // The 3 most recent should be there
@@ -691,12 +706,13 @@ async fn greeting_caps_latest_cognitions_to_three() {
 
 #[tokio::test]
 async fn greeting_shows_latest_experiences_with_refs() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    add_experience(&context, &agent, "first moment").await;
+    add_experience(&client, &agent, "first moment").await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
     let rendered = DreamTemplate::new(&context).to_string();
 
     assert!(
@@ -712,14 +728,15 @@ async fn greeting_shows_latest_experiences_with_refs() {
 
 #[tokio::test]
 async fn greeting_shows_latest_threads_as_connections() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    let mem = add_memory(&context, &agent, "core", "anchor").await;
-    let cog = add_cognition(&context, &agent, "linked thought").await;
-    connect(&context, &Ref::memory(mem), &Ref::cognition(cog)).await;
+    let mem = add_memory(&client, &agent, "core", "anchor").await;
+    let cog = add_cognition(&client, &agent, "linked thought").await;
+    connect(&client, &Ref::memory(mem), &Ref::cognition(cog)).await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
     let rendered = DreamTemplate::new(&context).to_string();
 
     assert!(
@@ -735,10 +752,11 @@ async fn greeting_shows_latest_threads_as_connections() {
 
 #[tokio::test]
 async fn greeting_omits_vocabulary_sections() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
     let rendered = DreamTemplate::new(&context).to_string();
 
     assert!(
@@ -753,14 +771,15 @@ async fn greeting_omits_vocabulary_sections() {
 
 #[tokio::test]
 async fn greeting_pressure_omits_verbose_forms() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
     for i in 0..10 {
-        add_cognition(&context, &agent, &format!("thought {i}")).await;
+        add_cognition(&client, &agent, &format!("thought {i}")).await;
     }
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
     let rendered = DreamTemplate::new(&context).to_string();
 
     // Per-urge breakdowns belong in introspect/reflect templates, not the greeting.
@@ -788,10 +807,11 @@ async fn greeting_pressure_omits_verbose_forms() {
 
 #[tokio::test]
 async fn greeting_includes_next_steps_and_hints() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
     let rendered = DreamTemplate::new(&context).to_string();
 
     assert!(
@@ -819,10 +839,11 @@ async fn greeting_includes_next_steps_and_hints() {
 
 #[tokio::test]
 async fn greeting_omits_legacy_sections() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
 
-    let context = dream(&context, &agent).await;
+    let context = dream(&client, &agent).await;
     let rendered = DreamTemplate::new(&context).to_string();
 
     assert!(
@@ -849,9 +870,10 @@ async fn greeting_omits_legacy_sections() {
 
 #[tokio::test]
 async fn introspect_template_renders() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
-    let context = dream(&context, &agent).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
+    let context = dream(&client, &agent).await;
 
     let pressures = RelevantPressures::from_pressures(
         context
@@ -868,9 +890,10 @@ async fn introspect_template_renders() {
 
 #[tokio::test]
 async fn guidebook_template_renders_vocabulary() {
-    let (context, _app) = seeded_context().await;
-    let agent = seed_agent(&context).await;
-    let context = dream(&context, &agent).await;
+    let app = seeded_app().await;
+    let client = app.client();
+    let agent = seed_agent(&client).await;
+    let context = dream(&client, &agent).await;
 
     let rendered = GuidebookTemplate::new(&context).to_string();
 

--- a/crates/oneiros-engine/src/tests/mod.rs
+++ b/crates/oneiros-engine/src/tests/mod.rs
@@ -3,167 +3,157 @@ mod dream_context;
 mod harness;
 mod workflows;
 
+use crate::tests::harness::TestApp;
 use crate::*;
 
 // ── Internal mechanics tests ────────────────────────────────────
 //
-// These test infrastructure that isn't exposed through the CLI/HTTP
-// surface: projection replay and storage content-addressing.
-// Write-side event emission is covered implicitly by every workflow
-// that persists and reads back data.
+// These test infrastructure that isn't directly exposed through HTTP:
+// projection replay (driven via the `project replay` CLI command) and
+// storage content-addressing (compress/decompress round-trip on the local
+// blob, which has no HTTP fetch route by design).
+//
+// All bootstrap and write-side setup goes through TestApp + TestClient —
+// the same path the binary takes. Pulling a ProjectLog out of the app is
+// reserved for exercising the specific internal mechanism under test.
 
-fn test_config(brain: &str) -> (Config, tempfile::TempDir) {
-    let dir = tempfile::tempdir().expect("create tempdir");
-    let config = Config::builder()
-        .data_dir(dir.path().to_path_buf())
-        .brain(BrainName::new(brain))
-        .build();
-
-    (config, dir)
+async fn booted_app() -> TestApp {
+    TestApp::new()
+        .await
+        .expect("boot test app")
+        .init_system()
+        .await
+        .expect("init system")
+        .init_project()
+        .await
+        .expect("init project")
 }
 
-async fn project_log() -> (ProjectLog, tempfile::TempDir) {
-    let (config, dir) = test_config("test");
-    let system = config.system();
-
-    SystemService::init(
-        &system,
-        &InitSystem::builder_v1()
-            .name("test".to_string())
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap();
-
-    ProjectService::init(
-        &system,
-        &InitProject::builder_v1()
-            .name(BrainName::new("test"))
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap();
-
-    (config.project(), dir)
+async fn seed_persona(client: &harness::TestClient) {
+    client
+        .persona()
+        .set(
+            &SetPersona::builder_v1()
+                .name("test-persona")
+                .description("A test persona")
+                .prompt("You are a test.")
+                .build()
+                .into(),
+        )
+        .await
+        .expect("seed persona");
 }
 
-async fn seed_persona(context: &ProjectLog) {
-    PersonaService::set(
-        context,
-        &SetPersona::builder_v1()
-            .name("test-persona")
-            .description("A test persona")
-            .prompt("You are a test.")
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap();
-}
-
-async fn seed_agent(context: &ProjectLog) {
-    AgentService::create(
-        context,
-        &CreateAgent::V1(
+async fn seed_agent(client: &harness::TestClient) {
+    client
+        .agent()
+        .create(&CreateAgent::V1(
             CreateAgentV1::builder()
                 .name("gov")
                 .persona("test-persona")
                 .description("Governor")
                 .prompt("You govern")
                 .build(),
-        ),
-    )
-    .await
-    .unwrap();
+        ))
+        .await
+        .expect("seed agent");
 }
 
 #[tokio::test]
 async fn replay_reconstructs_read_models() {
-    let (context, _dir) = project_log().await;
+    let app = booted_app().await;
+    let client = app.client();
 
-    LevelService::set(
-        &context,
-        &SetLevel::builder_v1()
-            .name("working")
-            .description("Active")
-            .prompt("")
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap();
-    LevelService::set(
-        &context,
-        &SetLevel::builder_v1()
-            .name("session")
-            .description("Session")
-            .prompt("")
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap();
-    seed_persona(&context).await;
-    seed_agent(&context).await;
-    CognitionService::add(
-        &context,
-        &AddCognition::builder_v1()
-            .agent("gov.test-persona")
-            .texture("observation")
-            .content("Test thought")
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap();
+    client
+        .level()
+        .set(
+            &SetLevel::builder_v1()
+                .name("working")
+                .description("Active")
+                .prompt("")
+                .build()
+                .into(),
+        )
+        .await
+        .expect("set working level");
+    client
+        .level()
+        .set(
+            &SetLevel::builder_v1()
+                .name("session")
+                .description("Session")
+                .prompt("")
+                .build()
+                .into(),
+        )
+        .await
+        .expect("set session level");
+    seed_persona(&client).await;
+    seed_agent(&client).await;
+    client
+        .cognition()
+        .add(
+            &AddCognition::builder_v1()
+                .agent("gov.test-persona")
+                .texture("observation")
+                .content("Test thought")
+                .build()
+                .into(),
+        )
+        .await
+        .expect("add cognition");
 
     // Verify read models before replay
-    match LevelService::list(&context, &ListLevels::builder_v1().build().into())
+    match client
+        .level()
+        .list(&ListLevels::builder_v1().build().into())
         .await
-        .unwrap()
+        .expect("list levels")
     {
         LevelResponse::Levels(LevelsResponse::V1(levels)) => assert_eq!(levels.items.len(), 2),
         other => panic!("Expected Listed, got {other:?}"),
     }
 
-    // Replay — resets all projections and re-applies all events
-    context.replay().unwrap();
+    // Replay through the CLI — same path the user takes.
+    app.command("project replay")
+        .await
+        .expect("project replay command");
 
     // Read models should be identical after replay
-    match LevelService::list(&context, &ListLevels::builder_v1().build().into())
+    match client
+        .level()
+        .list(&ListLevels::builder_v1().build().into())
         .await
-        .unwrap()
+        .expect("list levels after replay")
     {
         LevelResponse::Levels(LevelsResponse::V1(levels)) => assert_eq!(levels.items.len(), 2),
         other => panic!("Expected Listed after replay, got {other:?}"),
     }
-    match AgentService::get(
-        &context,
-        &GetAgent::V1(
+    match client
+        .agent()
+        .get(&GetAgent::V1(
             GetAgentV1::builder()
                 .key(AgentName::new("gov.test-persona"))
                 .build(),
-        ),
-    )
-    .await
-    .unwrap()
+        ))
+        .await
+        .expect("get agent after replay")
     {
         AgentResponse::AgentDetails(AgentDetailsResponse::V1(a)) => {
             assert_eq!(a.agent.name, AgentName::new("gov.test-persona"))
         }
         other => panic!("Expected AgentDetails after replay, got {other:?}"),
     }
-    match CognitionService::list(
-        &context,
-        &ListCognitions::builder_v1()
-            .agent(AgentName::new("gov.test-persona"))
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap()
+    match client
+        .cognition()
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("gov.test-persona"))
+                .build()
+                .into(),
+        )
+        .await
+        .expect("list cognitions after replay")
     {
         CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
             assert_eq!(cogs.items.len(), 1)
@@ -174,32 +164,35 @@ async fn replay_reconstructs_read_models() {
 
 #[tokio::test]
 async fn replay_recovers_from_deleted_bookmark_db() {
-    let (context, _dir) = project_log().await;
+    let app = booted_app().await;
+    let client = app.client();
 
-    seed_persona(&context).await;
-    seed_agent(&context).await;
-    CognitionService::add(
-        &context,
-        &AddCognition::builder_v1()
-            .agent("gov.test-persona")
-            .texture("observation")
-            .content("Pre-nuke thought")
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap();
+    seed_persona(&client).await;
+    seed_agent(&client).await;
+    client
+        .cognition()
+        .add(
+            &AddCognition::builder_v1()
+                .agent("gov.test-persona")
+                .texture("observation")
+                .content("Pre-nuke thought")
+                .build()
+                .into(),
+        )
+        .await
+        .expect("add cognition");
 
     // Verify baseline before nuking the DB
-    match CognitionService::list(
-        &context,
-        &ListCognitions::builder_v1()
-            .agent(AgentName::new("gov.test-persona"))
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap()
+    match client
+        .cognition()
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("gov.test-persona"))
+                .build()
+                .into(),
+        )
+        .await
+        .expect("list cognitions baseline")
     {
         CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
             assert_eq!(cogs.items.len(), 1);
@@ -208,45 +201,42 @@ async fn replay_recovers_from_deleted_bookmark_db() {
     }
 
     // Simulate schema-change / corruption: delete the bookmark DB file
-    let db_path = context.config.bookmark_db_path();
+    let db_path = app.config().bookmark_db_path();
     std::fs::remove_file(&db_path).unwrap();
     let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
     let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
 
-    // Replay should recreate the DB and restore all data
-    match ProjectService::replay(&context).unwrap() {
-        ProjectResponse::Replayed(ReplayedResponse::V1(result)) => {
-            assert!(result.replayed > 0);
-        }
-        other => panic!("Expected Replayed, got {other:?}"),
-    }
+    // Replay through the CLI should recreate the DB and restore all data.
+    app.command("project replay")
+        .await
+        .expect("project replay command");
 
     // Data should be fully restored
-    match AgentService::get(
-        &context,
-        &GetAgent::V1(
+    match client
+        .agent()
+        .get(&GetAgent::V1(
             GetAgentV1::builder()
                 .key(AgentName::new("gov.test-persona"))
                 .build(),
-        ),
-    )
-    .await
-    .unwrap()
+        ))
+        .await
+        .expect("get agent after replay")
     {
         AgentResponse::AgentDetails(AgentDetailsResponse::V1(a)) => {
             assert_eq!(a.agent.name, AgentName::new("gov.test-persona"))
         }
         other => panic!("Expected AgentDetails after replay, got {other:?}"),
     }
-    match CognitionService::list(
-        &context,
-        &ListCognitions::builder_v1()
-            .agent(AgentName::new("gov.test-persona"))
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap()
+    match client
+        .cognition()
+        .list(
+            &ListCognitions::builder_v1()
+                .agent(AgentName::new("gov.test-persona"))
+                .build()
+                .into(),
+        )
+        .await
+        .expect("list cognitions after replay")
     {
         CognitionResponse::Cognitions(CognitionsResponse::V1(cogs)) => {
             assert_eq!(cogs.items.len(), 1);
@@ -257,20 +247,22 @@ async fn replay_recovers_from_deleted_bookmark_db() {
 
 #[tokio::test]
 async fn storage_content_round_trips() {
-    let (context, _dir) = project_log().await;
+    let app = booted_app().await;
+    let client = app.client();
     let content = b"Hello, oneiros!";
 
-    let entry = match StorageService::upload(
-        &context,
-        &UploadStorage::builder_v1()
-            .key("test.txt")
-            .description("A test file")
-            .data(content.to_vec())
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap()
+    let entry = match client
+        .storage()
+        .upload(
+            &UploadStorage::builder_v1()
+                .key("test.txt")
+                .description("A test file")
+                .data(content.to_vec())
+                .build()
+                .into(),
+        )
+        .await
+        .expect("upload storage")
     {
         StorageResponse::StorageSet(StorageSetResponse::V1(set)) => {
             assert_eq!(set.entry.key.as_str(), "test.txt");
@@ -279,26 +271,30 @@ async fn storage_content_round_trips() {
         other => panic!("Expected StorageSet, got {other:?}"),
     };
 
-    // Get content — round-trips through compress/decompress
-    let retrieved = StorageService::get_content(&context, &StorageKey::new("test.txt"))
+    // Hash should be stable — verify via the show client.
+    match client
+        .storage()
+        .show(
+            &GetStorage::builder_v1()
+                .key(StorageKey::new("test.txt"))
+                .build()
+                .into(),
+        )
         .await
-        .unwrap();
-    assert_eq!(retrieved, content);
-
-    // Hash should be stable
-    match StorageService::show(
-        &context,
-        &GetStorage::builder_v1()
-            .key(StorageKey::new("test.txt"))
-            .build()
-            .into(),
-    )
-    .await
-    .unwrap()
+        .expect("show storage")
     {
         StorageResponse::StorageDetails(StorageDetailsResponse::V1(shown)) => {
             assert_eq!(shown.entry.hash, entry.hash);
         }
         other => panic!("Expected StorageDetails, got {other:?}"),
     }
+
+    // Internal mechanism under test: blob compression round-trip. There is
+    // no HTTP route that returns raw blob bytes, so this single call
+    // exercises the storage subsystem directly.
+    let context = app.config().project();
+    let retrieved = StorageService::get_content(&context, &StorageKey::new("test.txt"))
+        .await
+        .expect("get content");
+    assert_eq!(retrieved, content);
 }

--- a/crates/oneiros-engine/src/tests/workflows/bootstrap.rs
+++ b/crates/oneiros-engine/src/tests/workflows/bootstrap.rs
@@ -86,6 +86,113 @@ async fn from_nothing_to_a_dreaming_agent() -> Result<(), Box<dyn core::error::E
     Ok(())
 }
 
+/// `system init` claims the host. Once a tenant exists, a second call must
+/// surface the conflict via `HostAlreadyInitialized` rather than silently
+/// re-emitting events. The route is unauthenticated by design — this is the
+/// invariant that protects it from being usable as a takeover vector.
+#[tokio::test]
+async fn system_init_twice_returns_already_initialized() -> Result<(), Box<dyn core::error::Error>>
+{
+    let app = TestApp::new().await?;
+
+    let host_client = Client::new(app.base_url());
+    let system = SystemClient::new(&host_client);
+    let request: InitSystem = InitSystem::builder_v1().name("test").build().into();
+
+    match system.init(&request).await? {
+        SystemResponse::SystemInitialized(_) => {}
+        other => panic!("first init should succeed, got {other:?}"),
+    }
+
+    match system.init(&request).await? {
+        SystemResponse::HostAlreadyInitialized => {}
+        other => panic!("second init should refuse, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+/// Setup orchestrates the full bootstrap through HTTP. With the server
+/// already running, setup discovers it (no install prompt), drives the
+/// init / seed sequence over HTTP, and the token issued by project init
+/// authenticates the subsequent seed calls. The MCP step prompts in an
+/// interactive shell; in a non-interactive test it falls through to
+/// McpSkipped, leaving no `.mcp.json` side-effect.
+#[tokio::test]
+async fn setup_drives_bootstrap_through_http() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new().await?;
+
+    let result = app.command("setup").await?;
+    let response = match result.response() {
+        Responses::Setup(setup) => setup.clone(),
+        other => panic!("expected Setup response, got {other:?}"),
+    };
+    let SetupResponse::SetupComplete(SetupCompleteResponse::V1(complete)) = response;
+    let steps = complete.steps;
+
+    // Server was already running — no install/start step should appear.
+    for step in &steps {
+        match step {
+            SetupStep::ServiceInstalled | SetupStep::ServiceStarted => panic!(
+                "setup should not have installed/started the service when one was already running, steps: {steps:?}"
+            ),
+            _ => {}
+        }
+    }
+
+    // Bootstrap chain must complete via HTTP.
+    assert!(
+        steps
+            .iter()
+            .any(|s| matches!(s, SetupStep::SystemInitialized)),
+        "setup should report SystemInitialized, steps: {steps:?}"
+    );
+    assert!(
+        steps
+            .iter()
+            .any(|s| matches!(s, SetupStep::ProjectInitialized(_))),
+        "setup should report ProjectInitialized, steps: {steps:?}"
+    );
+    // Seed steps prove the token handoff worked: they require a valid Bearer
+    // token, and the token is sourced from the ProjectInitialized response.
+    assert!(
+        steps
+            .iter()
+            .any(|s| matches!(s, SetupStep::VocabularySeeded)),
+        "seed core must succeed via HTTP, proving token handoff, steps: {steps:?}"
+    );
+    assert!(
+        steps.iter().any(|s| matches!(s, SetupStep::AgentsSeeded)),
+        "seed agents must succeed via HTTP, proving token handoff, steps: {steps:?}"
+    );
+
+    // No StepFailed entries — the orchestration is end-to-end clean.
+    for step in &steps {
+        if let SetupStep::StepFailed { step, reason } = step {
+            panic!("setup reported StepFailed at {step}: {reason}");
+        }
+    }
+
+    // The bootstrap left a usable project: an authenticated client should
+    // see the seeded vocabulary.
+    let client = app.client();
+    match client
+        .level()
+        .list(&ListLevels::builder_v1().build().into())
+        .await?
+    {
+        LevelResponse::Levels(LevelsResponse::V1(levels)) => {
+            assert!(
+                levels.items.len() >= 4,
+                "post-setup brain should have the seeded levels"
+            );
+        }
+        other => panic!("expected Levels post-setup, got {other:?}"),
+    }
+
+    Ok(())
+}
+
 /// Project init should produce a "main" bookmark in the system DB.
 ///
 /// Nothing implicit: if a resource exists, an event brought it into being

--- a/crates/oneiros-engine/src/tests/workflows/system.rs
+++ b/crates/oneiros-engine/src/tests/workflows/system.rs
@@ -213,36 +213,34 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
     Ok(())
 }
 
-/// System init must generate the host keypair so that the host
-/// identity exists before the server is ever started.
+/// System init must produce a usable host keypair on disk, and must not
+/// rotate it on subsequent calls. We wield the app: drive `system init`
+/// through the CLI (HTTP-mediated) and then verify the keypair file.
 #[tokio::test]
 async fn system_init_creates_host_keypair() -> Result<(), Box<dyn core::error::Error>> {
-    let dir = tempfile::tempdir()?;
-    let config = Config::builder()
-        .data_dir(dir.path().to_path_buf())
-        .brain(BrainName::new("test"))
-        .build();
+    let app = TestApp::new().await?;
+    let keys = HostKey::new(&app.config().data_dir);
 
-    let context = HostLog::new(config.clone());
-    let keys = HostKey::new(&config.data_dir);
+    // The server's bind path generates the host key (see `ServerState::bind`),
+    // but `Engine::start` returns before that bind completes. Wait for the
+    // server to handle a request — that synchronizes against bind — so the
+    // key file is guaranteed to be on disk.
+    let _ = ServiceService::status(app.config()).await;
 
-    // Before init, no host key exists
-    assert!(
-        !keys.path().exists(),
-        "host key should not exist before system init"
+    let key_before = keys
+        .load()?
+        .expect("host key should exist after server bind");
+
+    app.command("system init --name test").await?;
+
+    let key_after = keys
+        .load()?
+        .expect("host key should still exist after init");
+    assert_eq!(
+        key_before.to_bytes(),
+        key_after.to_bytes(),
+        "system init must not rotate the host keypair",
     );
-
-    SystemService::init(&context, &InitSystem::builder_v1().build().into()).await?;
-
-    // After init, the host key should exist
-    assert!(
-        keys.path().exists(),
-        "system init should create the host keypair"
-    );
-
-    // The key should be loadable
-    let secret = keys.load()?;
-    assert!(secret.is_some(), "host key should be loadable after init");
 
     Ok(())
 }


### PR DESCRIPTION
We had a few special case commands that didn't leverage the host server like they ought to have. Some commands - doctor, for example - _must_ operate locally. But not all. For any command, particularly, where an emit might be necessary, we need to make sure that we channel it through the http layer, so that when we get to the point where we start structuring an actor strata, it can all sit in the server itself. That's what this command gets us: closer to that point.