### PR TITLE
Messaging

### DIFF
--- a/crates/oneiros-engine/src/bus/bookmark_actor.rs
+++ b/crates/oneiros-engine/src/bus/bookmark_actor.rs
@@ -1,0 +1,176 @@
+//! `BookmarkActor` — per-bookmark actor that owns both projection
+//! application and chronicle recording.
+//!
+//! One actor per `(brain, bookmark)` pair. Spawned lazily by the
+//! `ProjectActor` the first time it sees an event for a bookmark.
+//!
+//! On each `Stored` event the actor does two things in order:
+//! 1. Apply brain projections to the bookmark DB.
+//! 2. Record the event in the bookmark's chronicle (HAMT in the host
+//!    system DB).
+//!
+//! Doing both in the same actor — per-event, sequential — means there's
+//! no race between projection and chronicle for distribution callers.
+//! Wait for the chronicle to settle and the projection has settled too.
+//!
+//! On initial spawn the actor catches up: walks the project's event log
+//! and applies each event through projection + chronicle. Both
+//! operations are idempotent (delete-then-insert projections; HAMT
+//! insert by event id), so replaying the log is safe whether starting
+//! empty or inheriting from a fork. A `Reset` lifecycle message
+//! triggers a full rebuild — same shape, on demand.
+
+use tokio::sync::mpsc;
+
+use crate::*;
+
+#[derive(Clone)]
+pub struct BookmarkMailbox {
+    tx: mpsc::UnboundedSender<LifecycleMessage<Message<AtBookmark>>>,
+}
+
+impl BookmarkMailbox {
+    pub fn tell(&self, message: LifecycleMessage<Message<AtBookmark>>) {
+        if let Err(err) = self.tx.send(message) {
+            tracing::warn!(error = %err, "bookmark actor: receiver closed; message dropped");
+        }
+    }
+
+    /// Convenience — wrap a domain message and send.
+    pub fn tell_domain(&self, message: Message<AtBookmark>) {
+        self.tell(LifecycleMessage::Domain(message));
+    }
+
+    /// Convenience — send a Reset signal.
+    pub fn reset(&self) {
+        self.tell(LifecycleMessage::Reset);
+    }
+}
+
+pub struct BookmarkActor {
+    config: Config,
+    brain: BrainName,
+    bookmark: BookmarkName,
+    projections: Projections<BrainCanon>,
+    chronicle: Chronicle,
+}
+
+impl BookmarkActor {
+    /// Spawn a bookmark actor. The reducer pipeline from the entry is
+    /// wired into the projection set; the chronicle handle is the
+    /// shared `Arc<Mutex>` from `CanonIndex`.
+    ///
+    /// The actor catches up from history on its first run, before
+    /// processing any incoming domain messages.
+    pub fn spawn(
+        config: Config,
+        brain: BrainName,
+        bookmark: BookmarkName,
+        entry: BookmarkEntry,
+    ) -> BookmarkMailbox {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let actor = Self {
+            config,
+            brain,
+            bookmark,
+            projections: Projections::project_with_pipeline(entry.pipeline),
+            chronicle: entry.chronicle,
+        };
+        tokio::spawn(actor.run(rx));
+        BookmarkMailbox { tx }
+    }
+
+    async fn run(self, mut rx: mpsc::UnboundedReceiver<LifecycleMessage<Message<AtBookmark>>>) {
+        if let Err(err) = self.catch_up().await {
+            tracing::error!(
+                brain = %self.brain,
+                bookmark = %self.bookmark,
+                ?err,
+                "bookmark actor: initial catch-up failed",
+            );
+        }
+
+        while let Some(message) = rx.recv().await {
+            match message {
+                LifecycleMessage::Domain(message) => {
+                    if let Err(err) = self.handle(message).await {
+                        tracing::error!(
+                            brain = %self.brain,
+                            bookmark = %self.bookmark,
+                            ?err,
+                            "bookmark actor: handle failed",
+                        );
+                    }
+                }
+                LifecycleMessage::Reset => {
+                    if let Err(err) = self.catch_up().await {
+                        tracing::error!(
+                            brain = %self.brain,
+                            bookmark = %self.bookmark,
+                            ?err,
+                            "bookmark actor: reset/catch-up failed",
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Replay the project's event log into this bookmark — wipes
+    /// projection state, walks every event, applies each through
+    /// projections AND records it in the chronicle. Used for both
+    /// first-spawn catch-up and explicit `Reset`.
+    async fn catch_up(&self) -> Result<(), EventError> {
+        // Step 1: projections (and capture the events list while the
+        // bookmark DB is open). Drop the connection before opening
+        // the host DB — `EventLog<'_>` borrows the connection's
+        // statement cache (RefCell), which isn't Send across awaits.
+        let events = {
+            let bookmark_db =
+                BookmarkDb::open_with(&self.config.platform(), &self.brain, &self.bookmark).await?;
+            self.projections.migrate(&bookmark_db)?;
+            let log = EventLog::attached(&bookmark_db);
+            self.projections.replay_brain(&bookmark_db, &log)?;
+            log.load_all()?
+        };
+
+        if events.is_empty() {
+            return Ok(());
+        }
+
+        // Step 2: chronicle catch-up — record every event. Idempotent
+        // on event id.
+        let host_db = HostDb::open_with(&self.config.platform()).await?;
+        let store = ChronicleStore::new(&host_db);
+        store.migrate()?;
+        for event in &events {
+            self.chronicle
+                .record(event, &store.resolver(), &store.writer())?;
+        }
+        Ok(())
+    }
+
+    async fn handle(&self, message: Message<AtBookmark>) -> Result<(), EventError> {
+        let stored = match message.event {
+            Event::Stored(boxed) => *boxed,
+            _ => return Ok(()),
+        };
+
+        // 1. Apply projection.
+        let bookmark_db =
+            BookmarkDb::open_with(&self.config.platform(), &self.brain, &self.bookmark).await?;
+        self.projections.apply_brain(&bookmark_db, &stored)?;
+        drop(bookmark_db);
+
+        // 2. Record in chronicle. Sequential — by the time this
+        //    returns, both projection and chronicle reflect the
+        //    event. No race for downstream waiters.
+        let host_db = HostDb::open_with(&self.config.platform()).await?;
+        let store = ChronicleStore::new(&host_db);
+        store.migrate()?;
+        self.chronicle
+            .record(&stored, &store.resolver(), &store.writer())?;
+
+        Ok(())
+    }
+}

--- a/crates/oneiros-engine/src/bus/host_actor.rs
+++ b/crates/oneiros-engine/src/bus/host_actor.rs
@@ -1,0 +1,141 @@
+//! `HostActor` — the static, always-running root of the actor tree.
+//!
+//! Receives every `RoutedMessage` from the bus. Host-tier work
+//! (appending to the host event log, applying system-tier projections)
+//! happens here. Project- and bookmark-tier `New` messages are
+//! forwarded to lazily-spawned `ProjectActor` children, one per brain.
+//! `Import` messages are forwarded to lazily-spawned `InboundActor`
+//! children — sibling to the project actor — that handle foreign
+//! event ingestion. The brain is read off the message's scope; first
+//! sighting spawns the child.
+
+use std::collections::HashMap;
+
+use tokio::sync::mpsc;
+
+use crate::*;
+
+pub struct HostActor {
+    /// Server config — used to compose project-tier scopes when
+    /// lazy-spawning project children.
+    config: Config,
+    canons: CanonIndex,
+    projects: HashMap<BrainName, ProjectMailbox>,
+    inbounds: HashMap<BrainName, InboundMailbox>,
+}
+
+impl HostActor {
+    /// Spawn the host actor in the background. Returns a `JoinHandle` so
+    /// callers can hold it for the server's lifetime; dropping the handle
+    /// detaches the task (the actor still runs until the receiver closes).
+    pub fn spawn(
+        config: Config,
+        canons: CanonIndex,
+        rx: mpsc::UnboundedReceiver<RoutedMessage>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let actor = Self {
+                config,
+                canons,
+                projects: HashMap::new(),
+                inbounds: HashMap::new(),
+            };
+            actor.run(rx).await;
+        })
+    }
+
+    async fn run(mut self, mut rx: mpsc::UnboundedReceiver<RoutedMessage>) {
+        while let Some(message) = rx.recv().await {
+            match message {
+                RoutedMessage::Host(message) => {
+                    if let Err(err) = self.handle_host(message).await {
+                        tracing::error!(?err, "host actor: handle failed");
+                    }
+                }
+                RoutedMessage::Project(message) => {
+                    let brain = message.scope.project().name.clone();
+                    match self.project_mailbox(brain) {
+                        Ok(mailbox) => mailbox.tell_domain(ProjectDomain::Project(message)),
+                        Err(err) => tracing::error!(?err, "host actor: project compose failed"),
+                    }
+                }
+                RoutedMessage::Bookmark(message) => {
+                    let brain = message.scope.project().name.clone();
+                    match self.project_mailbox(brain) {
+                        Ok(mailbox) => mailbox.tell_domain(ProjectDomain::Bookmark(message)),
+                        Err(err) => tracing::error!(?err, "host actor: project compose failed"),
+                    }
+                }
+                RoutedMessage::Import(message) => {
+                    let brain = message.scope.project().name.clone();
+                    match self.inbound_mailbox(brain) {
+                        Ok(mailbox) => mailbox.tell_domain(message),
+                        Err(err) => tracing::error!(?err, "host actor: inbound compose failed"),
+                    }
+                }
+            }
+        }
+
+        tracing::info!("host actor: bus closed, exiting");
+    }
+
+    async fn handle_host(&self, message: Message<AtHost>) -> Result<(), EventError> {
+        let Message { scope, event } = message;
+
+        let new_event = match event {
+            Event::New(boxed) => *boxed,
+            // Stored events at the host tier are notifications for
+            // downstream actors (chronicle, future host-tier consumers).
+            // The host actor doesn't have downstream consumers yet, so
+            // it's a no-op for now.
+            Event::Stored(_) => return Ok(()),
+            // The other variants don't make sense as bus traffic — they
+            // arise from parsing on-disk rows. Ignored at the host
+            // boundary.
+            Event::Known(_)
+            | Event::Ephemeral(_)
+            | Event::Unknown(_)
+            | Event::Malformed
+            | Event::Import(_) => {
+                tracing::warn!(
+                    event_type = event.event_type(),
+                    "host actor: unexpected event variant on bus"
+                );
+                return Ok(());
+            }
+        };
+
+        let host_db = HostDb::open(&scope).await?;
+        let projections = Projections::system();
+        projections.migrate(&host_db)?;
+        let stored = EventLog::new(&host_db).append(&new_event)?;
+        projections.apply(&host_db, &stored)?;
+
+        Ok(())
+    }
+
+    fn project_mailbox(&mut self, brain: BrainName) -> Result<ProjectMailbox, ComposeError> {
+        if let Some(mb) = self.projects.get(&brain) {
+            return Ok(mb.clone());
+        }
+        let scope = ComposeScope::new(self.config.clone()).project(brain.clone())?;
+        let mb = ProjectActor::spawn(brain.clone(), scope, self.canons.clone());
+        self.projects.insert(brain, mb.clone());
+        Ok(mb)
+    }
+
+    fn inbound_mailbox(&mut self, brain: BrainName) -> Result<InboundMailbox, ComposeError> {
+        if let Some(mb) = self.inbounds.get(&brain) {
+            return Ok(mb.clone());
+        }
+        // The inbound actor needs a way to forward Stored events into
+        // the project actor's `Forward` path — so the same downstream
+        // (bookmark + chronicle) sees them as if they were locally
+        // stored. We give it a clone of the project actor's mailbox.
+        let project = self.project_mailbox(brain.clone())?;
+        let scope = ComposeScope::new(self.config.clone()).project(brain.clone())?;
+        let mb = InboundActor::spawn(brain.clone(), scope, project);
+        self.inbounds.insert(brain, mb.clone());
+        Ok(mb)
+    }
+}

--- a/crates/oneiros-engine/src/bus/inbound_actor.rs
+++ b/crates/oneiros-engine/src/bus/inbound_actor.rs
@@ -1,0 +1,110 @@
+//! `InboundActor` — handles foreign event ingestion for one brain.
+//!
+//! Sibling to the `ProjectActor` under `HostActor`, lazy-spawned per
+//! brain. Listens to `Event::Import(StoredEvent)` messages dispatched
+//! by the bridge during peer collect (or by any future ingestion
+//! source).
+//!
+//! Its job:
+//! 1. Insert-or-ignore the event into the project's events.db.
+//!    Idempotent on event id.
+//! 2. Tell the brain's project actor "Forward" — same downstream as a
+//!    local emission, but no append happens.
+//!
+//! After this, the bookmark + chronicle children see a regular
+//! `Stored` notification and project / record it like any other
+//! event. Origin is the inbound actor's concern only; downstream
+//! doesn't know or care where the event came from.
+
+use tokio::sync::mpsc;
+
+use crate::*;
+
+#[derive(Clone)]
+pub struct InboundMailbox {
+    tx: mpsc::UnboundedSender<LifecycleMessage<Message<AtBookmark>>>,
+}
+
+impl InboundMailbox {
+    pub fn tell(&self, message: LifecycleMessage<Message<AtBookmark>>) {
+        if let Err(err) = self.tx.send(message) {
+            tracing::warn!(error = %err, "inbound actor: receiver closed; message dropped");
+        }
+    }
+
+    pub fn tell_domain(&self, message: Message<AtBookmark>) {
+        self.tell(LifecycleMessage::Domain(message));
+    }
+}
+
+pub struct InboundActor {
+    brain: BrainName,
+    scope: Scope<AtProject>,
+    project: ProjectMailbox,
+}
+
+impl InboundActor {
+    pub fn spawn(
+        brain: BrainName,
+        scope: Scope<AtProject>,
+        project: ProjectMailbox,
+    ) -> InboundMailbox {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let actor = Self {
+            brain,
+            scope,
+            project,
+        };
+        tokio::spawn(actor.run(rx));
+        InboundMailbox { tx }
+    }
+
+    async fn run(self, mut rx: mpsc::UnboundedReceiver<LifecycleMessage<Message<AtBookmark>>>) {
+        while let Some(message) = rx.recv().await {
+            match message {
+                LifecycleMessage::Domain(message) => {
+                    if let Err(err) = self.handle(message).await {
+                        tracing::error!(
+                            brain = %self.brain,
+                            ?err,
+                            "inbound actor: ingest failed",
+                        );
+                    }
+                }
+                LifecycleMessage::Reset => {
+                    // Inbound actor has no state to reset — events.db
+                    // is the project actor's concern, and projection
+                    // state lives in the children. Ignored here.
+                }
+            }
+        }
+    }
+
+    async fn handle(&self, message: Message<AtBookmark>) -> Result<(), EventError> {
+        let Message { scope, event } = message;
+        let stored = match event {
+            Event::Import(boxed) => *boxed,
+            // The actor only listens to Import — anything else is a
+            // misroute.
+            _ => return Ok(()),
+        };
+        // Step 1: ensure the event is in events.db. Insert-or-ignore
+        // on id — duplicate ingests are no-ops.
+        let events_db = EventsDb::open(&self.scope).await?;
+        EventLog::new(&events_db).init()?;
+        EventLog::new(&events_db).import(&stored)?;
+        drop(events_db);
+
+        // Step 2: notify the project actor. It owns the bookmark +
+        // chronicle children, and forwards Stored to them as if the
+        // event had been locally appended.
+        let stored_message = Message {
+            scope,
+            event: Event::Stored(Box::new(stored)),
+        };
+        self.project
+            .tell_domain(ProjectDomain::Forward(stored_message));
+
+        Ok(())
+    }
+}

--- a/crates/oneiros-engine/src/bus/mailbox.rs
+++ b/crates/oneiros-engine/src/bus/mailbox.rs
@@ -1,0 +1,177 @@
+//! Mailbox — the typed envelope and the channel handle that carries it.
+
+use tokio::sync::mpsc;
+
+use crate::*;
+
+/// A bus message — a tier-typed scope paired with the event to dispatch.
+///
+/// `T` is the scope tier (`AtHost`, `AtProject`, `AtBookmark`). The tier
+/// is encoded in the type so the receiving actor doesn't have to
+/// re-derive it; the inner `Scope<T>` already carries the resources it
+/// needs for that tier. The `event` field carries lifecycle: a fresh
+/// emission travels as `Event::New(...)`, a post-append notification
+/// travels as `Event::Stored(...)`, a foreign event arriving for
+/// ingest travels as `Event::Import(...)`.
+#[derive(Clone)]
+pub struct Message<T> {
+    pub scope: Scope<T>,
+    pub event: Event,
+}
+
+impl<T> Message<T> {
+    pub fn new(scope: Scope<T>, event: impl Into<Event>) -> Self {
+        Self {
+            scope,
+            event: event.into(),
+        }
+    }
+}
+
+/// Lifecycle wrapper for actor mailboxes.
+///
+/// Every per-actor mailbox carries `LifecycleMessage<DomainMessage>`.
+/// The `Domain` variant carries the actor's regular work; the `Reset`
+/// variant is a control signal — the actor wipes its state and runs
+/// catch-up from history. Catch-up on initial spawn is implicit;
+/// `Reset` is the explicit way to ask for a rebuild after the actor
+/// is already running.
+#[derive(Clone)]
+pub enum LifecycleMessage<M> {
+    Domain(M),
+    Reset,
+}
+
+/// The over-the-wire form of a bus message — variants index by tier.
+///
+/// One channel feeds the host actor; the host actor matches on this
+/// enum to decide whether to handle the message itself or to forward
+/// it down the actor tree. New tiers are additive variants, never new
+/// channels.
+///
+/// `Import` is bookmark-tier but routes to a separate `InboundActor`,
+/// not the project actor — foreign events have their own ingestion
+/// path (insert-or-ignore by id), distinct from the local `New` path
+/// (append + assign rowid).
+#[derive(Clone)]
+pub enum RoutedMessage {
+    Host(Message<AtHost>),
+    Project(Message<AtProject>),
+    Bookmark(Message<AtBookmark>),
+    Import(Message<AtBookmark>),
+}
+
+impl From<Message<AtHost>> for RoutedMessage {
+    fn from(message: Message<AtHost>) -> Self {
+        Self::Host(message)
+    }
+}
+
+impl From<Message<AtProject>> for RoutedMessage {
+    fn from(message: Message<AtProject>) -> Self {
+        Self::Project(message)
+    }
+}
+
+impl From<Message<AtBookmark>> for RoutedMessage {
+    fn from(message: Message<AtBookmark>) -> Self {
+        // `Import` is dispatched explicitly by the bridge — the default
+        // wrap for a bookmark message is `Bookmark` (local path).
+        Self::Bookmark(message)
+    }
+}
+
+/// The bus handle held by the HTTP server and threaded into services.
+///
+/// Cloneable, fire-and-forget. `tell` enqueues a message and returns
+/// immediately; downstream actors react on their own tasks. A failed
+/// send (receiver dropped) is logged at warn-level — the bus is
+/// supposed to outlive every caller, so a closed receiver indicates
+/// the server is tearing down.
+#[derive(Clone)]
+pub struct Mailbox {
+    tx: mpsc::UnboundedSender<RoutedMessage>,
+}
+
+impl Mailbox {
+    /// Create a new bus channel and return the sending handle alongside
+    /// the receiver. The receiver is consumed by the host actor.
+    pub fn open() -> (Self, mpsc::UnboundedReceiver<RoutedMessage>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Self { tx }, rx)
+    }
+
+    /// Fire-and-forget enqueue. `Into<RoutedMessage>` lets callers pass
+    /// `Message<AtHost>`, `Message<AtProject>`, or `Message<AtBookmark>`
+    /// directly without wrapping at the call site.
+    pub fn tell(&self, message: impl Into<RoutedMessage>) {
+        if let Err(err) = self.tx.send(message.into()) {
+            tracing::warn!(error = %err, "bus receiver closed; message dropped");
+        }
+    }
+
+    /// Fire-and-forget enqueue for foreign event ingestion. Routes to
+    /// the inbound actor for the brain on the message's scope.
+    pub fn tell_import(&self, message: Message<AtBookmark>) {
+        if let Err(err) = self.tx.send(RoutedMessage::Import(message)) {
+            tracing::warn!(error = %err, "bus receiver closed; import dropped");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn empty_event() -> Event {
+        // A NewEvent with no domain content — we only care that the
+        // envelope round-trips, not what's inside it.
+        NewEvent::builder().data(noop_events()).build().into()
+    }
+
+    fn noop_events() -> Events {
+        Events::Tenant(TenantEvents::TenantCreated(
+            TenantCreated::builder_v1()
+                .tenant(Tenant::builder().name(TenantName::new("noop")).build())
+                .build()
+                .into(),
+        ))
+    }
+
+    fn host_scope(dir: &TempDir) -> Scope<AtHost> {
+        let config = Config::builder().data_dir(dir.path().to_path_buf()).build();
+        let host_infra = HostInfra {
+            data_dir: dir.path().to_path_buf(),
+            system_db_path: dir.path().join("system.db"),
+            host_key_path: dir.path().join("host.key"),
+            projects: Default::default(),
+        };
+        Scope::empty()
+            .load(config)
+            .to_host(std::sync::Arc::new(host_infra))
+    }
+
+    #[tokio::test]
+    async fn mailbox_round_trips_a_host_message() {
+        let dir = TempDir::new().unwrap();
+        let (mailbox, mut rx) = Mailbox::open();
+
+        mailbox.tell(Message::new(host_scope(&dir), empty_event()));
+
+        match rx.recv().await {
+            Some(RoutedMessage::Host(_)) => {}
+            other => panic!("expected Host, got {:?}", other.is_some()),
+        }
+    }
+
+    #[tokio::test]
+    async fn mailbox_drops_silently_when_receiver_is_gone() {
+        let dir = TempDir::new().unwrap();
+        let (mailbox, rx) = Mailbox::open();
+        drop(rx);
+
+        // No panic, no error returned — fire-and-forget contract.
+        mailbox.tell(Message::new(host_scope(&dir), empty_event()));
+    }
+}

--- a/crates/oneiros-engine/src/bus/mod.rs
+++ b/crates/oneiros-engine/src/bus/mod.rs
@@ -1,0 +1,25 @@
+//! Bus — the streaming substrate for event dispatch.
+//!
+//! The bus is the single, server-owned channel through which services
+//! emit events. A service constructs a tier-typed `Message<T>` carrying
+//! its `Scope<T>` and the `Event` to dispatch (a `New(...)` for fresh
+//! emissions, a `Stored(...)` for post-append notifications), wraps it
+//! as a `RoutedMessage`, and `tell`s the `Mailbox`. The host actor
+//! receives every message; it handles host-tier work itself and
+//! forwards project/bookmark messages to lazily-spawned children.
+//!
+//! Dispatch is fire-and-forget: services do not await the actor's
+//! work. Reads come back through the eventually-consistent fetch
+//! primitive, never through phantom state synthesised at the call site.
+
+mod bookmark_actor;
+mod host_actor;
+mod inbound_actor;
+mod mailbox;
+mod project_actor;
+
+pub use bookmark_actor::*;
+pub use host_actor::*;
+pub use inbound_actor::*;
+pub use mailbox::*;
+pub use project_actor::*;

--- a/crates/oneiros-engine/src/bus/project_actor.rs
+++ b/crates/oneiros-engine/src/bus/project_actor.rs
@@ -1,0 +1,207 @@
+//! `ProjectActor` — owns one project's event log and the routing tree
+//! beneath it.
+//!
+//! One actor per brain (project). Spawned lazily by the `HostActor` on
+//! the first project- or bookmark-tier message for that brain. Holds
+//! lazy registries of `BookmarkMailbox` and `ChronicleMailbox` keyed by
+//! `BookmarkName`; spawns those leaves on first sighting.
+//!
+//! The actor's domain has two paths into the same downstream:
+//!
+//! - **Append** — a local `Bookmark` message with `Event::New(...)`.
+//!   The actor appends to the project event log, builds a `Stored`,
+//!   and forwards to the bookmark + chronicle children.
+//! - **Forward** — a `Bookmark` message with `Event::Stored(...)`,
+//!   typically delivered by the `InboundActor` after a foreign
+//!   ingest. No append; just route the Stored to the children. This
+//!   keeps "events.db ownership" + "child registry" in one actor
+//!   without forking the input on event variant.
+//!
+//! Project-tier messages (events that apply to all bookmarks in a
+//! project) are not yet wired — services today emit at the bookmark
+//! tier. The variant is logged at debug and dropped until something
+//! needs it.
+
+use std::collections::HashMap;
+
+use tokio::sync::mpsc;
+
+use crate::*;
+
+/// Domain messages forwarded into a project actor by the host actor
+/// (and, in the case of `Forward`, by the inbound actor).
+#[derive(Clone)]
+pub enum ProjectDomain {
+    /// Project-tier message — currently log-and-drop.
+    Project(Message<AtProject>),
+    /// Bookmark-tier `New` event — actor appends to events.db, then
+    /// forwards a `Stored` to the bookmark + chronicle children.
+    Bookmark(Message<AtBookmark>),
+    /// Bookmark-tier `Stored` event arriving post-ingest from the
+    /// inbound actor — actor only forwards to children, no append.
+    Forward(Message<AtBookmark>),
+}
+
+/// Send-side handle held by the `HostActor`. Cloneable.
+#[derive(Clone)]
+pub struct ProjectMailbox {
+    tx: mpsc::UnboundedSender<LifecycleMessage<ProjectDomain>>,
+}
+
+impl ProjectMailbox {
+    pub fn tell(&self, message: LifecycleMessage<ProjectDomain>) {
+        if let Err(err) = self.tx.send(message) {
+            tracing::warn!(error = %err, "project actor: receiver closed; message dropped");
+        }
+    }
+
+    pub fn tell_domain(&self, message: ProjectDomain) {
+        self.tell(LifecycleMessage::Domain(message));
+    }
+}
+
+pub struct ProjectActor {
+    brain: BrainName,
+    /// Project-tier scope composed at spawn time. The actor owns this
+    /// because the project event log is project-tier work — it
+    /// shouldn't reach through a bookmark's per-request scope to do
+    /// what's structurally its own job.
+    scope: Scope<AtProject>,
+    canons: CanonIndex,
+    bookmarks: HashMap<BookmarkName, BookmarkMailbox>,
+}
+
+impl ProjectActor {
+    /// Spawn a project actor for one brain. The host actor calls this
+    /// the first time a project- or bookmark-scoped message arrives for
+    /// the brain.
+    pub fn spawn(brain: BrainName, scope: Scope<AtProject>, canons: CanonIndex) -> ProjectMailbox {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let actor = Self {
+            brain,
+            scope,
+            canons,
+            bookmarks: HashMap::new(),
+        };
+        tokio::spawn(actor.run(rx));
+        ProjectMailbox { tx }
+    }
+
+    async fn run(mut self, mut rx: mpsc::UnboundedReceiver<LifecycleMessage<ProjectDomain>>) {
+        while let Some(message) = rx.recv().await {
+            match message {
+                LifecycleMessage::Domain(ProjectDomain::Bookmark(message)) => {
+                    if let Err(err) = self.handle_append(message).await {
+                        tracing::error!(
+                            brain = %self.brain,
+                            ?err,
+                            "project actor: append failed",
+                        );
+                    }
+                }
+                LifecycleMessage::Domain(ProjectDomain::Forward(message)) => {
+                    if let Err(err) = self.handle_forward(message) {
+                        tracing::error!(
+                            brain = %self.brain,
+                            ?err,
+                            "project actor: forward failed",
+                        );
+                    }
+                }
+                LifecycleMessage::Domain(ProjectDomain::Project(_)) => {
+                    tracing::debug!(
+                        brain = %self.brain,
+                        "project actor: project-tier message dropped — no callers yet",
+                    );
+                }
+                LifecycleMessage::Reset => {
+                    // Reset cascades — every known bookmark child
+                    // resets and rebuilds. The project actor itself
+                    // has no state to wipe.
+                    for mb in self.bookmarks.values() {
+                        mb.reset();
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_append(&mut self, message: Message<AtBookmark>) -> Result<(), EventError> {
+        let Message {
+            scope: req_scope,
+            event,
+        } = message;
+        let new_event = match event {
+            Event::New(boxed) => *boxed,
+            // Stored notifications and parsing variants don't enter
+            // the append path. Stored is handled via Forward; the
+            // others are not bus traffic at all.
+            _ => return Ok(()),
+        };
+
+        let bookmark = req_scope.bookmark().name.clone();
+
+        // Project-tier append uses the actor's own project-tier scope.
+        // The bookmark DB ATTACHes events read-only for query
+        // convenience, but writes happen here, on the project tier.
+        let events_db = EventsDb::open(&self.scope).await?;
+        EventLog::new(&events_db).init()?;
+        let stored = EventLog::new(&events_db).append(&new_event)?;
+
+        let stored_message = Message {
+            scope: req_scope,
+            event: Event::Stored(Box::new(stored)),
+        };
+
+        self.fan_out(&bookmark, stored_message)
+    }
+
+    /// Forward a pre-stored event to bookmark + chronicle children
+    /// without appending. Used for events that the inbound actor has
+    /// already imported.
+    fn handle_forward(&mut self, message: Message<AtBookmark>) -> Result<(), EventError> {
+        // Sanity: only Stored makes sense here.
+        if !matches!(message.event, Event::Stored(_)) {
+            return Ok(());
+        }
+        let bookmark = message.scope.bookmark().name.clone();
+        self.fan_out(&bookmark, message)
+    }
+
+    /// Spawn the bookmark actor for `bookmark` if needed and forward
+    /// the stored notification to it. The bookmark actor handles both
+    /// projection apply and chronicle record per-event in sequence.
+    fn fan_out(
+        &mut self,
+        bookmark: &BookmarkName,
+        message: Message<AtBookmark>,
+    ) -> Result<(), EventError> {
+        let bookmark_mailbox = self.bookmark_mailbox(bookmark)?;
+        bookmark_mailbox.tell_domain(message);
+        Ok(())
+    }
+
+    fn bookmark_mailbox(&mut self, bookmark: &BookmarkName) -> Result<BookmarkMailbox, EventError> {
+        if let Some(mb) = self.bookmarks.get(bookmark) {
+            return Ok(mb.clone());
+        }
+        // The bookmark actor needs both the reducer pipeline and the
+        // chronicle handle — both live on the brain's `BookmarkEntry`,
+        // but `brain_entry` returns the *active* entry. For a specific
+        // bookmark we want its specific chronicle.
+        let entry = self.canons.brain_entry(&self.brain)?;
+        let chronicle = self.canons.bookmark_chronicle(&self.brain, bookmark)?;
+        let entry = BookmarkEntry {
+            pipeline: entry.pipeline,
+            chronicle,
+        };
+        let mb = BookmarkActor::spawn(
+            self.scope.config().clone(),
+            self.brain.clone(),
+            bookmark.clone(),
+            entry,
+        );
+        self.bookmarks.insert(bookmark.clone(), mb.clone());
+        Ok(mb)
+    }
+}

--- a/crates/oneiros-engine/src/db.rs
+++ b/crates/oneiros-engine/src/db.rs
@@ -50,7 +50,17 @@ pub struct HostDb {
 }
 
 impl HostDb {
-    pub async fn open(platform: &Platform) -> Result<Self, HostDbError> {
+    /// Open from any scope tier that carries host info. The primary
+    /// public entry — services and actors at any tier reach the
+    /// host db this way.
+    pub async fn open<S: HasHost>(scope: &S) -> Result<Self, HostDbError> {
+        Self::open_with(&scope.config().platform()).await
+    }
+
+    /// Open directly from a `Platform`. Underlying primitive — used by
+    /// the scope-form above and by tests / hydration paths that don't
+    /// have a scope handy.
+    pub async fn open_with(platform: &Platform) -> Result<Self, HostDbError> {
         platform.ensure_data_dir()?;
         let connection = rusqlite::Connection::open(platform.system_db_path())?;
         connection.pragma_update(None, "journal_mode", "wal")?;
@@ -74,7 +84,13 @@ pub struct EventsDb {
 }
 
 impl EventsDb {
-    pub async fn open(platform: &Platform, brain: &BrainName) -> Result<Self, EventsDbError> {
+    /// Open from any scope tier that carries project info.
+    pub async fn open<S: HasProject>(scope: &S) -> Result<Self, EventsDbError> {
+        Self::open_with(&scope.config().platform(), &scope.project().name).await
+    }
+
+    /// Open directly from a `Platform` + brain. Underlying primitive.
+    pub async fn open_with(platform: &Platform, brain: &BrainName) -> Result<Self, EventsDbError> {
         platform.ensure_brain_dir(brain)?;
         let connection = rusqlite::Connection::open(platform.events_db_path(brain))?;
         connection.pragma_update(None, "journal_mode", "wal")?;
@@ -100,7 +116,19 @@ pub struct BookmarkDb {
 }
 
 impl BookmarkDb {
-    pub async fn open(
+    /// Open from a bookmark-tier scope.
+    pub async fn open<S: HasBookmark>(scope: &S) -> Result<Self, BookmarkDbError> {
+        Self::open_with(
+            &scope.config().platform(),
+            &scope.project().name,
+            &scope.bookmark().name,
+        )
+        .await
+    }
+
+    /// Open directly from a `Platform` + brain + bookmark. Underlying
+    /// primitive — used by the scope-form above and by tests.
+    pub async fn open_with(
         platform: &Platform,
         brain: &BrainName,
         bookmark: &BookmarkName,
@@ -137,7 +165,7 @@ mod tests {
     #[tokio::test]
     async fn host_db_opens_and_creates_system_db() {
         let (_dir, platform) = test_platform();
-        let _db = HostDb::open(&platform).await.unwrap();
+        let _db = HostDb::open_with(&platform).await.unwrap();
         assert!(platform.system_db_path().exists());
     }
 
@@ -145,7 +173,7 @@ mod tests {
     async fn events_db_opens_and_creates_brain_dir() {
         let (_dir, platform) = test_platform();
         let brain = BrainName::new("alpha");
-        let _db = EventsDb::open(&platform, &brain).await.unwrap();
+        let _db = EventsDb::open_with(&platform, &brain).await.unwrap();
         assert!(platform.brain_dir(&brain).is_dir());
         assert!(platform.events_db_path(&brain).exists());
     }
@@ -157,8 +185,8 @@ mod tests {
         let bookmark = BookmarkName::main();
 
         // Pre-create events db so ATTACH points at a real file.
-        let _events = EventsDb::open(&platform, &brain).await.unwrap();
-        let db = BookmarkDb::open(&platform, &brain, &bookmark)
+        let _events = EventsDb::open_with(&platform, &brain).await.unwrap();
+        let db = BookmarkDb::open_with(&platform, &brain, &bookmark)
             .await
             .unwrap();
 

--- a/crates/oneiros-engine/src/domains/actor/features/http.rs
+++ b/crates/oneiros-engine/src/domains/actor/features/http.rs
@@ -33,25 +33,26 @@ impl ActorRouter {
 }
 
 async fn create(
-    context: HostLog,
+    scope: Scope<AtHost>,
+    mailbox: Mailbox,
     Json(body): Json<CreateActor>,
 ) -> Result<(StatusCode, Json<ActorResponse>), ActorError> {
-    let response = ActorService::create(&context, &body).await?;
+    let response = ActorService::create(&scope, &mailbox, &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
 
 async fn list(
-    context: HostLog,
+    scope: Scope<AtHost>,
     Query(params): Query<ListActors>,
 ) -> Result<Json<ActorResponse>, ActorError> {
-    Ok(Json(ActorService::list(&context, &params).await?))
+    Ok(Json(ActorService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: HostLog,
+    scope: Scope<AtHost>,
     Path(key): Path<ResourceKey<ActorId>>,
 ) -> Result<Json<ActorResponse>, ActorError> {
     Ok(Json(
-        ActorService::get(&context, &GetActor::builder_v1().key(key).build().into()).await?,
+        ActorService::get(&scope, &GetActor::builder_v1().key(key).build().into()).await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/actor/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/actor/features/mcp.rs
@@ -10,10 +10,11 @@ impl ActorMcp {
     pub async fn dispatch(
         &self,
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        actor_mcp::dispatch(context, tool_name, params).await
+        actor_mcp::dispatch(context, mailbox, tool_name, params).await
     }
 }
 
@@ -39,6 +40,7 @@ mod actor_mcp {
 
     pub async fn dispatch(
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
@@ -49,17 +51,16 @@ mod actor_mcp {
         let scope = ComposeScope::new(context.config.clone())
             .host()
             .map_err(Error::from)?;
-        let system = scope.host_log();
 
         let value = match request_type {
             ActorRequestType::CreateActor => {
-                ActorService::create(&system, &serde_json::from_str(params)?).await
+                ActorService::create(&scope, mailbox, &serde_json::from_str(params)?).await
             }
             ActorRequestType::GetActor => {
-                ActorService::get(&system, &serde_json::from_str(params)?).await
+                ActorService::get(&scope, &serde_json::from_str(params)?).await
             }
             ActorRequestType::ListActors => {
-                ActorService::list(&system, &serde_json::from_str(params)?).await
+                ActorService::list(&scope, &serde_json::from_str(params)?).await
             }
         }
         .map_err(Error::from)?;

--- a/crates/oneiros-engine/src/domains/actor/repo.rs
+++ b/crates/oneiros-engine/src/domains/actor/repo.rs
@@ -21,7 +21,7 @@ impl<'a> ActorRepo<'a> {
     }
 
     pub async fn get(&self, id: ActorId) -> Result<Option<Actor>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
         let mut statement =
             db.prepare("select id, tenant_id, name, created_at from actors where id = ?1")?;
 
@@ -49,7 +49,7 @@ impl<'a> ActorRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Actor>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM actors")?;

--- a/crates/oneiros-engine/src/domains/actor/service.rs
+++ b/crates/oneiros-engine/src/domains/actor/service.rs
@@ -4,7 +4,8 @@ pub struct ActorService;
 
 impl ActorService {
     pub async fn create(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
+        mailbox: &Mailbox,
         request: &CreateActor,
     ) -> Result<ActorResponse, ActorError> {
         let CreateActor::V1(create) = request;
@@ -13,28 +14,35 @@ impl ActorService {
             .tenant_id(create.tenant_id)
             .name(create.name.clone())
             .build();
+        let id = actor.id;
 
-        context
-            .emit(ActorEvents::ActorCreated(
-                ActorCreated::builder_v1()
-                    .actor(actor.clone())
-                    .build()
-                    .into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Actor(ActorEvents::ActorCreated(
+                ActorCreated::builder_v1().actor(actor).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let stored = ActorRepo::new(scope)
+            .fetch(id)
+            .await?
+            .ok_or(ActorError::NotFound(id))?;
 
         Ok(ActorResponse::Created(
             ActorCreatedResponse::builder_v1()
-                .actor(actor)
+                .actor(stored)
                 .build()
                 .into(),
         ))
     }
 
-    pub async fn get(context: &HostLog, request: &GetActor) -> Result<ActorResponse, ActorError> {
+    pub async fn get(
+        scope: &Scope<AtHost>,
+        request: &GetActor,
+    ) -> Result<ActorResponse, ActorError> {
         let GetActor::V1(lookup) = request;
         let id = lookup.key.resolve()?;
-        let actor = ActorRepo::new(context.scope()?)
+        let actor = ActorRepo::new(scope)
             .fetch(id)
             .await?
             .ok_or(ActorError::NotFound(id))?;
@@ -44,13 +52,11 @@ impl ActorService {
     }
 
     pub async fn list(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
         request: &ListActors,
     ) -> Result<ActorResponse, ActorError> {
         let ListActors::V1(listing) = request;
-        let listed = ActorRepo::new(context.scope()?)
-            .list(&listing.filters)
-            .await?;
+        let listed = ActorRepo::new(scope).list(&listing.filters).await?;
         Ok(ActorResponse::Listed(
             ActorsResponse::builder_v1()
                 .items(listed.items)

--- a/crates/oneiros-engine/src/domains/agent/features/http.rs
+++ b/crates/oneiros-engine/src/domains/agent/features/http.rs
@@ -42,44 +42,48 @@ impl AgentRouter {
 }
 
 async fn create(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Json(body): Json<CreateAgent>,
 ) -> Result<(StatusCode, Json<AgentResponse>), AgentError> {
-    let response = AgentService::create(&context, &body).await?;
+    let response = AgentService::create(&scope, &mailbox, &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
 
 async fn list(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<ListAgents>,
 ) -> Result<Json<AgentResponse>, AgentError> {
-    Ok(Json(AgentService::list(&context, &params).await?))
+    Ok(Json(AgentService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(key): Path<ResourceKey<AgentName>>,
 ) -> Result<Json<AgentResponse>, AgentError> {
     Ok(Json(
-        AgentService::get(&context, &GetAgent::builder_v1().key(key).build().into()).await?,
+        AgentService::get(&scope, &GetAgent::builder_v1().key(key).build().into()).await?,
     ))
 }
 
 async fn update(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(_): Path<AgentName>,
     Json(body): Json<UpdateAgent>,
 ) -> Result<Json<AgentResponse>, AgentError> {
-    Ok(Json(AgentService::update(&context, &body).await?))
+    Ok(Json(AgentService::update(&scope, &mailbox, &body).await?))
 }
 
 async fn remove(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<AgentName>,
 ) -> Result<Json<AgentResponse>, AgentError> {
     Ok(Json(
         AgentService::remove(
-            &context,
+            &scope,
+            &mailbox,
             &RemoveAgent::builder_v1().name(name).build().into(),
         )
         .await?,

--- a/crates/oneiros-engine/src/domains/agent/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/agent/features/mcp.rs
@@ -10,10 +10,11 @@ impl AgentMcp {
     pub async fn dispatch(
         &self,
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &ToolName,
         params: &serde_json::Value,
     ) -> Result<McpResponse, ToolError> {
-        agent_mcp::dispatch(context, tool_name, params).await
+        agent_mcp::dispatch(context, mailbox, tool_name, params).await
     }
 
     pub fn resources(&self) -> Vec<ResourceDef> {
@@ -82,6 +83,7 @@ mod agent_mcp {
 
     pub async fn dispatch(
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &ToolName,
         params: &serde_json::Value,
     ) -> Result<McpResponse, ToolError> {
@@ -90,24 +92,26 @@ mod agent_mcp {
             .parse()
             .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
 
+        let scope = context.scope().map_err(Error::from)?;
+
         match request_type {
             AgentRequestType::CreateAgent => {
                 let response =
-                    AgentService::create(context, &serde_json::from_value(params.clone())?)
+                    AgentService::create(scope, mailbox, &serde_json::from_value(params.clone())?)
                         .await
                         .map_err(Error::from)?;
                 Ok(AgentView::new(response).mcp())
             }
             AgentRequestType::UpdateAgent => {
                 let response =
-                    AgentService::update(context, &serde_json::from_value(params.clone())?)
+                    AgentService::update(scope, mailbox, &serde_json::from_value(params.clone())?)
                         .await
                         .map_err(Error::from)?;
                 Ok(AgentView::new(response).mcp())
             }
             AgentRequestType::RemoveAgent => {
                 let response =
-                    AgentService::remove(context, &serde_json::from_value(params.clone())?)
+                    AgentService::remove(scope, mailbox, &serde_json::from_value(params.clone())?)
                         .await
                         .map_err(Error::from)?;
                 Ok(AgentView::new(response).mcp())
@@ -122,9 +126,10 @@ mod agent_mcp {
         context: &ProjectLog,
         request: &AgentRequest,
     ) -> Result<McpResponse, ToolError> {
+        let scope = context.scope().map_err(Error::from)?;
         match request {
             AgentRequest::GetAgent(get) => {
-                let response = AgentService::get(context, get).await.map_err(Error::from)?;
+                let response = AgentService::get(scope, get).await.map_err(Error::from)?;
                 match &response {
                     AgentResponse::NoAgents => {
                         Err(ToolError::NotFound("Agent not found".to_string()))
@@ -133,7 +138,7 @@ mod agent_mcp {
                 }
             }
             AgentRequest::ListAgents(listing) => {
-                let response = AgentService::list(context, listing)
+                let response = AgentService::list(scope, listing)
                     .await
                     .map_err(Error::from)?;
                 Ok(AgentView::new(response).mcp())
@@ -150,8 +155,9 @@ mod agent_mcp {
         context: &ProjectLog,
         name: &AgentName,
     ) -> Result<McpResponse, ToolError> {
+        let scope = context.scope().map_err(Error::from)?;
         let agent = AgentService::get(
-            context,
+            scope,
             &GetAgent::builder_v1()
                 .key(ResourceKey::Key(name.clone()))
                 .build()

--- a/crates/oneiros-engine/src/domains/agent/repo.rs
+++ b/crates/oneiros-engine/src/domains/agent/repo.rs
@@ -15,7 +15,7 @@ impl<'a> AgentRepo<'a> {
     }
 
     pub async fn get(&self, name: &AgentName) -> Result<Option<Agent>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt = db
             .prepare("select id, name, persona, description, prompt from agents where name = ?1")?;
 
@@ -47,7 +47,7 @@ impl<'a> AgentRepo<'a> {
     }
 
     pub async fn get_by_id(&self, id: AgentId) -> Result<Option<Agent>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt =
             db.prepare("select id, name, persona, description, prompt from agents where id = ?1")?;
 
@@ -84,7 +84,7 @@ impl<'a> AgentRepo<'a> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let placeholders = (1..=ids.len())
             .map(|i| format!("?{i}"))
             .collect::<Vec<_>>()
@@ -122,7 +122,7 @@ impl<'a> AgentRepo<'a> {
     }
 
     pub async fn name_exists(&self, name: &AgentName) -> Result<bool, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let count: i64 = db.query_row(
             "select count(*) from agents where name = ?1",
             params![name.to_string()],

--- a/crates/oneiros-engine/src/domains/agent/service.rs
+++ b/crates/oneiros-engine/src/domains/agent/service.rs
@@ -4,13 +4,14 @@ pub struct AgentService;
 
 impl AgentService {
     pub async fn create(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &CreateAgent,
     ) -> Result<AgentResponse, AgentError> {
         let CreateAgent::V1(create) = request;
 
         // Cross-resource validation: persona must exist
-        if PersonaRepo::new(context.scope()?)
+        if PersonaRepo::new(scope)
             .fetch(&create.persona)
             .await?
             .is_none()
@@ -22,43 +23,43 @@ impl AgentService {
         let normalized_name = create.name.normalize_with(&create.persona);
 
         // Validate name uniqueness
-        if AgentRepo::new(context.scope()?)
-            .name_exists(&normalized_name)
-            .await?
-        {
+        if AgentRepo::new(scope).name_exists(&normalized_name).await? {
             return Err(AgentError::Conflict(normalized_name));
         }
 
         let agent = Agent::builder()
-            .name(normalized_name)
+            .name(normalized_name.clone())
             .persona(create.persona.clone())
             .description(create.description.clone())
             .prompt(create.prompt.clone())
             .build();
 
-        context
-            .emit(AgentEvents::AgentCreated(
-                AgentCreated::builder_v1()
-                    .agent(agent.clone())
-                    .build()
-                    .into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Agent(AgentEvents::AgentCreated(
+                AgentCreated::builder_v1().agent(agent).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let stored = AgentRepo::new(scope)
+            .fetch(&normalized_name)
+            .await?
+            .ok_or(AgentError::NotFound(normalized_name))?;
 
         Ok(AgentResponse::AgentCreated(
             AgentCreatedResponse::builder_v1()
-                .agent(agent)
+                .agent(stored)
                 .build()
                 .into(),
         ))
     }
 
     pub async fn get(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &GetAgent,
     ) -> Result<AgentResponse, AgentError> {
         let GetAgent::V1(lookup) = request;
-        let repo = AgentRepo::new(context.scope()?);
+        let repo = AgentRepo::new(scope);
         let agent = match &lookup.key {
             ResourceKey::Key(name) => repo
                 .fetch(name)
@@ -89,7 +90,7 @@ impl AgentService {
     }
 
     pub async fn list(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ListAgents,
     ) -> Result<AgentResponse, AgentError> {
         let ListAgents::V1(listing) = request;
@@ -99,9 +100,7 @@ impl AgentService {
             .filters(listing.filters)
             .build();
 
-        let results = SearchRepo::new(context.scope()?)
-            .search(&search_query, None)
-            .await?;
+        let results = SearchRepo::new(scope).search(&search_query, None).await?;
 
         if results.total == 0 {
             return Ok(AgentResponse::NoAgents);
@@ -115,7 +114,7 @@ impl AgentService {
             }
         }
 
-        let items = AgentRepo::new(context.scope()?).get_many(&ids).await?;
+        let items = AgentRepo::new(scope).get_many(&ids).await?;
 
         Ok(AgentResponse::Agents(
             AgentsResponse::builder_v1()
@@ -127,11 +126,12 @@ impl AgentService {
     }
 
     pub async fn update(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &UpdateAgent,
     ) -> Result<AgentResponse, AgentError> {
         let UpdateAgent::V1(update) = request;
-        let existing = AgentRepo::new(context.scope()?)
+        let existing = AgentRepo::new(scope)
             .fetch(&update.name)
             .await?
             .ok_or_else(|| AgentError::NotFound(update.name.clone()))?;
@@ -144,43 +144,64 @@ impl AgentService {
             .prompt(update.prompt.clone())
             .build();
 
-        context
-            .emit(AgentEvents::AgentUpdated(
-                AgentUpdated::builder_v1()
-                    .agent(agent.clone())
-                    .build()
-                    .into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Agent(AgentEvents::AgentUpdated(
+                AgentUpdated::builder_v1().agent(agent).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        // Read back the updated record. Filter on the fields we just
+        // changed so fetch keeps polling until the projection reflects
+        // them — otherwise we'd race the projector and return the
+        // pre-update record.
+        let updated = scope
+            .config()
+            .fetch
+            .eventual(|| async {
+                AgentRepo::new(scope).get(&update.name).await.map(|opt| {
+                    opt.filter(|agent| {
+                        agent.persona == update.persona
+                            && agent.description == update.description
+                            && agent.prompt == update.prompt
+                    })
+                })
+            })
+            .await?
+            .ok_or_else(|| AgentError::NotFound(update.name.clone()))?;
 
         Ok(AgentResponse::AgentUpdated(
             AgentUpdatedResponse::builder_v1()
-                .agent(agent)
+                .agent(updated)
                 .build()
                 .into(),
         ))
     }
 
     pub async fn remove(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &RemoveAgent,
     ) -> Result<AgentResponse, AgentError> {
         let RemoveAgent::V1(removal) = request;
-        if AgentRepo::new(context.scope()?)
-            .fetch(&removal.name)
-            .await?
-            .is_none()
-        {
+        if AgentRepo::new(scope).fetch(&removal.name).await?.is_none() {
             return Err(AgentError::NotFound(removal.name.clone()));
         }
 
-        context
-            .emit(AgentEvents::AgentRemoved(
+        let new_event = NewEvent::builder()
+            .data(Events::Agent(AgentEvents::AgentRemoved(
                 AgentRemoved::builder_v1()
                     .name(removal.name.clone())
                     .build()
                     .into(),
-            ))
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        scope
+            .config()
+            .fetch
+            .until_absent(|| async { AgentRepo::new(scope).get(&removal.name).await })
             .await?;
 
         Ok(AgentResponse::AgentRemoved(

--- a/crates/oneiros-engine/src/domains/bookmark/repo.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/repo.rs
@@ -14,7 +14,7 @@ impl<'a> BookmarkRepo<'a> {
         brain: &BrainName,
         filters: &SearchFilters,
     ) -> Result<Listed<Bookmark>, BookmarkError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
 
         let count_sql = "SELECT COUNT(*) FROM bookmarks WHERE brain = ?1";
         let total = {

--- a/crates/oneiros-engine/src/domains/bookmark/service.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/service.rs
@@ -21,16 +21,17 @@ impl BookmarkService {
             .name(name.clone())
             .build();
 
-        state
-            .host_log()
-            .emit(BookmarkEvents::BookmarkForked(
+        let scope = ComposeScope::new(state.config().clone()).host()?;
+        let new_event = NewEvent::builder()
+            .data(Events::Bookmark(BookmarkEvents::BookmarkForked(
                 BookmarkForked::builder_v1()
                     .bookmark(bookmark.clone())
                     .from(from.clone())
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        state.mailbox().tell(Message::new(scope, new_event));
 
         Ok(BookmarkResponse::Forked(
             BookmarkForkedResponse::builder_v1()
@@ -55,10 +56,13 @@ impl BookmarkService {
             .name(name.clone())
             .build();
 
-        state
-            .host_log()
-            .emit(BookmarkEvents::BookmarkSwitched(event.into()))
-            .await?;
+        let scope = ComposeScope::new(state.config().clone()).host()?;
+        let new_event = NewEvent::builder()
+            .data(Events::Bookmark(BookmarkEvents::BookmarkSwitched(
+                event.into(),
+            )))
+            .build();
+        state.mailbox().tell(Message::new(scope, new_event));
 
         Ok(BookmarkResponse::Switched(
             BookmarkSwitchedResponse::builder_v1()
@@ -87,10 +91,13 @@ impl BookmarkService {
             .target(target.clone())
             .build();
 
-        state
-            .host_log()
-            .emit(BookmarkEvents::BookmarkMerged(event.into()))
-            .await?;
+        let scope = ComposeScope::new(state.config().clone()).host()?;
+        let new_event = NewEvent::builder()
+            .data(Events::Bookmark(BookmarkEvents::BookmarkMerged(
+                event.into(),
+            )))
+            .build();
+        state.mailbox().tell(Message::new(scope, new_event));
 
         Ok(BookmarkResponse::Merged(
             BookmarkMergedResponse::builder_v1()
@@ -108,9 +115,8 @@ impl BookmarkService {
         request: &ListBookmarks,
     ) -> Result<BookmarkResponse, BookmarkError> {
         let ListBookmarks::V1(listing) = request;
-        let system = state.host_log();
-        let scope = system.scope()?;
-        let listed = BookmarkRepo::new(scope)
+        let scope = ComposeScope::new(state.config().clone()).host()?;
+        let listed = BookmarkRepo::new(&scope)
             .list(brain, &listing.filters)
             .await?;
         Ok(BookmarkResponse::Bookmarks(listed))
@@ -128,14 +134,14 @@ impl BookmarkService {
         let ShareBookmark::V1(sharing) = request;
         let name = &sharing.name;
         let actor_id = &sharing.actor_id;
-        let system = state.host_log();
-        let scope = system.scope()?;
+        let scope = ComposeScope::new(state.config().clone()).host()?;
+        let mailbox = state.mailbox();
         let all = SearchFilters {
             limit: Limit(usize::MAX),
             offset: Offset(0),
         };
 
-        let bookmarks = BookmarkRepo::new(scope).list(brain, &all).await?;
+        let bookmarks = BookmarkRepo::new(&scope).list(brain, &all).await?;
         let bookmark = bookmarks
             .items
             .iter()
@@ -143,7 +149,7 @@ impl BookmarkService {
             .ok_or_else(|| BookmarkError::NotFound(name.clone()))?
             .clone();
 
-        let brain_record = BrainRepo::new(scope)
+        let brain_record = BrainRepo::new(&scope)
             .get(brain)
             .await?
             .ok_or_else(|| BookmarkError::BrainNotFound(brain.clone()))?;
@@ -151,7 +157,7 @@ impl BookmarkService {
         let resolved_actor_id = match actor_id {
             Some(id) => *id,
             None => {
-                let actors = ActorRepo::new(scope).list(&all).await?;
+                let actors = ActorRepo::new(&scope).list(&all).await?;
                 actors
                     .items
                     .first()
@@ -161,15 +167,22 @@ impl BookmarkService {
         };
 
         let target = Ref::bookmark(bookmark.id);
-        let ticket =
-            TicketService::issue(&system, brain, &brain_record, resolved_actor_id, target).await?;
+        let ticket = TicketService::issue(
+            &scope,
+            mailbox,
+            brain,
+            &brain_record,
+            resolved_actor_id,
+            target,
+        )
+        .await?;
 
         let identity = state.host_identity();
         let peer_link = PeerLink::new(identity.address, ticket.link.clone());
         let uri = OneirosUri::Peer(peer_link).to_string();
 
-        system
-            .emit(BookmarkEvents::BookmarkShared(
+        let new_event = NewEvent::builder()
+            .data(Events::Bookmark(BookmarkEvents::BookmarkShared(
                 BookmarkShared::builder_v1()
                     .brain(brain.clone())
                     .bookmark(name.clone())
@@ -177,8 +190,9 @@ impl BookmarkService {
                     .shared_by(resolved_actor_id)
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope, new_event));
 
         Ok(BookmarkResponse::Shared(BookmarkShareResult {
             ticket,
@@ -195,7 +209,8 @@ impl BookmarkService {
         let FollowBookmark::V1(following) = request;
         let uri = &following.uri;
         let name = &following.name;
-        let system = state.host_log();
+        let scope = ComposeScope::new(state.config().clone()).host()?;
+        let mailbox = state.mailbox();
         let parsed: OneirosUri = uri
             .parse()
             .map_err(|e: OneirosUriError| BookmarkError::InvalidUri(e.to_string()))?;
@@ -205,7 +220,7 @@ impl BookmarkService {
             OneirosUri::Link(link) => FollowSource::Local(link.target),
             OneirosUri::Peer(peer_link) => {
                 let key = PeerKey::from_bytes(*peer_link.host.inner().id.as_bytes());
-                PeerService::ensure(&system, key, peer_link.host.clone()).await?;
+                PeerService::ensure(&scope, mailbox, key, peer_link.host.clone()).await?;
                 FollowSource::Peer(peer_link)
             }
         };
@@ -215,20 +230,23 @@ impl BookmarkService {
             .name(name.clone())
             .build();
 
-        system
-            .emit(BookmarkEvents::BookmarkCreated(
+        let new_event = NewEvent::builder()
+            .data(Events::Bookmark(BookmarkEvents::BookmarkCreated(
                 BookmarkCreated::builder_v1()
                     .bookmark(bookmark)
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
         state.canons().fork_brain(brain, name)?;
 
         // Create the new bookmark's DB (empty — collect will populate it).
         Self::create_bookmark_db(state.config(), brain, name)?;
 
-        let follow = FollowService::create(&system, brain.clone(), name.clone(), source).await?;
+        let follow =
+            FollowService::create(&scope, mailbox, brain.clone(), name.clone(), source).await?;
         Ok(BookmarkResponse::Followed(follow))
     }
 
@@ -240,15 +258,16 @@ impl BookmarkService {
     ) -> Result<BookmarkResponse, BookmarkError> {
         let CollectBookmark::V1(collection) = request;
         let name = &collection.name;
-        let system = state.host_log();
-        let follow = FollowService::for_bookmark(&system, brain, name)
+        let scope = ComposeScope::new(state.config().clone()).host()?;
+        let mailbox = state.mailbox();
+        let follow = FollowService::for_bookmark(&scope, brain, name)
             .await?
             .ok_or_else(|| BookmarkError::FollowNotFound(name.clone()))?;
 
         match follow.source.clone() {
             FollowSource::Local(_) => {
                 let checkpoint = Checkpoint::empty();
-                FollowService::advance(&system, follow.id, checkpoint.clone(), 0).await?;
+                FollowService::advance(&scope, mailbox, follow.id, checkpoint.clone(), 0).await?;
                 Ok(BookmarkResponse::Collected(BookmarkCollectResult {
                     follow_id: follow.id,
                     events_received: 0,
@@ -262,24 +281,31 @@ impl BookmarkService {
     }
 
     /// Collect from a peer via Merkle diff on the chronicle HAMT.
+    ///
+    /// The local-side ingestion flows through the bus as `Import`
+    /// messages. The inbound actor handles the events.db insert
+    /// (insert-or-ignore by id), then forwards `Stored` to the
+    /// bookmark + chronicle children — which project and record
+    /// without distinction from locally-emitted events.
     async fn collect_from_peer(
         state: &ServerState,
         brain: &BrainName,
         follow: &Follow,
         peer_link: PeerLink,
     ) -> Result<BookmarkResponse, BookmarkError> {
-        let system = state.host_log();
+        let scope = ComposeScope::new(state.config().clone()).host()?;
+        let mailbox = state.mailbox();
         let bridge = state.bridge();
 
-        // Get the bookmark's chronicle — this tracks what we've collected.
+        // Get the bookmark's chronicle — read-only here, used for the
+        // Merkle diff. The chronicle actor updates it on each Stored
+        // notification from the inbound actor.
         let chronicle = state.canons().bookmark_chronicle(brain, &follow.bookmark)?;
         let local_root = chronicle.root()?;
 
         // Build a local resolver from the system DB's ChronicleStore.
         // Opens its own connection per resolve call — Send-safe across
         // the async diff, and fast with WAL mode (~20 resolves per tree walk).
-        let mut brain_config = state.config().clone();
-        brain_config.brain = brain.clone();
         {
             let db = state.config().system_db()?;
             ChronicleStore::new(&db).migrate()?;
@@ -306,7 +332,10 @@ impl BookmarkService {
 
         let events_received = diff_result.missing.len() as u64;
 
-        // Phase 2: Fetch missing events and import them.
+        // Phase 2: Fetch missing events and dispatch each as an
+        // `Import` through the bus. The inbound actor handles
+        // events.db insert and notifies the project actor; bookmark
+        // + chronicle children project / record naturally.
         if !diff_result.missing.is_empty() {
             let event_ids: Vec<String> = diff_result
                 .missing
@@ -324,31 +353,50 @@ impl BookmarkService {
                 .await
                 .map_err(|e: BridgeError| BookmarkError::InvalidUri(e.to_string()))?;
 
-            // Import events to the event log (standalone events.db).
-            let events_path = brain_config.events_db_path();
-            let events_db = rusqlite::Connection::open(&events_path)?;
-            events_db.pragma_update(None, "journal_mode", "wal")?;
-            let log = EventLog::new(&events_db);
+            let bookmark_scope = ComposeScope::new(state.config().clone())
+                .bookmark(brain.clone(), follow.bookmark.clone())?;
 
-            // Chronicle objects live in the system DB.
-            let system_db = state.config().system_db()?;
-            let chronicle_store = ChronicleStore::new(&system_db);
-            chronicle_store.migrate()?;
+            // Capture the imported event ids — we'll wait until the
+            // chronicle (and therefore the bookmark actor processing
+            // the same FIFO) has seen them all.
+            let expected_ids: std::collections::HashSet<String> =
+                events.iter().map(|event| event.id.to_string()).collect();
 
-            for event in &events {
-                let _ = log.import(event);
-                // Record each collected event in the bookmark's chronicle
-                // so the next diff can short-circuit on matching roots.
-                chronicle.record(
-                    event,
-                    &chronicle_store.resolver(),
-                    &chronicle_store.writer(),
-                )?;
+            for event in events {
+                let import_message = Message {
+                    scope: bookmark_scope.clone(),
+                    event: Event::Import(Box::new(event)),
+                };
+                mailbox.tell_import(import_message);
             }
-        }
 
-        // Phase 3: Replay projections into the follow's bookmark DB.
-        Self::replay_bookmark(state.config(), brain, &follow.bookmark)?;
+            // Wait for every imported event id to appear in the
+            // bookmark's chronicle.
+            let chronicle_for_wait = chronicle.clone();
+            let resolve_for_wait = {
+                let config = state.config().clone();
+                move |hash: &ContentHash| -> Option<LedgerNode> {
+                    let db = config.system_db().ok()?;
+                    ChronicleStore::new(&db).get(hash)
+                }
+            };
+            state
+                .config()
+                .fetch
+                .eventual(|| async {
+                    let root = chronicle_for_wait.root()?;
+                    let seen = match root.as_ref() {
+                        Some(hash) => Ledger::collect_all_ids(Some(hash), &resolve_for_wait),
+                        None => std::collections::HashSet::new(),
+                    };
+                    Ok::<_, EventError>(if expected_ids.is_subset(&seen) {
+                        Some(())
+                    } else {
+                        None
+                    })
+                })
+                .await?;
+        }
 
         // Store the server's root hash in the checkpoint so we can
         // detect "already up to date" on the next collect.
@@ -359,7 +407,14 @@ impl BookmarkService {
             taken_at: Timestamp::now(),
         };
 
-        FollowService::advance(&system, follow.id, checkpoint.clone(), events_received).await?;
+        FollowService::advance(
+            &scope,
+            mailbox,
+            follow.id,
+            checkpoint.clone(),
+            events_received,
+        )
+        .await?;
 
         Ok(BookmarkResponse::Collected(BookmarkCollectResult {
             follow_id: follow.id,
@@ -376,13 +431,14 @@ impl BookmarkService {
     ) -> Result<BookmarkResponse, BookmarkError> {
         let UnfollowBookmark::V1(unfollowing) = request;
         let name = &unfollowing.name;
-        let system = state.host_log();
-        let follow = FollowService::for_bookmark(&system, brain, name)
+        let scope = ComposeScope::new(state.config().clone()).host()?;
+        let mailbox = state.mailbox();
+        let follow = FollowService::for_bookmark(&scope, brain, name)
             .await?
             .ok_or_else(|| BookmarkError::FollowNotFound(name.clone()))?;
 
         let id = follow.id;
-        FollowService::remove(&system, id).await?;
+        FollowService::remove(&scope, mailbox, id).await?;
 
         Ok(BookmarkResponse::Unfollowed(
             BookmarkUnfollowedResponse::builder_v1()

--- a/crates/oneiros-engine/src/domains/brain/features/http.rs
+++ b/crates/oneiros-engine/src/domains/brain/features/http.rs
@@ -33,25 +33,26 @@ impl BrainRouter {
 }
 
 async fn create(
-    context: HostLog,
+    scope: Scope<AtHost>,
+    mailbox: Mailbox,
     Json(body): Json<CreateBrain>,
 ) -> Result<(StatusCode, Json<BrainResponse>), BrainError> {
-    let response = BrainService::create(&context, &body).await?;
+    let response = BrainService::create(&scope, &mailbox, &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
 
 async fn list(
-    context: HostLog,
+    scope: Scope<AtHost>,
     Query(params): Query<ListBrains>,
 ) -> Result<Json<BrainResponse>, BrainError> {
-    Ok(Json(BrainService::list(&context, &params).await?))
+    Ok(Json(BrainService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: HostLog,
+    scope: Scope<AtHost>,
     Path(key): Path<ResourceKey<BrainName>>,
 ) -> Result<Json<BrainResponse>, BrainError> {
     Ok(Json(
-        BrainService::get(&context, &GetBrain::builder_v1().key(key).build().into()).await?,
+        BrainService::get(&scope, &GetBrain::builder_v1().key(key).build().into()).await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/brain/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/brain/features/mcp.rs
@@ -10,10 +10,11 @@ impl BrainMcp {
     pub async fn dispatch(
         &self,
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        brain_mcp::dispatch(context, tool_name, params).await
+        brain_mcp::dispatch(context, mailbox, tool_name, params).await
     }
 }
 
@@ -34,6 +35,7 @@ mod brain_mcp {
 
     pub async fn dispatch(
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
@@ -44,17 +46,16 @@ mod brain_mcp {
         let scope = ComposeScope::new(context.config.clone())
             .host()
             .map_err(Error::from)?;
-        let system = scope.host_log();
 
         let value = match request_type {
             BrainRequestType::CreateBrain => {
-                BrainService::create(&system, &serde_json::from_str(params)?).await
+                BrainService::create(&scope, mailbox, &serde_json::from_str(params)?).await
             }
             BrainRequestType::GetBrain => {
-                BrainService::get(&system, &serde_json::from_str(params)?).await
+                BrainService::get(&scope, &serde_json::from_str(params)?).await
             }
             BrainRequestType::ListBrains => {
-                BrainService::list(&system, &serde_json::from_str(params)?).await
+                BrainService::list(&scope, &serde_json::from_str(params)?).await
             }
         }
         .map_err(Error::from)?;

--- a/crates/oneiros-engine/src/domains/brain/repo.rs
+++ b/crates/oneiros-engine/src/domains/brain/repo.rs
@@ -33,7 +33,7 @@ impl<'a> BrainRepo<'a> {
     }
 
     pub async fn get(&self, name: &BrainName) -> Result<Option<Brain>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
         let mut stmt = db.prepare("select id, name, created_at from brains where name = ?1")?;
 
         let raw = stmt.query_row(params![name.to_string()], |row| {
@@ -57,7 +57,7 @@ impl<'a> BrainRepo<'a> {
     }
 
     pub async fn get_by_id(&self, id: &BrainId) -> Result<Option<Brain>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
         let mut stmt = db.prepare("select id, name, created_at from brains where id = ?1")?;
 
         let raw = stmt.query_row(params![id.to_string()], |row| {
@@ -81,7 +81,7 @@ impl<'a> BrainRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Brain>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM brains")?;
@@ -113,7 +113,7 @@ impl<'a> BrainRepo<'a> {
     }
 
     pub async fn name_exists(&self, name: &BrainName) -> Result<bool, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
         let count: i64 = db.query_row(
             "select count(*) from brains where name = ?1",
             params![name.to_string()],

--- a/crates/oneiros-engine/src/domains/brain/service.rs
+++ b/crates/oneiros-engine/src/domains/brain/service.rs
@@ -4,40 +4,46 @@ pub struct BrainService;
 
 impl BrainService {
     pub async fn create(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
+        mailbox: &Mailbox,
         request: &CreateBrain,
     ) -> Result<BrainResponse, BrainError> {
         let CreateBrain::V1(create) = request;
-        let already_exists = BrainRepo::new(context.scope()?)
-            .name_exists(&create.name)
-            .await?;
+        let already_exists = BrainRepo::new(scope).name_exists(&create.name).await?;
 
         if already_exists {
             return Err(BrainError::Conflict(create.name.clone()));
         }
 
         let brain = Brain::builder().name(create.name.clone()).build();
+        let name = brain.name.clone();
 
-        context
-            .emit(BrainEvents::BrainCreated(
-                BrainCreated::builder_v1()
-                    .brain(brain.clone())
-                    .build()
-                    .into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Brain(BrainEvents::BrainCreated(
+                BrainCreated::builder_v1().brain(brain).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let stored = BrainRepo::new(scope)
+            .fetch(&name)
+            .await?
+            .ok_or(BrainError::NotFound(name))?;
 
         Ok(BrainResponse::Created(
             BrainCreatedResponse::builder_v1()
-                .brain(brain)
+                .brain(stored)
                 .build()
                 .into(),
         ))
     }
 
-    pub async fn get(context: &HostLog, request: &GetBrain) -> Result<BrainResponse, BrainError> {
+    pub async fn get(
+        scope: &Scope<AtHost>,
+        request: &GetBrain,
+    ) -> Result<BrainResponse, BrainError> {
         let GetBrain::V1(lookup) = request;
-        let repo = BrainRepo::new(context.scope()?);
+        let repo = BrainRepo::new(scope);
         let brain = match &lookup.key {
             ResourceKey::Key(name) => repo
                 .fetch(name)
@@ -65,13 +71,11 @@ impl BrainService {
     }
 
     pub async fn list(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
         request: &ListBrains,
     ) -> Result<BrainResponse, BrainError> {
         let ListBrains::V1(listing) = request;
-        let listed = BrainRepo::new(context.scope()?)
-            .list(&listing.filters)
-            .await?;
+        let listed = BrainRepo::new(scope).list(&listing.filters).await?;
         Ok(BrainResponse::Listed(
             BrainsResponse::builder_v1()
                 .items(listed.items)

--- a/crates/oneiros-engine/src/domains/bridge/service.rs
+++ b/crates/oneiros-engine/src/domains/bridge/service.rs
@@ -56,7 +56,7 @@ impl SyncHandler {
         };
 
         // Chronicle objects live in the system DB.
-        let system_db = scope.host_db().await?;
+        let system_db = HostDb::open(&scope).await?;
         let store = ChronicleStore::new(&system_db);
         let resolve = store.resolver();
 
@@ -78,7 +78,7 @@ impl SyncHandler {
         let _ticket = self.validate_ticket(&scope, &resolve_req.link).await?;
 
         // Chronicle objects live in the system DB.
-        let system_db = scope.host_db().await?;
+        let system_db = HostDb::open(&scope).await?;
         let store = ChronicleStore::new(&system_db);
         let resolve = store.resolver();
 
@@ -104,7 +104,7 @@ impl SyncHandler {
             ComposeScope::new(self.config.clone()).project(ticket.brain_name.clone())?;
 
         // Event log lives in events.db (standalone, no ATTACH).
-        let db = project_scope.events_db().await?;
+        let db = EventsDb::open(&project_scope).await?;
 
         let ids: Vec<EventId> = fetch
             .event_ids

--- a/crates/oneiros-engine/src/domains/cognition/features/http.rs
+++ b/crates/oneiros-engine/src/domains/cognition/features/http.rs
@@ -36,29 +36,26 @@ impl CognitionRouter {
 }
 
 async fn add(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Json(body): Json<AddCognition>,
 ) -> Result<(StatusCode, Json<CognitionResponse>), CognitionError> {
-    let response = CognitionService::add(&context, &body).await?;
+    let response = CognitionService::add(&scope, &mailbox, &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
 
 async fn list(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<ListCognitions>,
 ) -> Result<Json<CognitionResponse>, CognitionError> {
-    Ok(Json(CognitionService::list(&context, &params).await?))
+    Ok(Json(CognitionService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(key): Path<ResourceKey<CognitionId>>,
 ) -> Result<Json<CognitionResponse>, CognitionError> {
     Ok(Json(
-        CognitionService::get(
-            &context,
-            &GetCognition::builder_v1().key(key).build().into(),
-        )
-        .await?,
+        CognitionService::get(&scope, &GetCognition::builder_v1().key(key).build().into()).await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/cognition/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/cognition/features/mcp.rs
@@ -10,10 +10,11 @@ impl CognitionMcp {
     pub async fn dispatch(
         &self,
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &ToolName,
         params: &serde_json::Value,
     ) -> Result<McpResponse, ToolError> {
-        cognition_mcp::dispatch(context, tool_name, params).await
+        cognition_mcp::dispatch(context, mailbox, tool_name, params).await
     }
 
     pub fn resources(&self) -> Vec<ResourceDef> {
@@ -44,6 +45,7 @@ mod cognition_mcp {
 
     pub async fn dispatch(
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &ToolName,
         params: &serde_json::Value,
     ) -> Result<McpResponse, ToolError> {
@@ -56,7 +58,8 @@ mod cognition_mcp {
             CognitionRequestType::AddCognition => {
                 let addition: AddCognition = serde_json::from_value(params.clone())?;
                 let request = CognitionRequest::AddCognition(addition.clone());
-                let response = CognitionService::add(context, &addition)
+                let scope = context.scope().map_err(Error::from)?;
+                let response = CognitionService::add(scope, mailbox, &addition)
                     .await
                     .map_err(Error::from)?;
                 Ok(CognitionView::new(response, &request).mcp())
@@ -71,11 +74,12 @@ mod cognition_mcp {
         context: &ProjectLog,
         request: &CognitionRequest,
     ) -> Result<McpResponse, ToolError> {
+        let scope = context.scope().map_err(Error::from)?;
         let response = match request {
-            CognitionRequest::GetCognition(get) => CognitionService::get(context, get)
+            CognitionRequest::GetCognition(get) => CognitionService::get(scope, get)
                 .await
                 .map_err(Error::from)?,
-            CognitionRequest::ListCognitions(listing) => CognitionService::list(context, listing)
+            CognitionRequest::ListCognitions(listing) => CognitionService::list(scope, listing)
                 .await
                 .map_err(Error::from)?,
             CognitionRequest::AddCognition(_) => {

--- a/crates/oneiros-engine/src/domains/cognition/repo.rs
+++ b/crates/oneiros-engine/src/domains/cognition/repo.rs
@@ -23,7 +23,7 @@ impl<'a> CognitionRepo<'a> {
     }
 
     pub async fn get(&self, id: &CognitionId) -> Result<Option<Cognition>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt = db.prepare(
             "SELECT id, agent_id, texture, content, created_at
              FROM cognitions WHERE id = ?1",
@@ -61,7 +61,7 @@ impl<'a> CognitionRepo<'a> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let placeholders = (1..=ids.len())
             .map(|i| format!("?{i}"))
             .collect::<Vec<_>>()
@@ -104,7 +104,7 @@ impl<'a> CognitionRepo<'a> {
         agent_id: &AgentId,
         limit: usize,
     ) -> Result<Vec<Cognition>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt = db.prepare(
             "SELECT id, agent_id, texture, content, created_at
              FROM cognitions

--- a/crates/oneiros-engine/src/domains/cognition/service.rs
+++ b/crates/oneiros-engine/src/domains/cognition/service.rs
@@ -3,12 +3,20 @@ use crate::*;
 pub struct CognitionService;
 
 impl CognitionService {
+    /// Record a cognition by dispatching `CognitionAdded` through the
+    /// bus and reading the eventually-consistent record back via fetch.
+    ///
+    /// No phantom state — the response carries whatever the projection
+    /// has seen, never a synthesised record. If the fetch window
+    /// expires before the projection catches up, this surfaces as
+    /// `CognitionError::NotFound`.
     pub async fn add(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &AddCognition,
     ) -> Result<CognitionResponse, CognitionError> {
         let AddCognition::V1(addition) = request;
-        let agent_record = AgentRepo::new(context.scope()?)
+        let agent_record = AgentRepo::new(scope)
             .fetch(&addition.agent)
             .await?
             .ok_or_else(|| CognitionError::AgentNotFound(addition.agent.clone()))?;
@@ -18,31 +26,39 @@ impl CognitionService {
             .texture(addition.texture.clone())
             .content(addition.content.clone())
             .build();
+        let id = cognition.id;
 
-        context
-            .emit(CognitionEvents::CognitionAdded(
+        let new_event = NewEvent::builder()
+            .data(Events::Cognition(CognitionEvents::CognitionAdded(
                 CognitionAdded::builder_v1()
-                    .cognition(cognition.clone())
+                    .cognition(cognition)
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let stored = CognitionRepo::new(scope)
+            .fetch(&id)
+            .await?
+            .ok_or(CognitionError::NotFound(id))?;
 
         Ok(CognitionResponse::CognitionAdded(
             CognitionAddedResponse::builder_v1()
-                .cognition(cognition)
+                .cognition(stored)
                 .build()
                 .into(),
         ))
     }
 
     pub async fn get(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &GetCognition,
     ) -> Result<CognitionResponse, CognitionError> {
         let GetCognition::V1(lookup) = request;
         let id = lookup.key.resolve()?;
-        let cognition = CognitionRepo::new(context.scope()?)
+        let cognition = CognitionRepo::new(scope)
             .fetch(&id)
             .await?
             .ok_or(CognitionError::NotFound(id))?;
@@ -55,13 +71,13 @@ impl CognitionService {
     }
 
     pub async fn list(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ListCognitions,
     ) -> Result<CognitionResponse, CognitionError> {
         let ListCognitions::V1(listing) = request;
         let agent_id = match &listing.agent {
             Some(name) => {
-                let record = AgentRepo::new(context.scope()?)
+                let record = AgentRepo::new(scope)
                     .fetch(name)
                     .await?
                     .ok_or_else(|| CognitionError::AgentNotFound(name.clone()))?;
@@ -77,7 +93,7 @@ impl CognitionService {
             .filters(listing.filters)
             .build();
 
-        let results = SearchRepo::new(context.scope()?)
+        let results = SearchRepo::new(scope)
             .search(&search_query, agent_id.as_ref())
             .await?;
 
@@ -93,7 +109,7 @@ impl CognitionService {
                 _ => None,
             })
             .collect();
-        let items = CognitionRepo::new(context.scope()?).get_many(&ids).await?;
+        let items = CognitionRepo::new(scope).get_many(&ids).await?;
 
         Ok(CognitionResponse::Cognitions(
             CognitionsResponse::builder_v1()

--- a/crates/oneiros-engine/src/domains/connection/features/http.rs
+++ b/crates/oneiros-engine/src/domains/connection/features/http.rs
@@ -39,40 +39,40 @@ impl ConnectionRouter {
 }
 
 async fn create(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Json(body): Json<CreateConnection>,
 ) -> Result<(StatusCode, Json<ConnectionResponse>), ConnectionError> {
-    let response = ConnectionService::create(&context, &body).await?;
+    let response = ConnectionService::create(&scope, &mailbox, &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
 
 async fn list(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<ListConnections>,
 ) -> Result<Json<ConnectionResponse>, ConnectionError> {
-    Ok(Json(ConnectionService::list(&context, &params).await?))
+    Ok(Json(ConnectionService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(key): Path<ResourceKey<ConnectionId>>,
 ) -> Result<Json<ConnectionResponse>, ConnectionError> {
     Ok(Json(
-        ConnectionService::get(
-            &context,
-            &GetConnection::builder_v1().key(key).build().into(),
-        )
-        .await?,
+        ConnectionService::get(&scope, &GetConnection::builder_v1().key(key).build().into())
+            .await?,
     ))
 }
 
 async fn remove(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(id): Path<ConnectionId>,
 ) -> Result<Json<ConnectionResponse>, ConnectionError> {
     Ok(Json(
         ConnectionService::remove(
-            &context,
+            &scope,
+            &mailbox,
             &RemoveConnection::builder_v1().id(id).build().into(),
         )
         .await?,

--- a/crates/oneiros-engine/src/domains/connection/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/connection/features/mcp.rs
@@ -10,10 +10,11 @@ impl ConnectionMcp {
     pub async fn dispatch(
         &self,
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &ToolName,
         params: &serde_json::Value,
     ) -> Result<McpResponse, ToolError> {
-        connection_mcp::dispatch(context, tool_name, params).await
+        connection_mcp::dispatch(context, mailbox, tool_name, params).await
     }
 
     pub fn resources(&self) -> Vec<ResourceDef> {
@@ -48,6 +49,7 @@ mod connection_mcp {
 
     pub async fn dispatch(
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &ToolName,
         params: &serde_json::Value,
     ) -> Result<McpResponse, ToolError> {
@@ -60,7 +62,8 @@ mod connection_mcp {
             ConnectionRequestType::CreateConnection => {
                 let creation: CreateConnection = serde_json::from_value(params.clone())?;
                 let request = ConnectionRequest::CreateConnection(creation.clone());
-                let response = ConnectionService::create(context, &creation)
+                let scope = context.scope().map_err(Error::from)?;
+                let response = ConnectionService::create(scope, mailbox, &creation)
                     .await
                     .map_err(Error::from)?;
                 Ok(ConnectionView::new(response, &request).mcp())
@@ -77,15 +80,14 @@ mod connection_mcp {
         context: &ProjectLog,
         request: &ConnectionRequest,
     ) -> Result<McpResponse, ToolError> {
+        let scope = context.scope().map_err(Error::from)?;
         let response = match request {
-            ConnectionRequest::GetConnection(get) => ConnectionService::get(context, get)
+            ConnectionRequest::GetConnection(get) => ConnectionService::get(scope, get)
                 .await
                 .map_err(Error::from)?,
-            ConnectionRequest::ListConnections(listing) => {
-                ConnectionService::list(context, listing)
-                    .await
-                    .map_err(Error::from)?
-            }
+            ConnectionRequest::ListConnections(listing) => ConnectionService::list(scope, listing)
+                .await
+                .map_err(Error::from)?,
             ConnectionRequest::CreateConnection(_) | ConnectionRequest::RemoveConnection(_) => {
                 return Err(ToolError::NotAResource(
                     "Mutations are tools, not resources".to_string(),

--- a/crates/oneiros-engine/src/domains/connection/repo.rs
+++ b/crates/oneiros-engine/src/domains/connection/repo.rs
@@ -21,7 +21,7 @@ impl<'a> ConnectionRepo<'a> {
     }
 
     pub async fn get(&self, id: &ConnectionId) -> Result<Option<Connection>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt = db.prepare(
             "SELECT id, from_ref, to_ref, nature, created_at
              FROM connections WHERE id = ?1",
@@ -57,7 +57,7 @@ impl<'a> ConnectionRepo<'a> {
         entity_ref: Option<&str>,
         filters: &SearchFilters,
     ) -> Result<Listed<Connection>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
 
         // Build WHERE clause from filters.
         let mut conditions = Vec::new();

--- a/crates/oneiros-engine/src/domains/connection/service.rs
+++ b/crates/oneiros-engine/src/domains/connection/service.rs
@@ -4,7 +4,8 @@ pub struct ConnectionService;
 
 impl ConnectionService {
     pub async fn create(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &CreateConnection,
     ) -> Result<ConnectionResponse, ConnectionError> {
         let CreateConnection::V1(creation) = request;
@@ -14,31 +15,38 @@ impl ConnectionService {
             .to_ref(creation.to_ref.clone().into_inner())
             .nature(creation.nature.clone())
             .build();
+        let id = connection.id;
 
-        context
-            .emit(ConnectionEvents::ConnectionCreated(
+        let new_event = NewEvent::builder()
+            .data(Events::Connection(ConnectionEvents::ConnectionCreated(
                 ConnectionCreated::builder_v1()
-                    .connection(connection.clone())
+                    .connection(connection)
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let stored = ConnectionRepo::new(scope)
+            .fetch(&id)
+            .await?
+            .ok_or(ConnectionError::NotFound(id))?;
 
         Ok(ConnectionResponse::ConnectionCreated(
             ConnectionCreatedResponse::builder_v1()
-                .connection(connection)
+                .connection(stored)
                 .build()
                 .into(),
         ))
     }
 
     pub async fn get(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &GetConnection,
     ) -> Result<ConnectionResponse, ConnectionError> {
         let GetConnection::V1(lookup) = request;
         let id = lookup.key.resolve()?;
-        let connection = ConnectionRepo::new(context.scope()?)
+        let connection = ConnectionRepo::new(scope)
             .fetch(&id)
             .await?
             .ok_or(ConnectionError::NotFound(id))?;
@@ -51,7 +59,7 @@ impl ConnectionService {
     }
 
     pub async fn list(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ListConnections,
     ) -> Result<ConnectionResponse, ConnectionError> {
         let ListConnections::V1(listing) = request;
@@ -64,7 +72,7 @@ impl ConnectionService {
             })
             .transpose()?;
 
-        let listed = ConnectionRepo::new(context.scope()?)
+        let listed = ConnectionRepo::new(scope)
             .list(ref_json.as_deref(), &listing.filters)
             .await?;
         if listed.total == 0 {
@@ -81,11 +89,12 @@ impl ConnectionService {
     }
 
     pub async fn remove(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &RemoveConnection,
     ) -> Result<ConnectionResponse, ConnectionError> {
         let RemoveConnection::V1(removal) = request;
-        if ConnectionRepo::new(context.scope()?)
+        if ConnectionRepo::new(scope)
             .fetch(&removal.id)
             .await?
             .is_none()
@@ -93,14 +102,22 @@ impl ConnectionService {
             return Err(ConnectionError::NotFound(removal.id));
         }
 
-        context
-            .emit(ConnectionEvents::ConnectionRemoved(
+        let new_event = NewEvent::builder()
+            .data(Events::Connection(ConnectionEvents::ConnectionRemoved(
                 ConnectionRemoved::builder_v1()
                     .id(removal.id)
                     .build()
                     .into(),
-            ))
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        scope
+            .config()
+            .fetch
+            .until_absent(|| async { ConnectionRepo::new(scope).get(&removal.id).await })
             .await?;
+
         Ok(ConnectionResponse::ConnectionRemoved(
             ConnectionRemovedResponse::builder_v1()
                 .id(removal.id)

--- a/crates/oneiros-engine/src/domains/continuity/features/http.rs
+++ b/crates/oneiros-engine/src/domains/continuity/features/http.rs
@@ -81,22 +81,25 @@ impl ContinuityRouter {
 }
 
 async fn emerge(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Json(body): Json<EmergeAgent>,
 ) -> Result<(StatusCode, Json<ContinuityResponse>), ContinuityError> {
     Ok((
         StatusCode::CREATED,
-        Json(ContinuityService::emerge(&context, &body, &DreamOverrides::default()).await?),
+        Json(ContinuityService::emerge(&scope, &mailbox, &body, &DreamOverrides::default()).await?),
     ))
 }
 
 async fn recede(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(agent): Path<AgentName>,
 ) -> Result<Json<ContinuityResponse>, ContinuityError> {
     Ok(Json(
         ContinuityService::recede(
-            &context,
+            &scope,
+            &mailbox,
             &RecedeAgent::builder_v1().agent(agent).build().into(),
         )
         .await?,
@@ -104,20 +107,22 @@ async fn recede(
 }
 
 async fn status(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<StatusAgent>,
 ) -> Result<Json<ContinuityResponse>, ContinuityError> {
-    Ok(Json(ContinuityService::status(&context, &params)?))
+    Ok(Json(ContinuityService::status(&scope, &params).await?))
 }
 
 async fn wake(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(agent): Path<AgentName>,
     Query(overrides): Query<DreamOverrides>,
 ) -> Result<Json<ContinuityResponse>, ContinuityError> {
     Ok(Json(
         ContinuityService::wake(
-            &context,
+            &scope,
+            &mailbox,
             &WakeAgent::builder_v1().agent(agent).build().into(),
             &overrides,
         )
@@ -126,13 +131,15 @@ async fn wake(
 }
 
 async fn dream(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(agent): Path<AgentName>,
     Query(overrides): Query<DreamOverrides>,
 ) -> Result<Json<ContinuityResponse>, ContinuityError> {
     Ok(Json(
         ContinuityService::dream(
-            &context,
+            &scope,
+            &mailbox,
             &DreamAgent::builder_v1().agent(agent).build().into(),
             &overrides,
         )
@@ -141,13 +148,15 @@ async fn dream(
 }
 
 async fn introspect(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(agent): Path<AgentName>,
     Query(overrides): Query<DreamOverrides>,
 ) -> Result<Json<ContinuityResponse>, ContinuityError> {
     Ok(Json(
         ContinuityService::introspect(
-            &context,
+            &scope,
+            &mailbox,
             &IntrospectAgent::builder_v1().agent(agent).build().into(),
             &overrides,
         )
@@ -156,13 +165,15 @@ async fn introspect(
 }
 
 async fn reflect(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(agent): Path<AgentName>,
     Query(overrides): Query<DreamOverrides>,
 ) -> Result<Json<ContinuityResponse>, ContinuityError> {
     Ok(Json(
         ContinuityService::reflect(
-            &context,
+            &scope,
+            &mailbox,
             &ReflectAgent::builder_v1().agent(agent).build().into(),
             &overrides,
         )
@@ -171,7 +182,8 @@ async fn reflect(
 }
 
 async fn sense(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(agent): Path<AgentName>,
     Json(body): Json<SenseContent>,
 ) -> Result<Json<ContinuityResponse>, ContinuityError> {
@@ -182,18 +194,20 @@ async fn sense(
         .build()
         .into();
     Ok(Json(
-        ContinuityService::sense(&context, &request, &DreamOverrides::default()).await?,
+        ContinuityService::sense(&scope, &mailbox, &request, &DreamOverrides::default()).await?,
     ))
 }
 
 async fn sleep(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(agent): Path<AgentName>,
     Query(overrides): Query<DreamOverrides>,
 ) -> Result<Json<ContinuityResponse>, ContinuityError> {
     Ok(Json(
         ContinuityService::sleep(
-            &context,
+            &scope,
+            &mailbox,
             &SleepAgent::builder_v1().agent(agent).build().into(),
             &overrides,
         )
@@ -202,13 +216,13 @@ async fn sleep(
 }
 
 async fn guidebook(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(agent): Path<AgentName>,
     Query(overrides): Query<DreamOverrides>,
 ) -> Result<Json<ContinuityResponse>, ContinuityError> {
     Ok(Json(
         ContinuityService::guidebook(
-            &context,
+            &scope,
             &GuidebookAgent::builder_v1().agent(agent).build().into(),
             &overrides,
         )

--- a/crates/oneiros-engine/src/domains/continuity/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/continuity/features/mcp.rs
@@ -16,7 +16,8 @@ impl ContinuityMcp {
         context: &ProjectLog,
         request: &ContinuityRequest,
     ) -> Result<McpResponse, ToolError> {
-        continuity_mcp::resource(context, request).await
+        let scope = context.scope().map_err(Error::from)?;
+        continuity_mcp::resource(scope, request).await
     }
 }
 
@@ -24,12 +25,14 @@ mod continuity_mcp {
     use crate::*;
 
     pub async fn resource(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ContinuityRequest,
     ) -> Result<McpResponse, ToolError> {
         match request {
             ContinuityRequest::StatusAgent(status) => {
-                let response = ContinuityService::status(context, status).map_err(Error::from)?;
+                let response = ContinuityService::status(scope, status)
+                    .await
+                    .map_err(Error::from)?;
                 Ok(ContinuityView::new(response).mcp())
             }
             _ => Err(ToolError::NotAResource(

--- a/crates/oneiros-engine/src/domains/continuity/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/continuity/protocol/errors.rs
@@ -19,6 +19,9 @@ pub enum ContinuityError {
     Compose(#[from] crate::ComposeError),
 
     #[error(transparent)]
+    BookmarkDb(#[from] crate::BookmarkDbError),
+
+    #[error(transparent)]
     Event(#[from] crate::EventError),
 
     #[error(transparent)]
@@ -35,7 +38,9 @@ impl IntoResponse for ContinuityError {
         let (status, message) = match &self {
             ContinuityError::AgentNotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
             ContinuityError::Agent(_) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
-            ContinuityError::Database(_) | ContinuityError::Event(_) => {
+            ContinuityError::Database(_)
+            | ContinuityError::Event(_)
+            | ContinuityError::BookmarkDb(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
             }
             ContinuityError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),

--- a/crates/oneiros-engine/src/domains/continuity/service.rs
+++ b/crates/oneiros-engine/src/domains/continuity/service.rs
@@ -23,13 +23,15 @@ pub struct ContinuityService;
 impl ContinuityService {
     /// Emerge — create an agent and immediately activate its continuity.
     pub async fn emerge(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &EmergeAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
         let EmergeAgent::V1(emerging) = request;
         let created = AgentService::create(
-            context,
+            scope,
+            mailbox,
             &CreateAgent::builder_v1()
                 .name(emerging.name.clone())
                 .persona(emerging.persona.clone())
@@ -46,12 +48,13 @@ impl ContinuityService {
             }
         };
 
-        // Wake activates continuity; then gather the full context for the
-        // response. We pass the agent record we already hold rather than
-        // re-looking-up by name — the lookup race doesn't happen because
-        // the lookup doesn't happen.
+        // Wake activates continuity; then gather the full context for
+        // the response. We pass the agent record we already hold
+        // rather than re-looking-up by name — the lookup race doesn't
+        // happen because the lookup doesn't happen.
         Self::wake(
-            context,
+            scope,
+            mailbox,
             &WakeAgent::builder_v1()
                 .agent(created_agent.name.clone())
                 .build()
@@ -59,7 +62,7 @@ impl ContinuityService {
             overrides,
         )
         .await?;
-        let dream = Self::gather_context_for(context, &created_agent, overrides)?;
+        let dream = Self::gather_context_for(scope, &created_agent, overrides).await?;
         Ok(ContinuityResponse::Emerged(
             EmergedResponse::builder_v1().context(dream).build().into(),
         ))
@@ -67,12 +70,14 @@ impl ContinuityService {
 
     /// Recede — retire an agent, ending its continuity.
     pub async fn recede(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &RecedeAgent,
     ) -> Result<ContinuityResponse, ContinuityError> {
         let RecedeAgent::V1(receding) = request;
         AgentService::remove(
-            context,
+            scope,
+            mailbox,
             &RemoveAgent::builder_v1()
                 .name(receding.agent.clone())
                 .build()
@@ -88,11 +93,11 @@ impl ContinuityService {
     }
 
     /// Status — cross-agent activity overview.
-    pub fn status(
-        context: &ProjectLog,
+    pub async fn status(
+        scope: &Scope<AtBookmark>,
         _request: &StatusAgent,
     ) -> Result<ContinuityResponse, ContinuityError> {
-        let db = context.db()?;
+        let db = BookmarkDb::open(scope).await?;
         let agents = AgentStore::new(&db).list()?;
 
         let mut rows = Vec::with_capacity(agents.len());
@@ -163,22 +168,24 @@ impl ContinuityService {
 
     /// Wake — restore an agent's full cognitive context (initial session start).
     pub async fn wake(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &WakeAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
         let WakeAgent::V1(wake) = request;
-        let dream = Self::gather_context(context, &wake.agent, overrides).await?;
+        let dream = Self::gather_context(scope, &wake.agent, overrides).await?;
 
-        context
-            .emit(ContinuityEvents::Dreamed(
+        let new_event = NewEvent::builder()
+            .data(Events::Continuity(ContinuityEvents::Dreamed(
                 Dreamed::builder_v1()
                     .agent(wake.agent.clone())
                     .created_at(Timestamp::now())
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
 
         Ok(ContinuityResponse::Waking(
             WakingResponse::builder_v1().context(dream).build().into(),
@@ -187,22 +194,24 @@ impl ContinuityService {
 
     /// Dream — restore an agent's full cognitive context.
     pub async fn dream(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &DreamAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
         let DreamAgent::V1(dreaming) = request;
-        let dream = Self::gather_context(context, &dreaming.agent, overrides).await?;
+        let dream = Self::gather_context(scope, &dreaming.agent, overrides).await?;
 
-        context
-            .emit(ContinuityEvents::Dreamed(
+        let new_event = NewEvent::builder()
+            .data(Events::Continuity(ContinuityEvents::Dreamed(
                 Dreamed::builder_v1()
                     .agent(dreaming.agent.clone())
                     .created_at(Timestamp::now())
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
 
         Ok(ContinuityResponse::Dreaming(
             DreamingResponse::builder_v1().context(dream).build().into(),
@@ -211,22 +220,24 @@ impl ContinuityService {
 
     /// Introspect — look inward, consolidate cognitive state.
     pub async fn introspect(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &IntrospectAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
         let IntrospectAgent::V1(introspecting) = request;
-        let dream = Self::gather_context(context, &introspecting.agent, overrides).await?;
+        let dream = Self::gather_context(scope, &introspecting.agent, overrides).await?;
 
-        context
-            .emit(ContinuityEvents::Introspected(
+        let new_event = NewEvent::builder()
+            .data(Events::Continuity(ContinuityEvents::Introspected(
                 Introspected::builder_v1()
                     .agent(introspecting.agent.clone())
                     .created_at(Timestamp::now())
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
 
         Ok(ContinuityResponse::Introspecting(
             IntrospectingResponse::builder_v1()
@@ -238,22 +249,24 @@ impl ContinuityService {
 
     /// Reflect — pause on something significant.
     pub async fn reflect(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &ReflectAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
         let ReflectAgent::V1(reflecting) = request;
-        let dream = Self::gather_context(context, &reflecting.agent, overrides).await?;
+        let dream = Self::gather_context(scope, &reflecting.agent, overrides).await?;
 
-        context
-            .emit(ContinuityEvents::Reflected(
+        let new_event = NewEvent::builder()
+            .data(Events::Continuity(ContinuityEvents::Reflected(
                 Reflected::builder_v1()
                     .agent(reflecting.agent.clone())
                     .created_at(Timestamp::now())
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
 
         Ok(ContinuityResponse::Reflecting(
             ReflectingResponse::builder_v1()
@@ -265,23 +278,25 @@ impl ContinuityService {
 
     /// Sense — receive and interpret something from outside.
     pub async fn sense(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &SenseContent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
         let SenseContent::V1(sensing) = request;
-        let dream = Self::gather_context(context, &sensing.agent, overrides).await?;
+        let dream = Self::gather_context(scope, &sensing.agent, overrides).await?;
 
-        context
-            .emit(ContinuityEvents::Sensed(
+        let new_event = NewEvent::builder()
+            .data(Events::Continuity(ContinuityEvents::Sensed(
                 Sensed::builder_v1()
                     .agent(sensing.agent.clone())
                     .content(Content::new(sensing.content.as_str()))
                     .created_at(Timestamp::now())
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
 
         Ok(ContinuityResponse::Sleeping(
             SleepingResponse::builder_v1().context(dream).build().into(),
@@ -290,22 +305,24 @@ impl ContinuityService {
 
     /// Sleep — end a session, capture continuity.
     pub async fn sleep(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &SleepAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
         let SleepAgent::V1(sleeping) = request;
-        let dream = Self::gather_context(context, &sleeping.agent, overrides).await?;
+        let dream = Self::gather_context(scope, &sleeping.agent, overrides).await?;
 
-        context
-            .emit(ContinuityEvents::Slept(
+        let new_event = NewEvent::builder()
+            .data(Events::Continuity(ContinuityEvents::Slept(
                 Slept::builder_v1()
                     .agent(sleeping.agent.clone())
                     .created_at(Timestamp::now())
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
 
         Ok(ContinuityResponse::Sleeping(
             SleepingResponse::builder_v1().context(dream).build().into(),
@@ -317,12 +334,12 @@ impl ContinuityService {
     /// Used to display the agent's full operational context (textures,
     /// sensations, levels, urges) without marking a continuity transition.
     pub async fn guidebook(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &GuidebookAgent,
         overrides: &DreamOverrides,
     ) -> Result<ContinuityResponse, ContinuityError> {
         let GuidebookAgent::V1(lookup) = request;
-        let dream = Self::gather_context(context, &lookup.agent, overrides).await?;
+        let dream = Self::gather_context(scope, &lookup.agent, overrides).await?;
         Ok(ContinuityResponse::Guidebook(
             GuidebookResponse::builder_v1()
                 .context(dream)
@@ -338,15 +355,15 @@ impl ContinuityService {
     ///
     /// [`gather_context_for`]: ContinuityService::gather_context_for
     pub async fn gather_context(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         agent_name: &AgentName,
         overrides: &DreamOverrides,
     ) -> Result<DreamContext, ContinuityError> {
-        let agent = AgentRepo::new(context.scope()?)
+        let agent = AgentRepo::new(scope)
             .fetch(agent_name)
             .await?
             .ok_or_else(|| ContinuityError::AgentNotFound(agent_name.clone()))?;
-        Self::gather_context_for(context, &agent, overrides)
+        Self::gather_context_for(scope, &agent, overrides).await
     }
 
     /// Gather the full cognitive context for a known agent.
@@ -357,13 +374,13 @@ impl ContinuityService {
     /// hold an owned Connection.
     ///
     /// [`emerge`]: ContinuityService::emerge
-    pub fn gather_context_for(
-        context: &ProjectLog,
+    pub async fn gather_context_for(
+        scope: &Scope<AtBookmark>,
         agent: &Agent,
         overrides: &DreamOverrides,
     ) -> Result<DreamContext, ContinuityError> {
-        let config = context.config.dream.merge(overrides);
-        let db = context.db()?;
+        let config = scope.config().dream.merge(overrides);
+        let db = BookmarkDb::open(scope).await?;
 
         let persona_name = agent.persona.clone();
         let persona = PersonaStore::new(&db).get(&persona_name)?;

--- a/crates/oneiros-engine/src/domains/doctor/service.rs
+++ b/crates/oneiros-engine/src/domains/doctor/service.rs
@@ -22,7 +22,7 @@ impl DoctorService {
             }
         };
 
-        let db = match scope.host_db().await {
+        let db = match HostDb::open(&scope).await {
             Ok(db) => db,
             Err(_) => {
                 checks.push(DoctorCheck::NotInitialized);

--- a/crates/oneiros-engine/src/domains/experience/features/http.rs
+++ b/crates/oneiros-engine/src/domains/experience/features/http.rs
@@ -51,41 +51,41 @@ struct UpdateSensationBody {
 }
 
 async fn create(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Json(body): Json<CreateExperience>,
 ) -> Result<(StatusCode, Json<ExperienceResponse>), ExperienceError> {
-    let response = ExperienceService::create(&context, &body).await?;
+    let response = ExperienceService::create(&scope, &mailbox, &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
 
 async fn list(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<ListExperiences>,
 ) -> Result<Json<ExperienceResponse>, ExperienceError> {
-    Ok(Json(ExperienceService::list(&context, &params).await?))
+    Ok(Json(ExperienceService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(key): Path<ResourceKey<ExperienceId>>,
 ) -> Result<Json<ExperienceResponse>, ExperienceError> {
     Ok(Json(
-        ExperienceService::get(
-            &context,
-            &GetExperience::builder_v1().key(key).build().into(),
-        )
-        .await?,
+        ExperienceService::get(&scope, &GetExperience::builder_v1().key(key).build().into())
+            .await?,
     ))
 }
 
 async fn update_description(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(id): Path<ExperienceId>,
     Json(body): Json<UpdateDescriptionBody>,
 ) -> Result<Json<ExperienceResponse>, ExperienceError> {
     Ok(Json(
         ExperienceService::update_description(
-            &context,
+            &scope,
+            &mailbox,
             &UpdateExperienceDescription::builder_v1()
                 .id(id)
                 .description(body.description)
@@ -97,13 +97,15 @@ async fn update_description(
 }
 
 async fn update_sensation(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(id): Path<ExperienceId>,
     Json(body): Json<UpdateSensationBody>,
 ) -> Result<Json<ExperienceResponse>, ExperienceError> {
     Ok(Json(
         ExperienceService::update_sensation(
-            &context,
+            &scope,
+            &mailbox,
             &UpdateExperienceSensation::builder_v1()
                 .id(id)
                 .sensation(body.sensation)

--- a/crates/oneiros-engine/src/domains/experience/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/experience/features/mcp.rs
@@ -10,10 +10,11 @@ impl ExperienceMcp {
     pub async fn dispatch(
         &self,
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &ToolName,
         params: &serde_json::Value,
     ) -> Result<McpResponse, ToolError> {
-        experience_mcp::dispatch(context, tool_name, params).await
+        experience_mcp::dispatch(context, mailbox, tool_name, params).await
     }
 
     pub fn resources(&self) -> Vec<ResourceDef> {
@@ -48,6 +49,7 @@ mod experience_mcp {
 
     pub async fn dispatch(
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &ToolName,
         params: &serde_json::Value,
     ) -> Result<McpResponse, ToolError> {
@@ -60,7 +62,8 @@ mod experience_mcp {
             ExperienceRequestType::CreateExperience => {
                 let creation: CreateExperience = serde_json::from_value(params.clone())?;
                 let request = ExperienceRequest::CreateExperience(creation.clone());
-                let response = ExperienceService::create(context, &creation)
+                let scope = context.scope().map_err(Error::from)?;
+                let response = ExperienceService::create(scope, mailbox, &creation)
                     .await
                     .map_err(Error::from)?;
                 Ok(ExperienceView::new(response, &request).mcp())
@@ -78,15 +81,14 @@ mod experience_mcp {
         context: &ProjectLog,
         request: &ExperienceRequest,
     ) -> Result<McpResponse, ToolError> {
+        let scope = context.scope().map_err(Error::from)?;
         let response = match request {
-            ExperienceRequest::GetExperience(get) => ExperienceService::get(context, get)
+            ExperienceRequest::GetExperience(get) => ExperienceService::get(scope, get)
                 .await
                 .map_err(Error::from)?,
-            ExperienceRequest::ListExperiences(listing) => {
-                ExperienceService::list(context, listing)
-                    .await
-                    .map_err(Error::from)?
-            }
+            ExperienceRequest::ListExperiences(listing) => ExperienceService::list(scope, listing)
+                .await
+                .map_err(Error::from)?,
             ExperienceRequest::CreateExperience(_)
             | ExperienceRequest::UpdateExperienceDescription(_)
             | ExperienceRequest::UpdateExperienceSensation(_) => {

--- a/crates/oneiros-engine/src/domains/experience/repo.rs
+++ b/crates/oneiros-engine/src/domains/experience/repo.rs
@@ -23,7 +23,7 @@ impl<'a> ExperienceRepo<'a> {
     }
 
     pub async fn get(&self, id: &ExperienceId) -> Result<Option<Experience>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt = db.prepare(
             "SELECT id, agent_id, sensation, description, created_at
              FROM experiences WHERE id = ?1",
@@ -61,7 +61,7 @@ impl<'a> ExperienceRepo<'a> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let placeholders = (1..=ids.len())
             .map(|i| format!("?{i}"))
             .collect::<Vec<_>>()
@@ -104,7 +104,7 @@ impl<'a> ExperienceRepo<'a> {
         agent_id: &str,
         limit: usize,
     ) -> Result<Vec<Experience>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt = db.prepare(
             "SELECT id, agent_id, sensation, description, created_at
              FROM experiences

--- a/crates/oneiros-engine/src/domains/experience/service.rs
+++ b/crates/oneiros-engine/src/domains/experience/service.rs
@@ -4,11 +4,12 @@ pub struct ExperienceService;
 
 impl ExperienceService {
     pub async fn create(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &CreateExperience,
     ) -> Result<ExperienceResponse, ExperienceError> {
         let CreateExperience::V1(creation) = request;
-        let agent_record = AgentRepo::new(context.scope()?)
+        let agent_record = AgentRepo::new(scope)
             .fetch(&creation.agent)
             .await?
             .ok_or_else(|| ExperienceError::AgentNotFound(creation.agent.clone()))?;
@@ -18,31 +19,38 @@ impl ExperienceService {
             .sensation(creation.sensation.clone())
             .description(creation.description.clone())
             .build();
+        let id = experience.id;
 
-        context
-            .emit(ExperienceEvents::ExperienceCreated(
+        let new_event = NewEvent::builder()
+            .data(Events::Experience(ExperienceEvents::ExperienceCreated(
                 ExperienceCreated::builder_v1()
-                    .experience(experience.clone())
+                    .experience(experience)
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let stored = ExperienceRepo::new(scope)
+            .fetch(&id)
+            .await?
+            .ok_or(ExperienceError::NotFound(id))?;
 
         Ok(ExperienceResponse::ExperienceCreated(
             ExperienceCreatedResponse::builder_v1()
-                .experience(experience)
+                .experience(stored)
                 .build()
                 .into(),
         ))
     }
 
     pub async fn get(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &GetExperience,
     ) -> Result<ExperienceResponse, ExperienceError> {
         let GetExperience::V1(lookup) = request;
         let id = lookup.key.resolve()?;
-        let experience = ExperienceRepo::new(context.scope()?)
+        let experience = ExperienceRepo::new(scope)
             .fetch(&id)
             .await?
             .ok_or(ExperienceError::NotFound(id))?;
@@ -55,13 +63,13 @@ impl ExperienceService {
     }
 
     pub async fn list(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ListExperiences,
     ) -> Result<ExperienceResponse, ExperienceError> {
         let ListExperiences::V1(listing) = request;
         let agent_id = match &listing.agent {
             Some(name) => {
-                let record = AgentRepo::new(context.scope()?)
+                let record = AgentRepo::new(scope)
                     .fetch(name)
                     .await?
                     .ok_or_else(|| ExperienceError::AgentNotFound(name.clone()))?;
@@ -77,7 +85,7 @@ impl ExperienceService {
             .filters(listing.filters)
             .build();
 
-        let results = SearchRepo::new(context.scope()?)
+        let results = SearchRepo::new(scope)
             .search(&search_query, agent_id.as_ref())
             .await?;
 
@@ -93,7 +101,7 @@ impl ExperienceService {
                 _ => None,
             })
             .collect();
-        let items = ExperienceRepo::new(context.scope()?).get_many(&ids).await?;
+        let items = ExperienceRepo::new(scope).get_many(&ids).await?;
 
         Ok(ExperienceResponse::Experiences(
             ExperiencesResponse::builder_v1()
@@ -105,60 +113,91 @@ impl ExperienceService {
     }
 
     pub async fn update_description(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &UpdateExperienceDescription,
     ) -> Result<ExperienceResponse, ExperienceError> {
         let UpdateExperienceDescription::V1(update) = request;
-        let mut experience = ExperienceRepo::new(context.scope()?)
+        // Validate the experience exists before dispatching the update.
+        ExperienceRepo::new(scope)
             .fetch(&update.id)
             .await?
-            .ok_or_else(|| ExperienceError::NotFound(update.id))?;
+            .ok_or(ExperienceError::NotFound(update.id))?;
 
-        experience.description = update.description.clone();
-
-        context
-            .emit(ExperienceEvents::ExperienceDescriptionUpdated(
-                ExperienceDescriptionUpdated::builder_v1()
-                    .id(update.id)
-                    .description(update.description.clone())
-                    .build()
-                    .into(),
+        let new_event = NewEvent::builder()
+            .data(Events::Experience(
+                ExperienceEvents::ExperienceDescriptionUpdated(
+                    ExperienceDescriptionUpdated::builder_v1()
+                        .id(update.id)
+                        .description(update.description.clone())
+                        .build()
+                        .into(),
+                ),
             ))
-            .await?;
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        // Read back the updated record. Fetch polls until the projection
+        // reflects the new description.
+        let updated = scope
+            .config()
+            .fetch
+            .eventual(|| async {
+                ExperienceRepo::new(scope)
+                    .get(&update.id)
+                    .await
+                    .map(|opt| opt.filter(|exp| exp.description == update.description))
+            })
+            .await?
+            .ok_or(ExperienceError::NotFound(update.id))?;
 
         Ok(ExperienceResponse::ExperienceUpdated(
             ExperienceUpdatedResponse::builder_v1()
-                .experience(experience)
+                .experience(updated)
                 .build()
                 .into(),
         ))
     }
 
     pub async fn update_sensation(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &UpdateExperienceSensation,
     ) -> Result<ExperienceResponse, ExperienceError> {
         let UpdateExperienceSensation::V1(update) = request;
-        let mut experience = ExperienceRepo::new(context.scope()?)
+        ExperienceRepo::new(scope)
             .fetch(&update.id)
             .await?
-            .ok_or_else(|| ExperienceError::NotFound(update.id))?;
+            .ok_or(ExperienceError::NotFound(update.id))?;
 
-        experience.sensation = update.sensation.clone();
-
-        context
-            .emit(ExperienceEvents::ExperienceSensationUpdated(
-                ExperienceSensationUpdated::builder_v1()
-                    .id(update.id)
-                    .sensation(update.sensation.clone())
-                    .build()
-                    .into(),
+        let new_event = NewEvent::builder()
+            .data(Events::Experience(
+                ExperienceEvents::ExperienceSensationUpdated(
+                    ExperienceSensationUpdated::builder_v1()
+                        .id(update.id)
+                        .sensation(update.sensation.clone())
+                        .build()
+                        .into(),
+                ),
             ))
-            .await?;
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let updated = scope
+            .config()
+            .fetch
+            .eventual(|| async {
+                ExperienceRepo::new(scope)
+                    .get(&update.id)
+                    .await
+                    .map(|opt| opt.filter(|exp| exp.sensation == update.sensation))
+            })
+            .await?
+            .ok_or(ExperienceError::NotFound(update.id))?;
 
         Ok(ExperienceResponse::ExperienceUpdated(
             ExperienceUpdatedResponse::builder_v1()
-                .experience(experience)
+                .experience(updated)
                 .build()
                 .into(),
         ))

--- a/crates/oneiros-engine/src/domains/follow/repo.rs
+++ b/crates/oneiros-engine/src/domains/follow/repo.rs
@@ -21,7 +21,7 @@ impl<'a> FollowRepo<'a> {
     }
 
     pub async fn get(&self, id: FollowId) -> Result<Option<Follow>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
         let mut stmt = db.prepare(
             "select id, brain, bookmark, source, checkpoint, created_at \
              from follows where id = ?1",
@@ -37,7 +37,7 @@ impl<'a> FollowRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Follow>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM follows")?;
@@ -66,7 +66,7 @@ impl<'a> FollowRepo<'a> {
         brain: &BrainName,
         bookmark: &BookmarkName,
     ) -> Result<Option<Follow>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
         let mut stmt = db.prepare(
             "select id, brain, bookmark, source, checkpoint, created_at \
              from follows where brain = ?1 and bookmark = ?2",

--- a/crates/oneiros-engine/src/domains/follow/service.rs
+++ b/crates/oneiros-engine/src/domains/follow/service.rs
@@ -7,7 +7,8 @@ impl FollowService {
     /// `BookmarkService::follow` in Act 3; exposed here for direct
     /// service-layer construction and testing.
     pub async fn create(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
+        mailbox: &Mailbox,
         brain: BrainName,
         bookmark: BookmarkName,
         source: FollowSource,
@@ -27,79 +28,87 @@ impl FollowService {
             .created_at(follow.created_at)
             .build();
 
-        context
-            .emit(BookmarkEvents::BookmarkFollowed(event.into()))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Bookmark(BookmarkEvents::BookmarkFollowed(
+                event.into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
 
         Ok(follow)
     }
 
-    pub async fn get(context: &HostLog, id: FollowId) -> Result<Follow, FollowError> {
-        FollowRepo::new(context.scope()?)
+    pub async fn get(scope: &Scope<AtHost>, id: FollowId) -> Result<Follow, FollowError> {
+        FollowRepo::new(scope)
             .fetch(id)
             .await?
             .ok_or(FollowError::NotFound(id))
     }
 
     pub async fn list(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
         filters: &SearchFilters,
     ) -> Result<Listed<Follow>, FollowError> {
-        Ok(FollowRepo::new(context.scope()?).list(filters).await?)
+        Ok(FollowRepo::new(scope).list(filters).await?)
     }
 
     /// Find the active Follow for a given brain/bookmark pair. Returns
     /// `None` when the bookmark isn't currently following anything.
     /// Used by `BookmarkService::collect` in Act 3.
     pub async fn for_bookmark(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
         brain: &BrainName,
         bookmark: &BookmarkName,
     ) -> Result<Option<Follow>, FollowError> {
-        Ok(FollowRepo::new(context.scope()?)
-            .for_bookmark(brain, bookmark)
-            .await?)
+        Ok(FollowRepo::new(scope).for_bookmark(brain, bookmark).await?)
     }
 
     /// Advance the checkpoint on a follow after a successful collect.
     /// Emits `BookmarkCollected`. Used by `BookmarkService::collect`.
     pub async fn advance(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
+        mailbox: &Mailbox,
         follow_id: FollowId,
         checkpoint: Checkpoint,
         events_received: u64,
     ) -> Result<(), FollowError> {
-        context
-            .emit(BookmarkEvents::BookmarkCollected(
+        let new_event = NewEvent::builder()
+            .data(Events::Bookmark(BookmarkEvents::BookmarkCollected(
                 BookmarkCollected::builder_v1()
                     .follow_id(follow_id)
                     .checkpoint(checkpoint)
                     .events_received(events_received)
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
         Ok(())
     }
 
     /// Remove a follow. Emits `BookmarkUnfollowed`. Used by
     /// `BookmarkService::unfollow`.
-    pub async fn remove(context: &HostLog, id: FollowId) -> Result<(), FollowError> {
-        let existing = FollowRepo::new(context.scope()?)
+    pub async fn remove(
+        scope: &Scope<AtHost>,
+        mailbox: &Mailbox,
+        id: FollowId,
+    ) -> Result<(), FollowError> {
+        let existing = FollowRepo::new(scope)
             .get(id)
             .await?
             .ok_or(FollowError::NotFound(id))?;
 
-        context
-            .emit(BookmarkEvents::BookmarkUnfollowed(
+        let new_event = NewEvent::builder()
+            .data(Events::Bookmark(BookmarkEvents::BookmarkUnfollowed(
                 BookmarkUnfollowed::builder_v1()
                     .follow_id(existing.id)
                     .brain(existing.brain)
                     .bookmark(existing.bookmark)
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
 
         Ok(())
     }

--- a/crates/oneiros-engine/src/domains/level/features/http.rs
+++ b/crates/oneiros-engine/src/domains/level/features/http.rs
@@ -39,7 +39,8 @@ impl LevelRouter {
 }
 
 async fn set(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<LevelName>,
     Json(body): Json<SetLevel>,
 ) -> Result<(StatusCode, Json<LevelResponse>), LevelError> {
@@ -48,33 +49,35 @@ async fn set(
     let request = SetLevel::V1(setting);
     Ok((
         StatusCode::OK,
-        Json(LevelService::set(&context, &request).await?),
+        Json(LevelService::set(&scope, &mailbox, &request).await?),
     ))
 }
 
 async fn list(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<ListLevels>,
 ) -> Result<Json<LevelResponse>, LevelError> {
-    Ok(Json(LevelService::list(&context, &params).await?))
+    Ok(Json(LevelService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(key): Path<ResourceKey<LevelName>>,
 ) -> Result<Json<LevelResponse>, LevelError> {
     Ok(Json(
-        LevelService::get(&context, &GetLevel::builder_v1().key(key).build().into()).await?,
+        LevelService::get(&scope, &GetLevel::builder_v1().key(key).build().into()).await?,
     ))
 }
 
 async fn remove(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<LevelName>,
 ) -> Result<Json<LevelResponse>, LevelError> {
     Ok(Json(
         LevelService::remove(
-            &context,
+            &scope,
+            &mailbox,
             &RemoveLevel::builder_v1().name(name).build().into(),
         )
         .await?,

--- a/crates/oneiros-engine/src/domains/level/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/level/features/mcp.rs
@@ -16,7 +16,8 @@ impl LevelMcp {
         context: &ProjectLog,
         request: &LevelRequest,
     ) -> Result<McpResponse, ToolError> {
-        level_mcp::resource(context, request).await
+        let scope = context.scope().map_err(Error::from)?;
+        level_mcp::resource(scope, request).await
     }
 }
 
@@ -24,18 +25,16 @@ mod level_mcp {
     use crate::*;
 
     pub async fn resource(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &LevelRequest,
     ) -> Result<McpResponse, ToolError> {
         match request {
             LevelRequest::ListLevels(list) => {
-                let response = LevelService::list(context, list)
-                    .await
-                    .map_err(Error::from)?;
+                let response = LevelService::list(scope, list).await.map_err(Error::from)?;
                 Ok(LevelView::new(response).mcp())
             }
             LevelRequest::GetLevel(get) => {
-                let response = LevelService::get(context, get).await.map_err(Error::from)?;
+                let response = LevelService::get(scope, get).await.map_err(Error::from)?;
                 Ok(LevelView::new(response).mcp())
             }
             LevelRequest::SetLevel(_) | LevelRequest::RemoveLevel(_) => Err(

--- a/crates/oneiros-engine/src/domains/level/repo.rs
+++ b/crates/oneiros-engine/src/domains/level/repo.rs
@@ -20,7 +20,7 @@ impl<'a> LevelRepo<'a> {
     }
 
     pub async fn get(&self, name: &LevelName) -> Result<Option<Level>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt =
             db.prepare("SELECT name, description, prompt FROM levels WHERE name = ?1")?;
 
@@ -46,7 +46,7 @@ impl<'a> LevelRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Level>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM levels")?;

--- a/crates/oneiros-engine/src/domains/level/service.rs
+++ b/crates/oneiros-engine/src/domains/level/service.rs
@@ -4,7 +4,8 @@ pub struct LevelService;
 
 impl LevelService {
     pub async fn set(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &SetLevel,
     ) -> Result<LevelResponse, LevelError> {
         let SetLevel::V1(set) = request;
@@ -13,25 +14,35 @@ impl LevelService {
             .description(set.description.clone())
             .prompt(set.prompt.clone())
             .build();
+        let name = level.name.clone();
 
-        context
-            .emit(LevelEvents::LevelSet(
-                LevelSet::builder_v1().level(level.clone()).build().into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Level(LevelEvents::LevelSet(
+                LevelSet::builder_v1().level(level).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let projected = LevelRepo::new(scope)
+            .fetch(&name)
+            .await?
+            .ok_or(LevelError::NotFound(name))?;
 
         Ok(LevelResponse::LevelSet(
-            LevelSetResponse::builder_v1().level(level).build().into(),
+            LevelSetResponse::builder_v1()
+                .level(projected)
+                .build()
+                .into(),
         ))
     }
 
     pub async fn get(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &GetLevel,
     ) -> Result<LevelResponse, LevelError> {
         let GetLevel::V1(lookup) = request;
         let name = lookup.key.resolve()?;
-        let level = LevelRepo::new(context.scope()?)
+        let level = LevelRepo::new(scope)
             .fetch(&name)
             .await?
             .ok_or(LevelError::NotFound(name))?;
@@ -44,13 +55,11 @@ impl LevelService {
     }
 
     pub async fn list(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ListLevels,
     ) -> Result<LevelResponse, LevelError> {
         let ListLevels::V1(listing) = request;
-        let listed = LevelRepo::new(context.scope()?)
-            .list(&listing.filters)
-            .await?;
+        let listed = LevelRepo::new(scope).list(&listing.filters).await?;
         if listed.total == 0 {
             Ok(LevelResponse::NoLevels)
         } else {
@@ -65,23 +74,28 @@ impl LevelService {
     }
 
     pub async fn remove(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &RemoveLevel,
     ) -> Result<LevelResponse, LevelError> {
         let RemoveLevel::V1(removal) = request;
-        context
-            .emit(LevelEvents::LevelRemoved(
-                LevelRemoved::builder_v1()
-                    .name(removal.name.clone())
-                    .build()
-                    .into(),
-            ))
+        let name = removal.name.clone();
+
+        let new_event = NewEvent::builder()
+            .data(Events::Level(LevelEvents::LevelRemoved(
+                LevelRemoved::builder_v1().name(name.clone()).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        scope
+            .config()
+            .fetch
+            .until_absent(|| async { LevelRepo::new(scope).get(&name).await })
             .await?;
+
         Ok(LevelResponse::LevelRemoved(
-            LevelRemovedResponse::builder_v1()
-                .name(removal.name.clone())
-                .build()
-                .into(),
+            LevelRemovedResponse::builder_v1().name(name).build().into(),
         ))
     }
 }

--- a/crates/oneiros-engine/src/domains/memory/features/http.rs
+++ b/crates/oneiros-engine/src/domains/memory/features/http.rs
@@ -36,25 +36,26 @@ impl MemoryRouter {
 }
 
 async fn add(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Json(body): Json<AddMemory>,
 ) -> Result<(StatusCode, Json<MemoryResponse>), MemoryError> {
-    let response = MemoryService::add(&context, &body).await?;
+    let response = MemoryService::add(&scope, &mailbox, &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
 
 async fn list(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<ListMemories>,
 ) -> Result<Json<MemoryResponse>, MemoryError> {
-    Ok(Json(MemoryService::list(&context, &params).await?))
+    Ok(Json(MemoryService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(key): Path<ResourceKey<MemoryId>>,
 ) -> Result<Json<MemoryResponse>, MemoryError> {
     Ok(Json(
-        MemoryService::get(&context, &GetMemory::builder_v1().key(key).build().into()).await?,
+        MemoryService::get(&scope, &GetMemory::builder_v1().key(key).build().into()).await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/memory/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/memory/features/mcp.rs
@@ -10,10 +10,11 @@ impl MemoryMcp {
     pub async fn dispatch(
         &self,
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &ToolName,
         params: &serde_json::Value,
     ) -> Result<McpResponse, ToolError> {
-        memory_mcp::dispatch(context, tool_name, params).await
+        memory_mcp::dispatch(context, mailbox, tool_name, params).await
     }
 
     pub fn resources(&self) -> Vec<ResourceDef> {
@@ -48,6 +49,7 @@ mod memory_mcp {
 
     pub async fn dispatch(
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &ToolName,
         params: &serde_json::Value,
     ) -> Result<McpResponse, ToolError> {
@@ -60,7 +62,8 @@ mod memory_mcp {
             MemoryRequestType::AddMemory => {
                 let addition: AddMemory = serde_json::from_value(params.clone())?;
                 let request = MemoryRequest::AddMemory(addition.clone());
-                let response = MemoryService::add(context, &addition)
+                let scope = context.scope().map_err(Error::from)?;
+                let response = MemoryService::add(scope, mailbox, &addition)
                     .await
                     .map_err(Error::from)?;
                 Ok(MemoryView::new(response, &request).mcp())
@@ -75,11 +78,12 @@ mod memory_mcp {
         context: &ProjectLog,
         request: &MemoryRequest,
     ) -> Result<McpResponse, ToolError> {
+        let scope = context.scope().map_err(Error::from)?;
         let response = match request {
-            MemoryRequest::GetMemory(get) => MemoryService::get(context, get)
-                .await
-                .map_err(Error::from)?,
-            MemoryRequest::ListMemories(listing) => MemoryService::list(context, listing)
+            MemoryRequest::GetMemory(get) => {
+                MemoryService::get(scope, get).await.map_err(Error::from)?
+            }
+            MemoryRequest::ListMemories(listing) => MemoryService::list(scope, listing)
                 .await
                 .map_err(Error::from)?,
             MemoryRequest::AddMemory(_) => {

--- a/crates/oneiros-engine/src/domains/memory/repo.rs
+++ b/crates/oneiros-engine/src/domains/memory/repo.rs
@@ -23,7 +23,7 @@ impl<'a> MemoryRepo<'a> {
     }
 
     pub async fn get(&self, id: &MemoryId) -> Result<Option<Memory>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt = db.prepare(
             "SELECT id, agent_id, level, content, created_at
              FROM memories WHERE id = ?1",
@@ -61,7 +61,7 @@ impl<'a> MemoryRepo<'a> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let placeholders = (1..=ids.len())
             .map(|i| format!("?{i}"))
             .collect::<Vec<_>>()

--- a/crates/oneiros-engine/src/domains/memory/service.rs
+++ b/crates/oneiros-engine/src/domains/memory/service.rs
@@ -4,11 +4,12 @@ pub struct MemoryService;
 
 impl MemoryService {
     pub async fn add(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &AddMemory,
     ) -> Result<MemoryResponse, MemoryError> {
         let AddMemory::V1(addition) = request;
-        let agent_record = AgentRepo::new(context.scope()?)
+        let agent_record = AgentRepo::new(scope)
             .fetch(&addition.agent)
             .await?
             .ok_or_else(|| MemoryError::AgentNotFound(addition.agent.clone()))?;
@@ -18,31 +19,35 @@ impl MemoryService {
             .level(addition.level.clone())
             .content(addition.content.clone())
             .build();
+        let id = memory.id;
 
-        context
-            .emit(MemoryEvents::MemoryAdded(
-                MemoryAdded::builder_v1()
-                    .memory(memory.clone())
-                    .build()
-                    .into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Memory(MemoryEvents::MemoryAdded(
+                MemoryAdded::builder_v1().memory(memory).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let stored = MemoryRepo::new(scope)
+            .fetch(&id)
+            .await?
+            .ok_or(MemoryError::NotFound(id))?;
 
         Ok(MemoryResponse::MemoryAdded(
             MemoryAddedResponse::builder_v1()
-                .memory(memory)
+                .memory(stored)
                 .build()
                 .into(),
         ))
     }
 
     pub async fn get(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &GetMemory,
     ) -> Result<MemoryResponse, MemoryError> {
         let GetMemory::V1(lookup) = request;
         let id = lookup.key.resolve()?;
-        let memory = MemoryRepo::new(context.scope()?)
+        let memory = MemoryRepo::new(scope)
             .fetch(&id)
             .await?
             .ok_or(MemoryError::NotFound(id))?;
@@ -55,13 +60,13 @@ impl MemoryService {
     }
 
     pub async fn list(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ListMemories,
     ) -> Result<MemoryResponse, MemoryError> {
         let ListMemories::V1(listing) = request;
         let agent_id = match &listing.agent {
             Some(name) => {
-                let record = AgentRepo::new(context.scope()?)
+                let record = AgentRepo::new(scope)
                     .fetch(name)
                     .await?
                     .ok_or_else(|| MemoryError::AgentNotFound(name.clone()))?;
@@ -77,7 +82,7 @@ impl MemoryService {
             .filters(listing.filters)
             .build();
 
-        let results = SearchRepo::new(context.scope()?)
+        let results = SearchRepo::new(scope)
             .search(&search_query, agent_id.as_ref())
             .await?;
 
@@ -93,7 +98,7 @@ impl MemoryService {
                 _ => None,
             })
             .collect();
-        let items = MemoryRepo::new(context.scope()?).get_many(&ids).await?;
+        let items = MemoryRepo::new(scope).get_many(&ids).await?;
 
         Ok(MemoryResponse::Memories(
             MemoriesResponse::builder_v1()

--- a/crates/oneiros-engine/src/domains/nature/features/http.rs
+++ b/crates/oneiros-engine/src/domains/nature/features/http.rs
@@ -39,7 +39,8 @@ impl NatureRouter {
 }
 
 async fn set(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<NatureName>,
     Json(body): Json<SetNature>,
 ) -> Result<(StatusCode, Json<NatureResponse>), NatureError> {
@@ -48,33 +49,35 @@ async fn set(
     let request = SetNature::V1(setting);
     Ok((
         StatusCode::OK,
-        Json(NatureService::set(&context, &request).await?),
+        Json(NatureService::set(&scope, &mailbox, &request).await?),
     ))
 }
 
 async fn list(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<ListNatures>,
 ) -> Result<Json<NatureResponse>, NatureError> {
-    Ok(Json(NatureService::list(&context, &params).await?))
+    Ok(Json(NatureService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(key): Path<ResourceKey<NatureName>>,
 ) -> Result<Json<NatureResponse>, NatureError> {
     Ok(Json(
-        NatureService::get(&context, &GetNature::builder_v1().key(key).build().into()).await?,
+        NatureService::get(&scope, &GetNature::builder_v1().key(key).build().into()).await?,
     ))
 }
 
 async fn remove(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<NatureName>,
 ) -> Result<Json<NatureResponse>, NatureError> {
     Ok(Json(
         NatureService::remove(
-            &context,
+            &scope,
+            &mailbox,
             &RemoveNature::builder_v1().name(name).build().into(),
         )
         .await?,

--- a/crates/oneiros-engine/src/domains/nature/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/nature/features/mcp.rs
@@ -16,7 +16,8 @@ impl NatureMcp {
         context: &ProjectLog,
         request: &NatureRequest,
     ) -> Result<McpResponse, ToolError> {
-        nature_mcp::resource(context, request).await
+        let scope = context.scope().map_err(Error::from)?;
+        nature_mcp::resource(scope, request).await
     }
 }
 
@@ -24,20 +25,18 @@ mod nature_mcp {
     use crate::*;
 
     pub async fn resource(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &NatureRequest,
     ) -> Result<McpResponse, ToolError> {
         match request {
             NatureRequest::ListNatures(list) => {
-                let response = NatureService::list(context, list)
+                let response = NatureService::list(scope, list)
                     .await
                     .map_err(Error::from)?;
                 Ok(NatureView::new(response).mcp())
             }
             NatureRequest::GetNature(get) => {
-                let response = NatureService::get(context, get)
-                    .await
-                    .map_err(Error::from)?;
+                let response = NatureService::get(scope, get).await.map_err(Error::from)?;
                 Ok(NatureView::new(response).mcp())
             }
             NatureRequest::SetNature(_) | NatureRequest::RemoveNature(_) => Err(

--- a/crates/oneiros-engine/src/domains/nature/repo.rs
+++ b/crates/oneiros-engine/src/domains/nature/repo.rs
@@ -20,7 +20,7 @@ impl<'a> NatureRepo<'a> {
     }
 
     pub async fn get(&self, name: &NatureName) -> Result<Option<Nature>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt =
             db.prepare("SELECT name, description, prompt FROM natures WHERE name = ?1")?;
 
@@ -46,7 +46,7 @@ impl<'a> NatureRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Nature>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM natures")?;

--- a/crates/oneiros-engine/src/domains/nature/service.rs
+++ b/crates/oneiros-engine/src/domains/nature/service.rs
@@ -4,7 +4,8 @@ pub struct NatureService;
 
 impl NatureService {
     pub async fn set(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &SetNature,
     ) -> Result<NatureResponse, NatureError> {
         let SetNature::V1(set) = request;
@@ -13,31 +14,35 @@ impl NatureService {
             .description(set.description.clone())
             .prompt(set.prompt.clone())
             .build();
+        let name = nature.name.clone();
 
-        context
-            .emit(NatureEvents::NatureSet(
-                NatureSet::builder_v1()
-                    .nature(nature.clone())
-                    .build()
-                    .into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Nature(NatureEvents::NatureSet(
+                NatureSet::builder_v1().nature(nature).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let projected = NatureRepo::new(scope)
+            .fetch(&name)
+            .await?
+            .ok_or(NatureError::NotFound(name))?;
 
         Ok(NatureResponse::NatureSet(
             NatureSetResponse::builder_v1()
-                .nature(nature)
+                .nature(projected)
                 .build()
                 .into(),
         ))
     }
 
     pub async fn get(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &GetNature,
     ) -> Result<NatureResponse, NatureError> {
         let GetNature::V1(lookup) = request;
         let name = lookup.key.resolve()?;
-        let nature = NatureRepo::new(context.scope()?)
+        let nature = NatureRepo::new(scope)
             .fetch(&name)
             .await?
             .ok_or(NatureError::NotFound(name))?;
@@ -50,13 +55,11 @@ impl NatureService {
     }
 
     pub async fn list(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ListNatures,
     ) -> Result<NatureResponse, NatureError> {
         let ListNatures::V1(listing) = request;
-        let listed = NatureRepo::new(context.scope()?)
-            .list(&listing.filters)
-            .await?;
+        let listed = NatureRepo::new(scope).list(&listing.filters).await?;
         if listed.total == 0 {
             Ok(NatureResponse::NoNatures)
         } else {
@@ -71,21 +74,32 @@ impl NatureService {
     }
 
     pub async fn remove(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &RemoveNature,
     ) -> Result<NatureResponse, NatureError> {
         let RemoveNature::V1(removal) = request;
-        context
-            .emit(NatureEvents::NatureRemoved(
+        let name = removal.name.clone();
+
+        let new_event = NewEvent::builder()
+            .data(Events::Nature(NatureEvents::NatureRemoved(
                 NatureRemoved::builder_v1()
-                    .name(removal.name.clone())
+                    .name(name.clone())
                     .build()
                     .into(),
-            ))
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        scope
+            .config()
+            .fetch
+            .until_absent(|| async { NatureRepo::new(scope).get(&name).await })
             .await?;
+
         Ok(NatureResponse::NatureRemoved(
             NatureRemovedResponse::builder_v1()
-                .name(removal.name.clone())
+                .name(name)
                 .build()
                 .into(),
         ))

--- a/crates/oneiros-engine/src/domains/peer/features/http.rs
+++ b/crates/oneiros-engine/src/domains/peer/features/http.rs
@@ -31,31 +31,41 @@ impl PeerRouter {
 }
 
 async fn add(
-    context: HostLog,
+    scope: Scope<AtHost>,
+    mailbox: Mailbox,
     Json(body): Json<AddPeer>,
 ) -> Result<(StatusCode, Json<PeerResponse>), PeerError> {
-    let response = PeerService::add(&context, &body).await?;
+    let response = PeerService::add(&scope, &mailbox, &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
 
 async fn list(
-    context: HostLog,
+    scope: Scope<AtHost>,
     Query(params): Query<ListPeers>,
 ) -> Result<Json<PeerResponse>, PeerError> {
-    Ok(Json(PeerService::list(&context, &params).await?))
+    Ok(Json(PeerService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: HostLog,
+    scope: Scope<AtHost>,
     Path(key): Path<ResourceKey<PeerId>>,
 ) -> Result<Json<PeerResponse>, PeerError> {
     Ok(Json(
-        PeerService::get(&context, &GetPeer::builder_v1().key(key).build().into()).await?,
+        PeerService::get(&scope, &GetPeer::builder_v1().key(key).build().into()).await?,
     ))
 }
 
-async fn remove(context: HostLog, Path(id): Path<PeerId>) -> Result<Json<PeerResponse>, PeerError> {
+async fn remove(
+    scope: Scope<AtHost>,
+    mailbox: Mailbox,
+    Path(id): Path<PeerId>,
+) -> Result<Json<PeerResponse>, PeerError> {
     Ok(Json(
-        PeerService::remove(&context, &RemovePeer::builder_v1().id(id).build().into()).await?,
+        PeerService::remove(
+            &scope,
+            &mailbox,
+            &RemovePeer::builder_v1().id(id).build().into(),
+        )
+        .await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/peer/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/peer/features/mcp.rs
@@ -10,10 +10,11 @@ impl PeerTools {
     pub async fn dispatch(
         &self,
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        peer_mcp::dispatch(context, tool_name, params).await
+        peer_mcp::dispatch(context, mailbox, tool_name, params).await
     }
 }
 
@@ -35,6 +36,7 @@ mod peer_mcp {
 
     pub async fn dispatch(
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
@@ -45,20 +47,19 @@ mod peer_mcp {
         let scope = ComposeScope::new(context.config.clone())
             .host()
             .map_err(Error::from)?;
-        let system = scope.host_log();
 
         let value = match request_type {
             PeerRequestType::AddPeer => {
-                PeerService::add(&system, &serde_json::from_str(params)?).await
+                PeerService::add(&scope, mailbox, &serde_json::from_str(params)?).await
             }
             PeerRequestType::GetPeer => {
-                PeerService::get(&system, &serde_json::from_str(params)?).await
+                PeerService::get(&scope, &serde_json::from_str(params)?).await
             }
             PeerRequestType::ListPeers => {
-                PeerService::list(&system, &serde_json::from_str(params)?).await
+                PeerService::list(&scope, &serde_json::from_str(params)?).await
             }
             PeerRequestType::RemovePeer => {
-                PeerService::remove(&system, &serde_json::from_str(params)?).await
+                PeerService::remove(&scope, mailbox, &serde_json::from_str(params)?).await
             }
         }
         .map_err(Error::from)?;

--- a/crates/oneiros-engine/src/domains/peer/repo.rs
+++ b/crates/oneiros-engine/src/domains/peer/repo.rs
@@ -21,7 +21,7 @@ impl<'a> PeerRepo<'a> {
     }
 
     pub async fn get(&self, id: PeerId) -> Result<Option<Peer>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
         let mut statement =
             db.prepare("select id, key, address, name, created_at from peers where id = ?1")?;
 
@@ -45,7 +45,7 @@ impl<'a> PeerRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Peer>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM peers")?;

--- a/crates/oneiros-engine/src/domains/peer/service.rs
+++ b/crates/oneiros-engine/src/domains/peer/service.rs
@@ -23,7 +23,11 @@ fn peer_to_found_v1(peer: Peer) -> PeerFoundResponseV1 {
 }
 
 impl PeerService {
-    pub async fn add(context: &HostLog, request: &AddPeer) -> Result<PeerResponse, PeerError> {
+    pub async fn add(
+        scope: &Scope<AtHost>,
+        mailbox: &Mailbox,
+        request: &AddPeer,
+    ) -> Result<PeerResponse, PeerError> {
         let AddPeer::V1(add) = request;
         let parsed: PeerAddress = add
             .address
@@ -51,16 +55,20 @@ impl PeerService {
             .created_at(peer.created_at)
             .build();
 
-        context.emit(PeerEvents::PeerAdded(event.into())).await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Peer(PeerEvents::PeerAdded(event.into())))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
         Ok(PeerResponse::Added(PeerAddedResponse::V1(
             peer_to_added_v1(peer),
         )))
     }
 
-    pub async fn get(context: &HostLog, request: &GetPeer) -> Result<PeerResponse, PeerError> {
+    pub async fn get(scope: &Scope<AtHost>, request: &GetPeer) -> Result<PeerResponse, PeerError> {
         let GetPeer::V1(get) = request;
         let id = get.key.resolve()?;
-        let peer = PeerRepo::new(context.scope()?)
+        let peer = PeerRepo::new(scope)
             .fetch(id)
             .await?
             .ok_or(PeerError::NotFound(id))?;
@@ -69,11 +77,12 @@ impl PeerService {
         )))
     }
 
-    pub async fn list(context: &HostLog, request: &ListPeers) -> Result<PeerResponse, PeerError> {
+    pub async fn list(
+        scope: &Scope<AtHost>,
+        request: &ListPeers,
+    ) -> Result<PeerResponse, PeerError> {
         let ListPeers::V1(listing) = request;
-        let listed = PeerRepo::new(context.scope()?)
-            .list(&listing.filters)
-            .await?;
+        let listed = PeerRepo::new(scope).list(&listing.filters).await?;
         let total = listed.total;
         let items: Vec<PeerFoundResponseV1> =
             listed.items.into_iter().map(peer_to_found_v1).collect();
@@ -90,7 +99,8 @@ impl PeerService {
     /// return it without emitting an event. Otherwise add it and return
     /// the newly-created record.
     pub async fn ensure(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
+        mailbox: &Mailbox,
         key: PeerKey,
         address: PeerAddress,
     ) -> Result<Peer, PeerError> {
@@ -98,7 +108,7 @@ impl PeerService {
             limit: Limit(usize::MAX),
             offset: Offset(0),
         };
-        let listed = PeerRepo::new(context.scope()?).list(&all).await?;
+        let listed = PeerRepo::new(scope).list(&all).await?;
         if let Some(existing) = listed.items.iter().find(|p| p.key == key) {
             return Ok(existing.clone());
         }
@@ -114,26 +124,31 @@ impl PeerService {
             .created_at(peer.created_at)
             .build();
 
-        context.emit(PeerEvents::PeerAdded(event.into())).await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Peer(PeerEvents::PeerAdded(event.into())))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
 
         Ok(peer)
     }
 
     pub async fn remove(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
+        mailbox: &Mailbox,
         request: &RemovePeer,
     ) -> Result<PeerResponse, PeerError> {
         let RemovePeer::V1(remove) = request;
-        let existing = PeerRepo::new(context.scope()?)
+        let existing = PeerRepo::new(scope)
             .get(remove.id)
             .await?
             .ok_or(PeerError::NotFound(remove.id))?;
 
-        context
-            .emit(PeerEvents::PeerRemoved(
+        let new_event = NewEvent::builder()
+            .data(Events::Peer(PeerEvents::PeerRemoved(
                 PeerRemoved::builder_v1().id(existing.id).build().into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
 
         Ok(PeerResponse::Removed(
             PeerRemovedResponse::builder_v1()

--- a/crates/oneiros-engine/src/domains/persona/features/http.rs
+++ b/crates/oneiros-engine/src/domains/persona/features/http.rs
@@ -39,7 +39,8 @@ impl PersonaRouter {
 }
 
 async fn set(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<PersonaName>,
     Json(body): Json<SetPersona>,
 ) -> Result<(StatusCode, Json<PersonaResponse>), PersonaError> {
@@ -48,33 +49,35 @@ async fn set(
     let request = SetPersona::V1(setting);
     Ok((
         StatusCode::OK,
-        Json(PersonaService::set(&context, &request).await?),
+        Json(PersonaService::set(&scope, &mailbox, &request).await?),
     ))
 }
 
 async fn list(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<ListPersonas>,
 ) -> Result<Json<PersonaResponse>, PersonaError> {
-    Ok(Json(PersonaService::list(&context, &params).await?))
+    Ok(Json(PersonaService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(key): Path<ResourceKey<PersonaName>>,
 ) -> Result<Json<PersonaResponse>, PersonaError> {
     Ok(Json(
-        PersonaService::get(&context, &GetPersona::builder_v1().key(key).build().into()).await?,
+        PersonaService::get(&scope, &GetPersona::builder_v1().key(key).build().into()).await?,
     ))
 }
 
 async fn remove(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<PersonaName>,
 ) -> Result<Json<PersonaResponse>, PersonaError> {
     Ok(Json(
         PersonaService::remove(
-            &context,
+            &scope,
+            &mailbox,
             &RemovePersona::builder_v1().name(name).build().into(),
         )
         .await?,

--- a/crates/oneiros-engine/src/domains/persona/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/persona/features/mcp.rs
@@ -16,7 +16,8 @@ impl PersonaMcp {
         context: &ProjectLog,
         request: &PersonaRequest,
     ) -> Result<McpResponse, ToolError> {
-        persona_mcp::resource(context, request).await
+        let scope = context.scope().map_err(Error::from)?;
+        persona_mcp::resource(scope, request).await
     }
 }
 
@@ -24,20 +25,18 @@ mod persona_mcp {
     use crate::*;
 
     pub async fn resource(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &PersonaRequest,
     ) -> Result<McpResponse, ToolError> {
         match request {
             PersonaRequest::ListPersonas(list) => {
-                let response = PersonaService::list(context, list)
+                let response = PersonaService::list(scope, list)
                     .await
                     .map_err(Error::from)?;
                 Ok(PersonaView::new(response).mcp())
             }
             PersonaRequest::GetPersona(get) => {
-                let response = PersonaService::get(context, get)
-                    .await
-                    .map_err(Error::from)?;
+                let response = PersonaService::get(scope, get).await.map_err(Error::from)?;
                 Ok(PersonaView::new(response).mcp())
             }
             PersonaRequest::SetPersona(_) | PersonaRequest::RemovePersona(_) => Err(

--- a/crates/oneiros-engine/src/domains/persona/repo.rs
+++ b/crates/oneiros-engine/src/domains/persona/repo.rs
@@ -20,7 +20,7 @@ impl<'a> PersonaRepo<'a> {
     }
 
     pub async fn get(&self, name: &PersonaName) -> Result<Option<Persona>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt =
             db.prepare("SELECT name, description, prompt FROM personas WHERE name = ?1")?;
 
@@ -46,7 +46,7 @@ impl<'a> PersonaRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Persona>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM personas")?;

--- a/crates/oneiros-engine/src/domains/persona/service.rs
+++ b/crates/oneiros-engine/src/domains/persona/service.rs
@@ -4,7 +4,8 @@ pub struct PersonaService;
 
 impl PersonaService {
     pub async fn set(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &SetPersona,
     ) -> Result<PersonaResponse, PersonaError> {
         let SetPersona::V1(set) = request;
@@ -13,31 +14,35 @@ impl PersonaService {
             .description(set.description.clone())
             .prompt(set.prompt.clone())
             .build();
+        let name = persona.name.clone();
 
-        context
-            .emit(PersonaEvents::PersonaSet(
-                PersonaSet::builder_v1()
-                    .persona(persona.clone())
-                    .build()
-                    .into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Persona(PersonaEvents::PersonaSet(
+                PersonaSet::builder_v1().persona(persona).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let projected = PersonaRepo::new(scope)
+            .fetch(&name)
+            .await?
+            .ok_or(PersonaError::NotFound(name))?;
 
         Ok(PersonaResponse::PersonaSet(
             PersonaSetResponse::builder_v1()
-                .persona(persona)
+                .persona(projected)
                 .build()
                 .into(),
         ))
     }
 
     pub async fn get(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &GetPersona,
     ) -> Result<PersonaResponse, PersonaError> {
         let GetPersona::V1(lookup) = request;
         let name = lookup.key.resolve()?;
-        let persona = PersonaRepo::new(context.scope()?)
+        let persona = PersonaRepo::new(scope)
             .fetch(&name)
             .await?
             .ok_or(PersonaError::NotFound(name))?;
@@ -50,13 +55,11 @@ impl PersonaService {
     }
 
     pub async fn list(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ListPersonas,
     ) -> Result<PersonaResponse, PersonaError> {
         let ListPersonas::V1(listing) = request;
-        let listed = PersonaRepo::new(context.scope()?)
-            .list(&listing.filters)
-            .await?;
+        let listed = PersonaRepo::new(scope).list(&listing.filters).await?;
         if listed.total == 0 {
             Ok(PersonaResponse::NoPersonas)
         } else {
@@ -71,21 +74,32 @@ impl PersonaService {
     }
 
     pub async fn remove(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &RemovePersona,
     ) -> Result<PersonaResponse, PersonaError> {
         let RemovePersona::V1(removal) = request;
-        context
-            .emit(PersonaEvents::PersonaRemoved(
+        let name = removal.name.clone();
+
+        let new_event = NewEvent::builder()
+            .data(Events::Persona(PersonaEvents::PersonaRemoved(
                 PersonaRemoved::builder_v1()
-                    .name(removal.name.clone())
+                    .name(name.clone())
                     .build()
                     .into(),
-            ))
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        scope
+            .config()
+            .fetch
+            .until_absent(|| async { PersonaRepo::new(scope).get(&name).await })
             .await?;
+
         Ok(PersonaResponse::PersonaRemoved(
             PersonaRemovedResponse::builder_v1()
-                .name(removal.name.clone())
+                .name(name)
                 .build()
                 .into(),
         ))

--- a/crates/oneiros-engine/src/domains/pressure/repo.rs
+++ b/crates/oneiros-engine/src/domains/pressure/repo.rs
@@ -14,7 +14,7 @@ impl<'a> PressureRepo<'a> {
     }
 
     pub async fn get(&self, agent_name: &AgentName) -> Result<Vec<Pressure>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
 
         // Look up agent by name to get the ID
         let agent = match AgentStore::new(&db).get(agent_name)? {
@@ -60,7 +60,7 @@ impl<'a> PressureRepo<'a> {
     }
 
     pub async fn list(&self) -> Result<Vec<Pressure>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
 
         let mut stmt = db.prepare(
             "SELECT id, agent_id, urge, data, updated_at FROM pressures ORDER BY agent_id, urge",

--- a/crates/oneiros-engine/src/domains/pressure/store.rs
+++ b/crates/oneiros-engine/src/domains/pressure/store.rs
@@ -184,7 +184,12 @@ impl<'a> PressureStore<'a> {
                 | Events::Experience(_)
                 | Events::Bookmark(_) => return Ok(vec![]),
             },
-            Event::Ephemeral(_) | Event::Unknown(_) | Event::Malformed => return Ok(vec![]),
+            Event::Ephemeral(_)
+            | Event::Unknown(_)
+            | Event::Malformed
+            | Event::New(_)
+            | Event::Stored(_)
+            | Event::Import(_) => return Ok(vec![]),
         };
 
         match agent_name {

--- a/crates/oneiros-engine/src/domains/project/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/project/features/cli.rs
@@ -18,12 +18,12 @@ impl ProjectCommands {
                 ProjectClient::new(&client).init(initialization).await?
             }
             ProjectCommands::Export(exporting) => {
-                ProjectService::export(&config.project(), exporting)?
+                let scope = ComposeScope::new(config.clone())
+                    .bookmark(config.brain.clone(), config.bookmark.clone())?;
+                ProjectService::export(&scope, exporting).await?
             }
-            ProjectCommands::Import(importing) => {
-                ProjectService::import(&config.project(), importing)?
-            }
-            ProjectCommands::Replay => ProjectService::replay(&config.project())?,
+            ProjectCommands::Import(importing) => ProjectService::import(config, importing).await?,
+            ProjectCommands::Replay => ProjectService::replay(config).await?,
         };
 
         Ok(ProjectView::new(response).render().map(Into::into))

--- a/crates/oneiros-engine/src/domains/project/features/http.rs
+++ b/crates/oneiros-engine/src/domains/project/features/http.rs
@@ -21,15 +21,16 @@ impl ProjectRouter {
 }
 
 async fn init(
-    context: HostLog,
+    scope: Scope<AtHost>,
+    mailbox: Mailbox,
     Json(body): Json<InitProject>,
 ) -> Result<(StatusCode, Json<ProjectResponse>), ProjectError> {
-    let response = ProjectService::init(&context, &body).await?;
+    let response = ProjectService::init(&scope, &mailbox, &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
 
-async fn summary(context: ProjectLog) -> Result<Json<BrainSummary>, ProjectError> {
-    let db = context.db()?;
+async fn summary(scope: Scope<AtBookmark>) -> Result<Json<BrainSummary>, ProjectError> {
+    let db = BookmarkDb::open(&scope).await?;
 
     let agents = AgentStore::new(&db).list().unwrap_or_default();
     let agent_count = agents.len();

--- a/crates/oneiros-engine/src/domains/project/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/project/protocol/errors.rs
@@ -30,6 +30,9 @@ pub enum ProjectError {
     Compose(#[from] crate::ComposeError),
 
     #[error(transparent)]
+    BookmarkDb(#[from] crate::BookmarkDbError),
+
+    #[error(transparent)]
     Event(#[from] EventError),
 
     #[error(transparent)]
@@ -52,7 +55,8 @@ impl IntoResponse for ProjectError {
             | ProjectError::Serde(_)
             | ProjectError::Io(_)
             | ProjectError::Upcast(_)
-            | ProjectError::Compose(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            | ProjectError::Compose(_)
+            | ProjectError::BookmarkDb(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             ProjectError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
         };
         (status, Json(ErrorResponse::new(message))).into_response()

--- a/crates/oneiros-engine/src/domains/project/service.rs
+++ b/crates/oneiros-engine/src/domains/project/service.rs
@@ -6,17 +6,18 @@ pub struct ProjectService;
 
 impl ProjectService {
     pub async fn init(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
+        mailbox: &Mailbox,
         request: &InitProject,
     ) -> Result<ProjectResponse, ProjectError> {
         let details = request.current()?;
         let brain_name = details
             .name
             .clone()
-            .unwrap_or_else(|| context.config.brain.clone());
+            .unwrap_or_else(|| scope.config().brain.clone());
 
         if let Ok(BrainResponse::Found(_)) = BrainService::get(
-            context,
+            scope,
             &GetBrain::builder_v1()
                 .key(brain_name.clone())
                 .build()
@@ -33,7 +34,8 @@ impl ProjectService {
         }
 
         BrainService::create(
-            context,
+            scope,
+            mailbox,
             &CreateBrain::builder_v1()
                 .name(brain_name.clone())
                 .build()
@@ -46,19 +48,20 @@ impl ProjectService {
             .name(BookmarkName::main())
             .build();
 
-        context
-            .emit(BookmarkEvents::BookmarkCreated(
+        let new_event = NewEvent::builder()
+            .data(Events::Bookmark(BookmarkEvents::BookmarkCreated(
                 BookmarkCreated::builder_v1()
                     .bookmark(main_bookmark)
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
 
         // Create the brain's database layout:
         //   {brain_dir}/events.db         — event log (append-only)
         //   {brain_dir}/bookmarks/main.db — projection tables for the default bookmark
-        let brain_dir = context.config.data_dir.join(brain_name.as_str());
+        let brain_dir = scope.config().data_dir.join(brain_name.as_str());
         let bookmarks_dir = brain_dir.join("bookmarks");
         std::fs::create_dir_all(&bookmarks_dir)?;
 
@@ -78,11 +81,12 @@ impl ProjectService {
             limit: Limit(usize::MAX),
             offset: Offset(0),
         };
-        let actors = ActorRepo::new(context.scope()?).list(&all_filters).await?;
+        let actors = ActorRepo::new(scope).list(&all_filters).await?;
 
         let token = if let Some(actor) = actors.items.first() {
             match TicketService::create(
-                context,
+                scope,
+                mailbox,
                 &CreateTicket::builder_v1()
                     .actor_id(actor.id)
                     .brain_name(brain_name.clone())
@@ -100,7 +104,7 @@ impl ProjectService {
             return Err(ProjectError::Missing);
         };
 
-        let tickets_dir = context.config.data_dir.join("tickets");
+        let tickets_dir = scope.config().data_dir.join("tickets");
 
         std::fs::create_dir_all(&tickets_dir)?;
 
@@ -123,14 +127,14 @@ impl ProjectService {
     /// event is prepended carrying the binary content. This makes the export
     /// portable — the receiving brain materializes the blob at import time
     /// without persisting the ephemeral event to the log.
-    pub fn export(
-        context: &ProjectLog,
+    pub async fn export(
+        scope: &Scope<AtBookmark>,
         request: &ExportProject,
     ) -> Result<ProjectResponse, ProjectError> {
         let details = request.current()?;
         let target_dir = &details.target;
-        let project_name = context.brain_name();
-        let db = context.db()?;
+        let project_name = &scope.config().brain;
+        let db = BookmarkDb::open(scope).await?;
         let events = EventLog::attached(&db).load_all()?;
         let storage = StorageStore::new(&db);
 
@@ -179,8 +183,13 @@ impl ProjectService {
     /// at the import boundary — they never enter the event log.
     /// Domain events are persisted normally, then all projections
     /// are replayed to rebuild the read models.
-    pub fn import(
-        context: &ProjectLog,
+    /// Import is self-bootstrapping — the destination brain may not yet
+    /// be in the projection (system init without project init), so we
+    /// can't compose a `Scope<AtBookmark>` here. Take the platform +
+    /// brain + bookmark directly and open the bookmark DB via the
+    /// underlying primitive.
+    pub async fn import(
+        config: &Config,
         request: &ImportProject,
     ) -> Result<ProjectResponse, ProjectError> {
         let details = request.current()?;
@@ -188,8 +197,9 @@ impl ProjectService {
         let reader = std::io::BufReader::new(file);
         let mut imported = 0usize;
 
-        let db = context.db()?;
+        let db = BookmarkDb::open_with(&config.platform(), &config.brain, &config.bookmark).await?;
         let log = EventLog::attached(&db);
+        let projections = Projections::<BrainCanon>::project();
 
         // Import is self-bootstrapping: a destination brain may have seen
         // `system init` without `project init`, leaving the events DB and
@@ -197,7 +207,7 @@ impl ProjectService {
         // (CREATE TABLE IF NOT EXISTS) and makes import the correctness
         // gate the versioning story relies on.
         log.init()?;
-        context.projections.migrate(&db)?;
+        projections.migrate(&db)?;
 
         // Batch all inserts in a single transaction — without this,
         // each INSERT is an implicit transaction with an fsync.
@@ -236,7 +246,7 @@ impl ProjectService {
         }
 
         let log = EventLog::attached(&db);
-        let replayed = context.projections.replay_brain(&db, &log)?;
+        let replayed = projections.replay_brain(&db, &log)?;
 
         Ok(ProjectResponse::Imported(
             ImportedResponse::builder_v1()
@@ -255,10 +265,14 @@ impl ProjectService {
     /// alone cannot add columns to existing tables. The event log
     /// (`events.db`) is untouched; projection data is always derivable
     /// from events.
-    pub fn replay(context: &ProjectLog) -> Result<ProjectResponse, ProjectError> {
+    ///
+    /// Takes `&Config` rather than `&Scope<AtBookmark>` because the
+    /// bookmark DB file may be deleted mid-call — composing a scope
+    /// would fail the existence check.
+    pub async fn replay(config: &Config) -> Result<ProjectResponse, ProjectError> {
         // Ensure a clean schema by deleting the old bookmark DB.
         // WAL sidecar files are silently cleaned up if present.
-        let db_path = context.config.bookmark_db_path();
+        let db_path = config.bookmark_db_path();
         if db_path.exists() {
             std::fs::remove_file(&db_path)?;
         }
@@ -266,10 +280,11 @@ impl ProjectService {
         let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
 
         // Open a fresh DB, create tables with current schema, then replay.
-        let db = context.db()?;
-        context.projections.migrate(&db)?;
+        let db = BookmarkDb::open_with(&config.platform(), &config.brain, &config.bookmark).await?;
+        let projections = Projections::<BrainCanon>::project();
+        projections.migrate(&db)?;
         let log = EventLog::attached(&db);
-        let replayed = context.projections.replay_brain(&db, &log)?;
+        let replayed = projections.replay_brain(&db, &log)?;
 
         Ok(ProjectResponse::Replayed(
             ReplayedResponse::builder_v1()

--- a/crates/oneiros-engine/src/domains/search/repo.rs
+++ b/crates/oneiros-engine/src/domains/search/repo.rs
@@ -32,7 +32,7 @@ impl<'a> SearchRepo<'a> {
         query: &SearchQueryV1,
         agent_id: Option<&AgentId>,
     ) -> Result<SearchHits, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
 
         let has_query = query.query.is_some();
         let where_clause = query.where_clause(agent_id);

--- a/crates/oneiros-engine/src/domains/search/store.rs
+++ b/crates/oneiros-engine/src/domains/search/store.rs
@@ -66,6 +66,15 @@ impl<'a> SearchStore<'a> {
             .map(ToString::to_string)
             .unwrap_or_default();
         let created_at = entry.created_at.map(|t| t.as_string()).unwrap_or_default();
+        // Idempotent — delete any prior row for this resource ref
+        // before inserting. FTS5 has no native upsert, so
+        // delete-then-insert is the canonical pattern; matches the
+        // discipline used by other projections (cognitions etc.) so
+        // the same event applied twice settles to one row.
+        self.conn.execute(
+            "delete from search_index where resource_ref = ?1",
+            params![&resource_ref],
+        )?;
         self.conn.execute(
             "insert into search_index (
                  resource_ref, kind, content,

--- a/crates/oneiros-engine/src/domains/seed/features/http.rs
+++ b/crates/oneiros-engine/src/domains/seed/features/http.rs
@@ -30,12 +30,18 @@ impl SeedRouter {
     }
 }
 
-async fn seed_core(context: ProjectLog) -> Result<(StatusCode, Json<SeedResponse>), SeedError> {
-    let response = SeedService::core(&context).await?;
+async fn seed_core(
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
+) -> Result<(StatusCode, Json<SeedResponse>), SeedError> {
+    let response = SeedService::core(&scope, &mailbox).await?;
     Ok((StatusCode::OK, Json(response)))
 }
 
-async fn seed_agents(context: ProjectLog) -> Result<(StatusCode, Json<SeedResponse>), SeedError> {
-    let response = SeedService::agents(&context).await?;
+async fn seed_agents(
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
+) -> Result<(StatusCode, Json<SeedResponse>), SeedError> {
+    let response = SeedService::agents(&scope, &mailbox).await?;
     Ok((StatusCode::OK, Json(response)))
 }

--- a/crates/oneiros-engine/src/domains/seed/service.rs
+++ b/crates/oneiros-engine/src/domains/seed/service.rs
@@ -3,7 +3,10 @@ use crate::*;
 pub struct SeedService;
 
 impl SeedService {
-    pub async fn core(context: &ProjectLog) -> Result<SeedResponse, SeedError> {
+    pub async fn core(
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
+    ) -> Result<SeedResponse, SeedError> {
         for (name, description, prompt) in [
             (
                 "working",
@@ -32,7 +35,8 @@ impl SeedService {
             ),
         ] {
             LevelService::set(
-                context,
+                scope,
+                mailbox,
                 &SetLevel::builder_v1()
                     .name(LevelName::new(name))
                     .description(Description::from(description))
@@ -71,7 +75,8 @@ impl SeedService {
             ),
         ] {
             TextureService::set(
-                context,
+                scope,
+                mailbox,
                 &SetTexture::builder_v1()
                     .name(TextureName::new(name))
                     .description(Description::from(description))
@@ -105,7 +110,8 @@ impl SeedService {
             ),
         ] {
             SensationService::set(
-                context,
+                scope,
+                mailbox,
                 &SetSensation::builder_v1()
                     .name(name)
                     .description(description)
@@ -136,7 +142,8 @@ impl SeedService {
             ),
         ] {
             NatureService::set(
-                context,
+                scope,
+                mailbox,
                 &SetNature::builder_v1()
                     .name(name)
                     .description(description)
@@ -158,7 +165,8 @@ impl SeedService {
             ("scribe", "Record-keepers — maintain the cognitive record."),
         ] {
             PersonaService::set(
-                context,
+                scope,
+                mailbox,
                 &SetPersona::builder_v1()
                     .name(name)
                     .description(description)
@@ -191,7 +199,8 @@ impl SeedService {
             ),
         ] {
             UrgeService::set(
-                context,
+                scope,
+                mailbox,
                 &SetUrge::builder_v1()
                     .name(name)
                     .description(description)
@@ -205,15 +214,16 @@ impl SeedService {
         Ok(SeedResponse::SeedComplete)
     }
 
-    pub async fn agents(context: &ProjectLog) -> Result<SeedResponse, SeedError> {
+    pub async fn agents(
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
+    ) -> Result<SeedResponse, SeedError> {
         // Verify required personas exist — hint at `seed core` if missing.
         let all_filters = SearchFilters {
             limit: Limit(usize::MAX),
             offset: Offset(0),
         };
-        let personas = PersonaRepo::new(context.scope()?)
-            .list(&all_filters)
-            .await?;
+        let personas = PersonaRepo::new(scope).list(&all_filters).await?;
         let persona_names: Vec<&str> = personas.items.iter().map(|p| p.name.as_str()).collect();
 
         if !persona_names.contains(&"process") || !persona_names.contains(&"scribe") {
@@ -245,7 +255,7 @@ impl SeedService {
             // Skip agents that already exist (idempotent).
             let agent_name = AgentName::new(name);
 
-            if AgentRepo::new(context.scope()?)
+            if AgentRepo::new(scope)
                 .name_exists(&agent_name.normalize_with(&PersonaName::new(persona)))
                 .await?
             {
@@ -253,7 +263,8 @@ impl SeedService {
             }
 
             AgentService::create(
-                context,
+                scope,
+                mailbox,
                 &CreateAgent::V1(
                     CreateAgentV1::builder()
                         .name(agent_name)

--- a/crates/oneiros-engine/src/domains/sensation/features/http.rs
+++ b/crates/oneiros-engine/src/domains/sensation/features/http.rs
@@ -39,7 +39,8 @@ impl SensationRouter {
 }
 
 async fn set(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<SensationName>,
     Json(body): Json<SetSensation>,
 ) -> Result<(StatusCode, Json<SensationResponse>), SensationError> {
@@ -48,37 +49,35 @@ async fn set(
     let request = SetSensation::V1(setting);
     Ok((
         StatusCode::OK,
-        Json(SensationService::set(&context, &request).await?),
+        Json(SensationService::set(&scope, &mailbox, &request).await?),
     ))
 }
 
 async fn list(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<ListSensations>,
 ) -> Result<Json<SensationResponse>, SensationError> {
-    Ok(Json(SensationService::list(&context, &params).await?))
+    Ok(Json(SensationService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(key): Path<ResourceKey<SensationName>>,
 ) -> Result<Json<SensationResponse>, SensationError> {
     Ok(Json(
-        SensationService::get(
-            &context,
-            &GetSensation::builder_v1().key(key).build().into(),
-        )
-        .await?,
+        SensationService::get(&scope, &GetSensation::builder_v1().key(key).build().into()).await?,
     ))
 }
 
 async fn remove(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<SensationName>,
 ) -> Result<Json<SensationResponse>, SensationError> {
     Ok(Json(
         SensationService::remove(
-            &context,
+            &scope,
+            &mailbox,
             &RemoveSensation::builder_v1().name(name).build().into(),
         )
         .await?,

--- a/crates/oneiros-engine/src/domains/sensation/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/sensation/features/mcp.rs
@@ -16,7 +16,8 @@ impl SensationMcp {
         context: &ProjectLog,
         request: &SensationRequest,
     ) -> Result<McpResponse, ToolError> {
-        sensation_mcp::resource(context, request).await
+        let scope = context.scope().map_err(Error::from)?;
+        sensation_mcp::resource(scope, request).await
     }
 }
 
@@ -24,18 +25,18 @@ mod sensation_mcp {
     use crate::*;
 
     pub async fn resource(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &SensationRequest,
     ) -> Result<McpResponse, ToolError> {
         match request {
             SensationRequest::ListSensations(list) => {
-                let response = SensationService::list(context, list)
+                let response = SensationService::list(scope, list)
                     .await
                     .map_err(Error::from)?;
                 Ok(SensationView::new(response).mcp())
             }
             SensationRequest::GetSensation(get) => {
-                let response = SensationService::get(context, get)
+                let response = SensationService::get(scope, get)
                     .await
                     .map_err(Error::from)?;
                 Ok(SensationView::new(response).mcp())

--- a/crates/oneiros-engine/src/domains/sensation/repo.rs
+++ b/crates/oneiros-engine/src/domains/sensation/repo.rs
@@ -20,7 +20,7 @@ impl<'a> SensationRepo<'a> {
     }
 
     pub async fn get(&self, name: &SensationName) -> Result<Option<Sensation>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt =
             db.prepare("SELECT name, description, prompt FROM sensations WHERE name = ?1")?;
 
@@ -46,7 +46,7 @@ impl<'a> SensationRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Sensation>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM sensations")?;

--- a/crates/oneiros-engine/src/domains/sensation/service.rs
+++ b/crates/oneiros-engine/src/domains/sensation/service.rs
@@ -4,7 +4,8 @@ pub struct SensationService;
 
 impl SensationService {
     pub async fn set(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &SetSensation,
     ) -> Result<SensationResponse, SensationError> {
         let SetSensation::V1(set) = request;
@@ -13,31 +14,38 @@ impl SensationService {
             .description(set.description.clone())
             .prompt(set.prompt.clone())
             .build();
+        let name = sensation.name.clone();
 
-        context
-            .emit(SensationEvents::SensationSet(
+        let new_event = NewEvent::builder()
+            .data(Events::Sensation(SensationEvents::SensationSet(
                 SensationSet::builder_v1()
-                    .sensation(sensation.clone())
+                    .sensation(sensation)
                     .build()
                     .into(),
-            ))
-            .await?;
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let projected = SensationRepo::new(scope)
+            .fetch(&name)
+            .await?
+            .ok_or(SensationError::NotFound(name))?;
 
         Ok(SensationResponse::SensationSet(
             SensationSetResponse::builder_v1()
-                .sensation(sensation)
+                .sensation(projected)
                 .build()
                 .into(),
         ))
     }
 
     pub async fn get(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &GetSensation,
     ) -> Result<SensationResponse, SensationError> {
         let GetSensation::V1(lookup) = request;
         let name = lookup.key.resolve()?;
-        let sensation = SensationRepo::new(context.scope()?)
+        let sensation = SensationRepo::new(scope)
             .fetch(&name)
             .await?
             .ok_or(SensationError::NotFound(name))?;
@@ -50,13 +58,11 @@ impl SensationService {
     }
 
     pub async fn list(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ListSensations,
     ) -> Result<SensationResponse, SensationError> {
         let ListSensations::V1(listing) = request;
-        let listed = SensationRepo::new(context.scope()?)
-            .list(&listing.filters)
-            .await?;
+        let listed = SensationRepo::new(scope).list(&listing.filters).await?;
         if listed.total == 0 {
             Ok(SensationResponse::NoSensations)
         } else {
@@ -71,21 +77,32 @@ impl SensationService {
     }
 
     pub async fn remove(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &RemoveSensation,
     ) -> Result<SensationResponse, SensationError> {
         let RemoveSensation::V1(removal) = request;
-        context
-            .emit(SensationEvents::SensationRemoved(
+        let name = removal.name.clone();
+
+        let new_event = NewEvent::builder()
+            .data(Events::Sensation(SensationEvents::SensationRemoved(
                 SensationRemoved::builder_v1()
-                    .name(removal.name.clone())
+                    .name(name.clone())
                     .build()
                     .into(),
-            ))
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        scope
+            .config()
+            .fetch
+            .until_absent(|| async { SensationRepo::new(scope).get(&name).await })
             .await?;
+
         Ok(SensationResponse::SensationRemoved(
             SensationRemovedResponse::builder_v1()
-                .name(removal.name.clone())
+                .name(name)
                 .build()
                 .into(),
         ))

--- a/crates/oneiros-engine/src/domains/storage/features/http.rs
+++ b/crates/oneiros-engine/src/domains/storage/features/http.rs
@@ -39,22 +39,23 @@ impl StorageRouter {
 }
 
 async fn upload(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Json(body): Json<UploadStorage>,
 ) -> Result<(StatusCode, Json<StorageResponse>), StorageError> {
-    let response = StorageService::upload(&context, &body).await?;
+    let response = StorageService::upload(&scope, &mailbox, &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
 
 async fn list(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<ListStorage>,
 ) -> Result<Json<StorageResponse>, StorageError> {
-    Ok(Json(StorageService::list(&context, &params).await?))
+    Ok(Json(StorageService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(ref_key): Path<String>,
 ) -> Result<Json<StorageResponse>, StorageError> {
     let key = if ref_key.starts_with("ref:") {
@@ -64,19 +65,21 @@ async fn show(
         ResourceKey::Key(storage_ref.decode().map_err(|_| StorageError::InvalidRef)?)
     };
     Ok(Json(
-        StorageService::show(&context, &GetStorage::builder_v1().key(key).build().into()).await?,
+        StorageService::show(&scope, &GetStorage::builder_v1().key(key).build().into()).await?,
     ))
 }
 
 async fn remove(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(ref_key): Path<String>,
 ) -> Result<Json<StorageResponse>, StorageError> {
     let storage_ref = StorageRef(ref_key);
     let key = storage_ref.decode().map_err(|_| StorageError::InvalidRef)?;
     Ok(Json(
         StorageService::remove(
-            &context,
+            &scope,
+            &mailbox,
             &RemoveStorage::builder_v1().key(key).build().into(),
         )
         .await?,

--- a/crates/oneiros-engine/src/domains/storage/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/storage/features/mcp.rs
@@ -10,10 +10,11 @@ impl StorageMcp {
     pub async fn dispatch(
         &self,
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        storage_mcp::dispatch(context, tool_name, params).await
+        storage_mcp::dispatch(context, mailbox, tool_name, params).await
     }
 }
 
@@ -35,6 +36,7 @@ mod storage_mcp {
 
     pub async fn dispatch(
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
@@ -42,17 +44,19 @@ mod storage_mcp {
             .parse()
             .map_err(|_| ToolError::UnknownTool(tool_name.to_string()))?;
 
+        let scope = context.scope().map_err(Error::from)?;
+
         let value = match request_type {
             StorageRequestType::ListStorage => {
                 let request: ListStorage = serde_json::from_str(params)
                     .unwrap_or_else(|_| ListStorage::builder_v1().build().into());
-                StorageService::list(context, &request).await
+                StorageService::list(scope, &request).await
             }
             StorageRequestType::GetStorage => {
-                StorageService::show(context, &serde_json::from_str(params)?).await
+                StorageService::show(scope, &serde_json::from_str(params)?).await
             }
             StorageRequestType::RemoveStorage => {
-                StorageService::remove(context, &serde_json::from_str(params)?).await
+                StorageService::remove(scope, mailbox, &serde_json::from_str(params)?).await
             }
             StorageRequestType::UploadStorage => {
                 return Err(ToolError::UnknownTool(tool_name.to_string()));

--- a/crates/oneiros-engine/src/domains/storage/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/storage/protocol/errors.rs
@@ -31,6 +31,9 @@ pub enum StorageError {
     Compose(#[from] crate::ComposeError),
 
     #[error(transparent)]
+    BookmarkDb(#[from] crate::BookmarkDbError),
+
+    #[error(transparent)]
     Event(#[from] crate::EventError),
 
     #[error(transparent)]
@@ -48,9 +51,10 @@ impl IntoResponse for StorageError {
             StorageError::BlobMissing(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             StorageError::BlobError(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             StorageError::Io(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
-            StorageError::Database(_) | StorageError::Event(_) | StorageError::Compose(_) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
-            }
+            StorageError::Database(_)
+            | StorageError::Event(_)
+            | StorageError::Compose(_)
+            | StorageError::BookmarkDb(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             StorageError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
         };
         (status, Json(ErrorResponse::new(message))).into_response()

--- a/crates/oneiros-engine/src/domains/storage/repo.rs
+++ b/crates/oneiros-engine/src/domains/storage/repo.rs
@@ -28,7 +28,7 @@ impl<'a> StorageRepo<'a> {
     }
 
     pub async fn get_storage(&self, key: &StorageKey) -> Result<Option<StorageEntry>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt = db.prepare("SELECT key, description, hash FROM storage WHERE key = ?1")?;
 
         let result = stmt.query_row(params![key.as_str()], |row| {
@@ -53,7 +53,7 @@ impl<'a> StorageRepo<'a> {
         &self,
         filters: &SearchFilters,
     ) -> Result<Listed<StorageEntry>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
 
         let total: usize = db.query_row("SELECT COUNT(*) FROM storage", [], |row| row.get(0))?;
 
@@ -95,7 +95,7 @@ impl<'a> StorageRepo<'a> {
     }
 
     pub async fn get_blob(&self, hash: &ContentHash) -> Result<Option<BlobContent>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt = db.prepare("SELECT hash, data, size FROM blob WHERE hash = ?1")?;
 
         let result = stmt.query_row(params![hash.as_str()], |row| {

--- a/crates/oneiros-engine/src/domains/storage/service.rs
+++ b/crates/oneiros-engine/src/domains/storage/service.rs
@@ -3,43 +3,61 @@ use crate::*;
 pub struct StorageService;
 
 impl StorageService {
-    /// Upload content — hash it, store the blob, record the metadata.
+    /// Upload content — hash it, store the blob, dispatch the metadata
+    /// event, return the eventually-consistent entry.
+    ///
+    /// The blob table is the durable store, not a projection — the put
+    /// happens here directly, outside the bus. The metadata event is
+    /// the projection-driving signal that the bookmark actor materializes.
     pub async fn upload(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &UploadStorage,
     ) -> Result<StorageResponse, StorageError> {
         let UploadStorage::V1(upload) = request;
         let blob = BlobContent::create(&upload.data)?;
 
-        // Put the blob directly (not via event — the blob table is the durable store).
-        StorageStore::new(&context.db()?).put_blob(&blob)?;
+        // Put the blob directly — content-addressed storage, not a
+        // projection. Direct write to the bookmark DB.
+        let bookmark_db = BookmarkDb::open(scope).await?;
+        StorageStore::new(&bookmark_db).put_blob(&blob)?;
+        drop(bookmark_db);
 
         let entry = StorageEntry {
             key: upload.key.clone(),
             description: upload.description.clone(),
             hash: blob.hash.clone(),
         };
+        let key = entry.key.clone();
 
-        // Emit StorageSet — this drives the storage metadata projection.
-        context
-            .emit(StorageEvents::StorageSet(
-                StorageSet::builder_v1().entry(entry.clone()).build().into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Storage(StorageEvents::StorageSet(
+                StorageSet::builder_v1().entry(entry).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let stored = StorageRepo::new(scope)
+            .fetch_storage(&key)
+            .await?
+            .ok_or(StorageError::KeyNotFound(key))?;
 
         Ok(StorageResponse::StorageSet(
-            StorageSetResponse::builder_v1().entry(entry).build().into(),
+            StorageSetResponse::builder_v1()
+                .entry(stored)
+                .build()
+                .into(),
         ))
     }
 
     /// Show storage metadata by key.
     pub async fn show(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &GetStorage,
     ) -> Result<StorageResponse, StorageError> {
         let GetStorage::V1(lookup) = request;
         let key = lookup.key.resolve()?;
-        let entry = StorageRepo::new(context.scope()?)
+        let entry = StorageRepo::new(scope)
             .fetch_storage(&key)
             .await?
             .ok_or(StorageError::KeyNotFound(key))?;
@@ -53,11 +71,11 @@ impl StorageService {
 
     /// List all storage entries.
     pub async fn list(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ListStorage,
     ) -> Result<StorageResponse, StorageError> {
         let ListStorage::V1(listing) = request;
-        let listed = StorageRepo::new(context.scope()?)
+        let listed = StorageRepo::new(scope)
             .list_storage(&listing.filters)
             .await?;
 
@@ -76,23 +94,30 @@ impl StorageService {
 
     /// Remove storage metadata by key. The blob is NOT deleted (dedup preservation).
     pub async fn remove(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &RemoveStorage,
     ) -> Result<StorageResponse, StorageError> {
         let RemoveStorage::V1(removal) = request;
-        // Confirm the key exists before emitting.
-        StorageRepo::new(context.scope()?)
+        StorageRepo::new(scope)
             .fetch_storage(&removal.key)
             .await?
             .ok_or_else(|| StorageError::KeyNotFound(removal.key.clone()))?;
 
-        context
-            .emit(StorageEvents::StorageRemoved(
+        let new_event = NewEvent::builder()
+            .data(Events::Storage(StorageEvents::StorageRemoved(
                 StorageRemoved::builder_v1()
                     .key(removal.key.clone())
                     .build()
                     .into(),
-            ))
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        scope
+            .config()
+            .fetch
+            .until_absent(|| async { StorageRepo::new(scope).fetch_storage(&removal.key).await })
             .await?;
 
         Ok(StorageResponse::StorageRemoved(
@@ -105,10 +130,10 @@ impl StorageService {
 
     /// Retrieve the raw binary content for a storage key.
     pub async fn get_content(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         key: &StorageKey,
     ) -> Result<Vec<u8>, StorageError> {
-        let repo = StorageRepo::new(context.scope()?);
+        let repo = StorageRepo::new(scope);
 
         let entry = repo
             .fetch_storage(key)

--- a/crates/oneiros-engine/src/domains/system/features/http.rs
+++ b/crates/oneiros-engine/src/domains/system/features/http.rs
@@ -1,5 +1,5 @@
 use aide::axum::{ApiRouter, routing};
-use axum::{Json, http::StatusCode};
+use axum::{Json, extract::State, http::StatusCode};
 
 use crate::*;
 
@@ -17,9 +17,9 @@ impl SystemRouter {
 }
 
 async fn init(
-    context: HostLog,
+    State(state): State<ServerState>,
     Json(body): Json<InitSystem>,
 ) -> Result<(StatusCode, Json<SystemResponse>), SystemError> {
-    let response = SystemService::init(&context, &body).await?;
+    let response = SystemService::init(state.config(), state.mailbox(), &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }

--- a/crates/oneiros-engine/src/domains/system/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/system/protocol/errors.rs
@@ -32,6 +32,12 @@ pub enum SystemError {
 
     #[error(transparent)]
     Client(#[from] ClientError),
+
+    #[error(transparent)]
+    HostDb(#[from] HostDbError),
+
+    #[error("Unexpected service response: {0}")]
+    UnexpectedResponse(String),
 }
 
 resource_op_error!(SystemError);
@@ -47,7 +53,11 @@ impl IntoResponse for SystemError {
             | SystemError::Io(_)
             | SystemError::HostKey(_)
             | SystemError::Upcast(_)
-            | SystemError::Compose(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            | SystemError::Compose(_)
+            | SystemError::HostDb(_)
+            | SystemError::UnexpectedResponse(_) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
+            }
             SystemError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
         };
         (status, Json(ErrorResponse::new(message))).into_response()

--- a/crates/oneiros-engine/src/domains/system/service.rs
+++ b/crates/oneiros-engine/src/domains/system/service.rs
@@ -3,28 +3,35 @@ use crate::*;
 pub struct SystemService;
 
 impl SystemService {
+    /// Initialize the host system. Bootstrapping order:
+    ///
+    /// 1. ensure data dir, host key, system db schema, projection migrations
+    ///    — this is a precondition for any scope composition or actor work
+    /// 2. compose `Scope<AtHost>` (now that data_dir exists)
+    /// 3. idempotency check via `TenantRepo::list`
+    /// 4. dispatch the bootstrap tenant via the bus
+    /// 5. dispatch the bootstrap actor via the bus
     pub async fn init(
-        context: &HostLog,
+        config: &Config,
+        mailbox: &Mailbox,
         request: &InitSystem,
     ) -> Result<SystemResponse, SystemError> {
         let details = request.current()?;
-        // system init is the bootstrapper — ensure data dir, schema, and
-        // host keypair all exist. The keypair establishes host identity
-        // before the server ever starts.
-        std::fs::create_dir_all(&context.config.data_dir)?;
-        HostKey::new(&context.config.data_dir).ensure()?;
-        let db = context.db()?;
-        EventLog::new(&db).init()?;
-        context.projections.migrate(&db)?;
-        drop(db);
+
+        std::fs::create_dir_all(&config.data_dir)?;
+        HostKey::new(&config.data_dir).ensure()?;
+        let host_db = HostDb::open_with(&config.platform()).await?;
+        EventLog::new(&host_db).init()?;
+        Projections::system().migrate(&host_db)?;
+        drop(host_db);
+
+        let scope = ComposeScope::new(config.clone()).host()?;
 
         let all_filters = SearchFilters {
             limit: Limit(usize::MAX),
             offset: Offset(0),
         };
-
-        let scope = context.scope()?;
-        let tenants = TenantRepo::new(scope).list(&all_filters).await?;
+        let tenants = TenantRepo::new(&scope).list(&all_filters).await?;
 
         if tenants.total > 0 {
             return Ok(SystemResponse::HostAlreadyInitialized);
@@ -34,11 +41,11 @@ impl SystemService {
             .name
             .clone()
             .unwrap_or_else(|| "oneiros user".to_string());
-
         let tenant_name = TenantName::new(&name);
 
-        TenantService::create(
-            context,
+        let tenant_response = TenantService::create(
+            &scope,
+            mailbox,
             &CreateTenant::builder_v1()
                 .name(tenant_name.clone())
                 .build()
@@ -46,19 +53,25 @@ impl SystemService {
         )
         .await?;
 
-        let tenants = TenantRepo::new(scope).list(&all_filters).await?;
+        let tenant = match tenant_response {
+            TenantResponse::Created(TenantCreatedResponse::V1(created)) => created.tenant,
+            other => {
+                return Err(SystemError::UnexpectedResponse(format!(
+                    "expected Tenant(Created), got {other:?}"
+                )));
+            }
+        };
 
-        if let Some(tenant) = tenants.items.first() {
-            ActorService::create(
-                context,
-                &CreateActor::builder_v1()
-                    .tenant_id(tenant.id)
-                    .name(ActorName::new(&name))
-                    .build()
-                    .into(),
-            )
-            .await?;
-        }
+        ActorService::create(
+            &scope,
+            mailbox,
+            &CreateActor::builder_v1()
+                .tenant_id(tenant.id)
+                .name(ActorName::new(&name))
+                .build()
+                .into(),
+        )
+        .await?;
 
         Ok(SystemResponse::SystemInitialized(
             SystemInitializedResponse::builder_v1()

--- a/crates/oneiros-engine/src/domains/tenant/features/http.rs
+++ b/crates/oneiros-engine/src/domains/tenant/features/http.rs
@@ -33,25 +33,26 @@ impl TenantRouter {
 }
 
 async fn create(
-    context: HostLog,
+    scope: Scope<AtHost>,
+    mailbox: Mailbox,
     Json(body): Json<CreateTenant>,
 ) -> Result<(StatusCode, Json<TenantResponse>), TenantError> {
-    let response = TenantService::create(&context, &body).await?;
+    let response = TenantService::create(&scope, &mailbox, &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
 
 async fn list(
-    context: HostLog,
+    scope: Scope<AtHost>,
     Query(params): Query<ListTenants>,
 ) -> Result<Json<TenantResponse>, TenantError> {
-    Ok(Json(TenantService::list(&context, &params).await?))
+    Ok(Json(TenantService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: HostLog,
+    scope: Scope<AtHost>,
     Path(key): Path<ResourceKey<TenantId>>,
 ) -> Result<Json<TenantResponse>, TenantError> {
     Ok(Json(
-        TenantService::get(&context, &GetTenant::builder_v1().key(key).build().into()).await?,
+        TenantService::get(&scope, &GetTenant::builder_v1().key(key).build().into()).await?,
     ))
 }

--- a/crates/oneiros-engine/src/domains/tenant/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/tenant/features/mcp.rs
@@ -10,10 +10,11 @@ impl TenantMcp {
     pub async fn dispatch(
         &self,
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        tenant_mcp::dispatch(context, tool_name, params).await
+        tenant_mcp::dispatch(context, mailbox, tool_name, params).await
     }
 }
 
@@ -34,6 +35,7 @@ mod tenant_mcp {
 
     pub async fn dispatch(
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
@@ -44,17 +46,16 @@ mod tenant_mcp {
         let scope = ComposeScope::new(context.config.clone())
             .host()
             .map_err(Error::from)?;
-        let system = scope.host_log();
 
         let value = match request_type {
             TenantRequestType::CreateTenant => {
-                TenantService::create(&system, &serde_json::from_str(params)?).await
+                TenantService::create(&scope, mailbox, &serde_json::from_str(params)?).await
             }
             TenantRequestType::GetTenant => {
-                TenantService::get(&system, &serde_json::from_str(params)?).await
+                TenantService::get(&scope, &serde_json::from_str(params)?).await
             }
             TenantRequestType::ListTenants => {
-                TenantService::list(&system, &serde_json::from_str(params)?).await
+                TenantService::list(&scope, &serde_json::from_str(params)?).await
             }
         }
         .map_err(Error::from)?;

--- a/crates/oneiros-engine/src/domains/tenant/repo.rs
+++ b/crates/oneiros-engine/src/domains/tenant/repo.rs
@@ -21,7 +21,7 @@ impl<'a> TenantRepo<'a> {
     }
 
     pub async fn get(&self, id: &TenantId) -> Result<Option<Tenant>, TenantError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
         let mut stmt = db.prepare("select id, name, created_at from tenants where id = ?1")?;
 
         let raw = stmt.query_row(params![id.to_string()], |row| {
@@ -43,7 +43,7 @@ impl<'a> TenantRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Tenant>, TenantError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
 
         let count_sql = "SELECT COUNT(*) FROM tenants";
         let total = {

--- a/crates/oneiros-engine/src/domains/tenant/service.rs
+++ b/crates/oneiros-engine/src/domains/tenant/service.rs
@@ -3,38 +3,50 @@ use crate::*;
 pub struct TenantService;
 
 impl TenantService {
+    /// Create a tenant by dispatching `TenantCreated` through the bus
+    /// and reading the eventually-consistent record back via fetch.
+    ///
+    /// No phantom state — the response carries whatever the projection
+    /// has seen, never a synthesized record. If the fetch window
+    /// expires before the projection catches up, this surfaces as
+    /// `TenantError::NotFound`.
     pub async fn create(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
+        mailbox: &Mailbox,
         request: &CreateTenant,
     ) -> Result<TenantResponse, TenantError> {
         let CreateTenant::V1(create) = request;
 
         let tenant = Tenant::builder().name(create.name.clone()).build();
+        let id = tenant.id;
 
-        context
-            .emit(TenantEvents::TenantCreated(
-                TenantCreated::builder_v1()
-                    .tenant(tenant.clone())
-                    .build()
-                    .into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Tenant(TenantEvents::TenantCreated(
+                TenantCreated::builder_v1().tenant(tenant).build().into(),
+            )))
+            .build();
+
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let stored = TenantRepo::new(scope)
+            .fetch(&id)
+            .await?
+            .ok_or(TenantError::NotFound(id))?;
 
         Ok(TenantResponse::Created(
             TenantCreatedResponse::builder_v1()
-                .tenant(tenant)
+                .tenant(stored)
                 .build()
                 .into(),
         ))
     }
 
     pub async fn get(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
         request: &GetTenant,
     ) -> Result<TenantResponse, TenantError> {
         let GetTenant::V1(lookup) = request;
         let id = lookup.key.resolve()?;
-        let scope = context.scope()?;
         let tenant = TenantRepo::new(scope)
             .fetch(&id)
             .await?
@@ -48,11 +60,10 @@ impl TenantService {
     }
 
     pub async fn list(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
         request: &ListTenants,
     ) -> Result<TenantResponse, TenantError> {
         let ListTenants::V1(listing) = request;
-        let scope = context.scope()?;
         let listed = TenantRepo::new(scope).list(&listing.filters).await?;
         Ok(TenantResponse::Listed(
             TenantsResponse::builder_v1()

--- a/crates/oneiros-engine/src/domains/texture/features/http.rs
+++ b/crates/oneiros-engine/src/domains/texture/features/http.rs
@@ -39,7 +39,8 @@ impl TextureRouter {
 }
 
 async fn set(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<TextureName>,
     Json(body): Json<SetTexture>,
 ) -> Result<(StatusCode, Json<TextureResponse>), TextureError> {
@@ -48,33 +49,35 @@ async fn set(
     let request = SetTexture::V1(setting);
     Ok((
         StatusCode::OK,
-        Json(TextureService::set(&context, &request).await?),
+        Json(TextureService::set(&scope, &mailbox, &request).await?),
     ))
 }
 
 async fn list(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<ListTextures>,
 ) -> Result<Json<TextureResponse>, TextureError> {
-    Ok(Json(TextureService::list(&context, &params).await?))
+    Ok(Json(TextureService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(key): Path<ResourceKey<TextureName>>,
 ) -> Result<Json<TextureResponse>, TextureError> {
     Ok(Json(
-        TextureService::get(&context, &GetTexture::builder_v1().key(key).build().into()).await?,
+        TextureService::get(&scope, &GetTexture::builder_v1().key(key).build().into()).await?,
     ))
 }
 
 async fn remove(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<TextureName>,
 ) -> Result<Json<TextureResponse>, TextureError> {
     Ok(Json(
         TextureService::remove(
-            &context,
+            &scope,
+            &mailbox,
             &RemoveTexture::builder_v1().name(name).build().into(),
         )
         .await?,

--- a/crates/oneiros-engine/src/domains/texture/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/texture/features/mcp.rs
@@ -16,7 +16,8 @@ impl TextureMcp {
         context: &ProjectLog,
         request: &TextureRequest,
     ) -> Result<McpResponse, ToolError> {
-        texture_mcp::resource(context, request).await
+        let scope = context.scope().map_err(Error::from)?;
+        texture_mcp::resource(scope, request).await
     }
 }
 
@@ -24,20 +25,18 @@ mod texture_mcp {
     use crate::*;
 
     pub async fn resource(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &TextureRequest,
     ) -> Result<McpResponse, ToolError> {
         match request {
             TextureRequest::ListTextures(list) => {
-                let response = TextureService::list(context, list)
+                let response = TextureService::list(scope, list)
                     .await
                     .map_err(Error::from)?;
                 Ok(TextureView::new(response).mcp())
             }
             TextureRequest::GetTexture(get) => {
-                let response = TextureService::get(context, get)
-                    .await
-                    .map_err(Error::from)?;
+                let response = TextureService::get(scope, get).await.map_err(Error::from)?;
                 Ok(TextureView::new(response).mcp())
             }
             TextureRequest::SetTexture(_) | TextureRequest::RemoveTexture(_) => Err(

--- a/crates/oneiros-engine/src/domains/texture/repo.rs
+++ b/crates/oneiros-engine/src/domains/texture/repo.rs
@@ -20,7 +20,7 @@ impl<'a> TextureRepo<'a> {
     }
 
     pub async fn get(&self, name: &TextureName) -> Result<Option<Texture>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt =
             db.prepare("SELECT name, description, prompt FROM textures WHERE name = ?1")?;
 
@@ -46,7 +46,7 @@ impl<'a> TextureRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Texture>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM textures")?;

--- a/crates/oneiros-engine/src/domains/texture/service.rs
+++ b/crates/oneiros-engine/src/domains/texture/service.rs
@@ -4,7 +4,8 @@ pub struct TextureService;
 
 impl TextureService {
     pub async fn set(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &SetTexture,
     ) -> Result<TextureResponse, TextureError> {
         let SetTexture::V1(set) = request;
@@ -13,31 +14,35 @@ impl TextureService {
             .description(set.description.clone())
             .prompt(set.prompt.clone())
             .build();
+        let name = texture.name.clone();
 
-        context
-            .emit(TextureEvents::TextureSet(
-                TextureSet::builder_v1()
-                    .texture(texture.clone())
-                    .build()
-                    .into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Texture(TextureEvents::TextureSet(
+                TextureSet::builder_v1().texture(texture).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let projected = TextureRepo::new(scope)
+            .fetch(&name)
+            .await?
+            .ok_or(TextureError::NotFound(name))?;
 
         Ok(TextureResponse::TextureSet(
             TextureSetResponse::builder_v1()
-                .texture(texture)
+                .texture(projected)
                 .build()
                 .into(),
         ))
     }
 
     pub async fn get(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &GetTexture,
     ) -> Result<TextureResponse, TextureError> {
         let GetTexture::V1(lookup) = request;
         let name = lookup.key.resolve()?;
-        let texture = TextureRepo::new(context.scope()?)
+        let texture = TextureRepo::new(scope)
             .fetch(&name)
             .await?
             .ok_or(TextureError::NotFound(name))?;
@@ -50,13 +55,11 @@ impl TextureService {
     }
 
     pub async fn list(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ListTextures,
     ) -> Result<TextureResponse, TextureError> {
         let ListTextures::V1(listing) = request;
-        let listed = TextureRepo::new(context.scope()?)
-            .list(&listing.filters)
-            .await?;
+        let listed = TextureRepo::new(scope).list(&listing.filters).await?;
         if listed.total == 0 {
             Ok(TextureResponse::NoTextures)
         } else {
@@ -71,21 +74,32 @@ impl TextureService {
     }
 
     pub async fn remove(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &RemoveTexture,
     ) -> Result<TextureResponse, TextureError> {
         let RemoveTexture::V1(removal) = request;
-        context
-            .emit(TextureEvents::TextureRemoved(
+        let name = removal.name.clone();
+
+        let new_event = NewEvent::builder()
+            .data(Events::Texture(TextureEvents::TextureRemoved(
                 TextureRemoved::builder_v1()
-                    .name(removal.name.clone())
+                    .name(name.clone())
                     .build()
                     .into(),
-            ))
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        scope
+            .config()
+            .fetch
+            .until_absent(|| async { TextureRepo::new(scope).get(&name).await })
             .await?;
+
         Ok(TextureResponse::TextureRemoved(
             TextureRemovedResponse::builder_v1()
-                .name(removal.name.clone())
+                .name(name)
                 .build()
                 .into(),
         ))

--- a/crates/oneiros-engine/src/domains/ticket/features/http.rs
+++ b/crates/oneiros-engine/src/domains/ticket/features/http.rs
@@ -37,32 +37,33 @@ impl TicketRouter {
 }
 
 async fn create(
-    context: HostLog,
+    scope: Scope<AtHost>,
+    mailbox: Mailbox,
     Json(body): Json<CreateTicket>,
 ) -> Result<(StatusCode, Json<TicketResponse>), TicketError> {
-    let response = TicketService::create(&context, &body).await?;
+    let response = TicketService::create(&scope, &mailbox, &body).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
 
 async fn list(
-    context: HostLog,
+    scope: Scope<AtHost>,
     Query(params): Query<ListTickets>,
 ) -> Result<Json<TicketResponse>, TicketError> {
-    Ok(Json(TicketService::list(&context, &params).await?))
+    Ok(Json(TicketService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: HostLog,
+    scope: Scope<AtHost>,
     Path(key): Path<ResourceKey<TicketId>>,
 ) -> Result<Json<TicketResponse>, TicketError> {
     Ok(Json(
-        TicketService::get(&context, &GetTicket::builder_v1().key(key).build().into()).await?,
+        TicketService::get(&scope, &GetTicket::builder_v1().key(key).build().into()).await?,
     ))
 }
 
 async fn validate(
-    context: HostLog,
+    scope: Scope<AtHost>,
     Json(body): Json<ValidateTicket>,
 ) -> Result<Json<TicketResponse>, TicketError> {
-    Ok(Json(TicketService::validate(&context, &body).await?))
+    Ok(Json(TicketService::validate(&scope, &body).await?))
 }

--- a/crates/oneiros-engine/src/domains/ticket/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/ticket/features/mcp.rs
@@ -10,10 +10,11 @@ impl TicketMcp {
     pub async fn dispatch(
         &self,
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
-        ticket_mcp::dispatch(context, tool_name, params).await
+        ticket_mcp::dispatch(context, mailbox, tool_name, params).await
     }
 }
 
@@ -43,6 +44,7 @@ mod ticket_mcp {
 
     pub async fn dispatch(
         context: &ProjectLog,
+        mailbox: &Mailbox,
         tool_name: &str,
         params: &str,
     ) -> Result<serde_json::Value, ToolError> {
@@ -53,20 +55,19 @@ mod ticket_mcp {
         let scope = ComposeScope::new(context.config.clone())
             .host()
             .map_err(Error::from)?;
-        let system = scope.host_log();
 
         let value = match request_type {
             TicketRequestType::CreateTicket => {
-                TicketService::create(&system, &serde_json::from_str(params)?).await
+                TicketService::create(&scope, mailbox, &serde_json::from_str(params)?).await
             }
             TicketRequestType::GetTicket => {
-                TicketService::get(&system, &serde_json::from_str(params)?).await
+                TicketService::get(&scope, &serde_json::from_str(params)?).await
             }
             TicketRequestType::ListTickets => {
-                TicketService::list(&system, &serde_json::from_str(params)?).await
+                TicketService::list(&scope, &serde_json::from_str(params)?).await
             }
             TicketRequestType::ValidateTicket => {
-                TicketService::validate(&system, &serde_json::from_str(params)?).await
+                TicketService::validate(&scope, &serde_json::from_str(params)?).await
             }
         }
         .map_err(Error::from)?;

--- a/crates/oneiros-engine/src/domains/ticket/repo.rs
+++ b/crates/oneiros-engine/src/domains/ticket/repo.rs
@@ -106,7 +106,7 @@ impl<'a> TicketRepo<'a> {
     }
 
     pub async fn get(&self, id: &TicketId) -> Result<Option<Ticket>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
         let sql = format!("SELECT {SELECT_COLUMNS} FROM tickets WHERE id = ?1");
         let mut stmt = db.prepare(&sql)?;
 
@@ -120,7 +120,7 @@ impl<'a> TicketRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Ticket>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM tickets")?;
@@ -149,7 +149,7 @@ impl<'a> TicketRepo<'a> {
     }
 
     pub async fn get_by_token(&self, token: &str) -> Result<Option<Ticket>, EventError> {
-        let db = self.scope.host_db().await?;
+        let db = HostDb::open(self.scope).await?;
         let sql = format!("SELECT {SELECT_COLUMNS} FROM tickets WHERE token = ?1");
         let mut stmt = db.prepare(&sql)?;
 

--- a/crates/oneiros-engine/src/domains/ticket/service.rs
+++ b/crates/oneiros-engine/src/domains/ticket/service.rs
@@ -4,18 +4,26 @@ pub struct TicketService;
 
 impl TicketService {
     pub async fn create(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
+        mailbox: &Mailbox,
         request: &CreateTicket,
     ) -> Result<TicketResponse, TicketError> {
         let CreateTicket::V1(create) = request;
-        let brain = BrainRepo::new(context.scope()?)
+        let brain = BrainRepo::new(scope)
             .get(&create.brain_name)
             .await?
             .ok_or_else(|| TicketError::BrainNotFound(create.brain_name.clone()))?;
 
         let target = Ref::brain(brain.id);
-        let ticket =
-            Self::issue(context, &create.brain_name, &brain, create.actor_id, target).await?;
+        let ticket = Self::issue(
+            scope,
+            mailbox,
+            &create.brain_name,
+            &brain,
+            create.actor_id,
+            target,
+        )
+        .await?;
         Ok(TicketResponse::Created(
             TicketCreatedResponse::builder_v1()
                 .ticket(ticket)
@@ -27,13 +35,14 @@ impl TicketService {
     /// Issue a ticket scoped to a specific target ref. Used by both
     /// `create` (brain-scoped) and `bookmark share` (bookmark-scoped).
     pub async fn issue(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
+        mailbox: &Mailbox,
         brain_name: &BrainName,
         brain: &Brain,
         actor_id: ActorId,
         target: Ref,
     ) -> Result<Ticket, TicketError> {
-        let actor = ActorRepo::new(context.scope()?)
+        let actor = ActorRepo::new(scope)
             .get(actor_id)
             .await?
             .ok_or_else(|| TicketError::ActorNotFound(actor_id))?;
@@ -53,26 +62,30 @@ impl TicketService {
             .link(link)
             .granted_by(actor_id)
             .build();
+        let id = ticket.id;
 
-        context
-            .emit(TicketEvents::TicketIssued(
-                TicketIssued::builder_v1()
-                    .ticket(ticket.clone())
-                    .build()
-                    .into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Ticket(TicketEvents::TicketIssued(
+                TicketIssued::builder_v1().ticket(ticket).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
 
-        Ok(ticket)
+        let stored = TicketRepo::new(scope)
+            .fetch(&id)
+            .await?
+            .ok_or(TicketError::NotFound(id))?;
+
+        Ok(stored)
     }
 
     pub async fn get(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
         request: &GetTicket,
     ) -> Result<TicketResponse, TicketError> {
         let GetTicket::V1(lookup) = request;
         let id = lookup.key.resolve()?;
-        let ticket = TicketRepo::new(context.scope()?)
+        let ticket = TicketRepo::new(scope)
             .fetch(&id)
             .await?
             .ok_or(TicketError::NotFound(id))?;
@@ -85,13 +98,11 @@ impl TicketService {
     }
 
     pub async fn list(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
         request: &ListTickets,
     ) -> Result<TicketResponse, TicketError> {
         let ListTickets::V1(listing) = request;
-        let listed = TicketRepo::new(context.scope()?)
-            .list(&listing.filters)
-            .await?;
+        let listed = TicketRepo::new(scope).list(&listing.filters).await?;
         Ok(TicketResponse::Listed(
             TicketsResponse::builder_v1()
                 .items(listed.items)
@@ -102,11 +113,11 @@ impl TicketService {
     }
 
     pub async fn validate(
-        context: &HostLog,
+        scope: &Scope<AtHost>,
         request: &ValidateTicket,
     ) -> Result<TicketResponse, TicketError> {
         let ValidateTicket::V1(validate) = request;
-        let ticket = TicketRepo::new(context.scope()?)
+        let ticket = TicketRepo::new(scope)
             .get_by_token(validate.token.as_str())
             .await?
             .ok_or(TicketError::InvalidToken)?;

--- a/crates/oneiros-engine/src/domains/urge/features/http.rs
+++ b/crates/oneiros-engine/src/domains/urge/features/http.rs
@@ -39,7 +39,8 @@ impl UrgeRouter {
 }
 
 async fn set(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<UrgeName>,
     Json(body): Json<SetUrge>,
 ) -> Result<(StatusCode, Json<UrgeResponse>), UrgeError> {
@@ -48,33 +49,35 @@ async fn set(
     let request = SetUrge::V1(setting);
     Ok((
         StatusCode::OK,
-        Json(UrgeService::set(&context, &request).await?),
+        Json(UrgeService::set(&scope, &mailbox, &request).await?),
     ))
 }
 
 async fn list(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Query(params): Query<ListUrges>,
 ) -> Result<Json<UrgeResponse>, UrgeError> {
-    Ok(Json(UrgeService::list(&context, &params).await?))
+    Ok(Json(UrgeService::list(&scope, &params).await?))
 }
 
 async fn show(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
     Path(key): Path<ResourceKey<UrgeName>>,
 ) -> Result<Json<UrgeResponse>, UrgeError> {
     Ok(Json(
-        UrgeService::get(&context, &GetUrge::builder_v1().key(key).build().into()).await?,
+        UrgeService::get(&scope, &GetUrge::builder_v1().key(key).build().into()).await?,
     ))
 }
 
 async fn remove(
-    context: ProjectLog,
+    scope: Scope<AtBookmark>,
+    mailbox: Mailbox,
     Path(name): Path<UrgeName>,
 ) -> Result<Json<UrgeResponse>, UrgeError> {
     Ok(Json(
         UrgeService::remove(
-            &context,
+            &scope,
+            &mailbox,
             &RemoveUrge::builder_v1().name(name).build().into(),
         )
         .await?,

--- a/crates/oneiros-engine/src/domains/urge/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/urge/features/mcp.rs
@@ -16,7 +16,8 @@ impl UrgeMcp {
         context: &ProjectLog,
         request: &UrgeRequest,
     ) -> Result<McpResponse, ToolError> {
-        urge_mcp::resource(context, request).await
+        let scope = context.scope().map_err(Error::from)?;
+        urge_mcp::resource(scope, request).await
     }
 }
 
@@ -24,18 +25,16 @@ mod urge_mcp {
     use crate::*;
 
     pub async fn resource(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &UrgeRequest,
     ) -> Result<McpResponse, ToolError> {
         match request {
             UrgeRequest::ListUrges(list) => {
-                let response = UrgeService::list(context, list)
-                    .await
-                    .map_err(Error::from)?;
+                let response = UrgeService::list(scope, list).await.map_err(Error::from)?;
                 Ok(UrgeView::new(response).mcp())
             }
             UrgeRequest::GetUrge(get) => {
-                let response = UrgeService::get(context, get).await.map_err(Error::from)?;
+                let response = UrgeService::get(scope, get).await.map_err(Error::from)?;
                 Ok(UrgeView::new(response).mcp())
             }
             UrgeRequest::SetUrge(_) | UrgeRequest::RemoveUrge(_) => Err(ToolError::NotAResource(

--- a/crates/oneiros-engine/src/domains/urge/repo.rs
+++ b/crates/oneiros-engine/src/domains/urge/repo.rs
@@ -20,7 +20,7 @@ impl<'a> UrgeRepo<'a> {
     }
 
     pub async fn get(&self, name: &UrgeName) -> Result<Option<Urge>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
         let mut stmt = db.prepare("SELECT name, description, prompt FROM urges WHERE name = ?1")?;
 
         let result = stmt.query_row(params![name.to_string()], |row| {
@@ -45,7 +45,7 @@ impl<'a> UrgeRepo<'a> {
     }
 
     pub async fn list(&self, filters: &SearchFilters) -> Result<Listed<Urge>, EventError> {
-        let db = self.scope.bookmark_db().await?;
+        let db = BookmarkDb::open(self.scope).await?;
 
         let total = {
             let mut stmt = db.prepare("SELECT COUNT(*) FROM urges")?;

--- a/crates/oneiros-engine/src/domains/urge/service.rs
+++ b/crates/oneiros-engine/src/domains/urge/service.rs
@@ -3,29 +3,43 @@ use crate::*;
 pub struct UrgeService;
 
 impl UrgeService {
-    pub async fn set(context: &ProjectLog, request: &SetUrge) -> Result<UrgeResponse, UrgeError> {
+    pub async fn set(
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
+        request: &SetUrge,
+    ) -> Result<UrgeResponse, UrgeError> {
         let SetUrge::V1(set) = request;
         let urge = Urge::builder()
             .name(set.name.clone())
             .description(set.description.clone())
             .prompt(set.prompt.clone())
             .build();
+        let name = urge.name.clone();
 
-        context
-            .emit(UrgeEvents::UrgeSet(
-                UrgeSet::builder_v1().urge(urge.clone()).build().into(),
-            ))
-            .await?;
+        let new_event = NewEvent::builder()
+            .data(Events::Urge(UrgeEvents::UrgeSet(
+                UrgeSet::builder_v1().urge(urge).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        let projected = UrgeRepo::new(scope)
+            .fetch(&name)
+            .await?
+            .ok_or(UrgeError::NotFound(name))?;
 
         Ok(UrgeResponse::UrgeSet(
-            UrgeSetResponse::builder_v1().urge(urge).build().into(),
+            UrgeSetResponse::builder_v1().urge(projected).build().into(),
         ))
     }
 
-    pub async fn get(context: &ProjectLog, request: &GetUrge) -> Result<UrgeResponse, UrgeError> {
+    pub async fn get(
+        scope: &Scope<AtBookmark>,
+        request: &GetUrge,
+    ) -> Result<UrgeResponse, UrgeError> {
         let GetUrge::V1(lookup) = request;
         let name = lookup.key.resolve()?;
-        let urge = UrgeRepo::new(context.scope()?)
+        let urge = UrgeRepo::new(scope)
             .fetch(&name)
             .await?
             .ok_or(UrgeError::NotFound(name))?;
@@ -35,13 +49,11 @@ impl UrgeService {
     }
 
     pub async fn list(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
         request: &ListUrges,
     ) -> Result<UrgeResponse, UrgeError> {
         let ListUrges::V1(listing) = request;
-        let listed = UrgeRepo::new(context.scope()?)
-            .list(&listing.filters)
-            .await?;
+        let listed = UrgeRepo::new(scope).list(&listing.filters).await?;
         if listed.total == 0 {
             Ok(UrgeResponse::NoUrges)
         } else {
@@ -56,23 +68,28 @@ impl UrgeService {
     }
 
     pub async fn remove(
-        context: &ProjectLog,
+        scope: &Scope<AtBookmark>,
+        mailbox: &Mailbox,
         request: &RemoveUrge,
     ) -> Result<UrgeResponse, UrgeError> {
         let RemoveUrge::V1(removal) = request;
-        context
-            .emit(UrgeEvents::UrgeRemoved(
-                UrgeRemoved::builder_v1()
-                    .name(removal.name.clone())
-                    .build()
-                    .into(),
-            ))
+        let name = removal.name.clone();
+
+        let new_event = NewEvent::builder()
+            .data(Events::Urge(UrgeEvents::UrgeRemoved(
+                UrgeRemoved::builder_v1().name(name.clone()).build().into(),
+            )))
+            .build();
+        mailbox.tell(Message::new(scope.clone(), new_event));
+
+        scope
+            .config()
+            .fetch
+            .until_absent(|| async { UrgeRepo::new(scope).get(&name).await })
             .await?;
+
         Ok(UrgeResponse::UrgeRemoved(
-            UrgeRemovedResponse::builder_v1()
-                .name(removal.name.clone())
-                .build()
-                .into(),
+            UrgeRemovedResponse::builder_v1().name(name).build().into(),
         ))
     }
 }

--- a/crates/oneiros-engine/src/http/dashboard.rs
+++ b/crates/oneiros-engine/src/http/dashboard.rs
@@ -16,8 +16,7 @@ use crate::*;
 /// The tokens returned in `tickets` are the same tokens anyone
 /// with local access to the ticket DB can already read.
 pub async fn dashboard_config(State(state): State<ServerState>) -> Json<DashboardBootstrap> {
-    let system = state.host_log();
-    let scope = system.scope().ok();
+    let scope = ComposeScope::new(state.config().clone()).host().ok();
 
     let tenants = match scope.as_ref() {
         Some(s) => TenantRepo::new(s)

--- a/crates/oneiros-engine/src/http/state.rs
+++ b/crates/oneiros-engine/src/http/state.rs
@@ -15,6 +15,7 @@ pub struct ServerState {
     canons: CanonIndex,
     bridge: Bridge,
     api: Arc<OnceLock<OpenApi>>,
+    mailbox: Mailbox,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -27,18 +28,28 @@ pub enum ServerStateError {
 
 impl ServerState {
     /// Construct a server state with a bound iroh bridge. Loads (or
-    /// generates) the host secret key from disk and binds a `Bridge`.
+    /// generates) the host secret key from disk, binds a `Bridge`, and
+    /// spawns the host actor that consumes the bus.
     pub async fn bind(config: Config) -> Result<Self, ServerStateError> {
         let secret = HostKey::new(&config.data_dir).ensure()?;
         let bridge = Bridge::bind(secret).await?;
 
         let canons = CanonIndex::new();
+        let (mailbox, rx) = Mailbox::open();
+        let _actor = HostActor::spawn(config.clone(), canons.clone(), rx);
+
         Ok(Self {
             config,
             canons,
             bridge,
             api: Arc::new(OnceLock::new()),
+            mailbox,
         })
+    }
+
+    /// The bus mailbox — services dispatch events through this handle.
+    pub fn mailbox(&self) -> &Mailbox {
+        &self.mailbox
     }
 
     /// Install the OpenAPI spec. Called once after the router is assembled.
@@ -87,13 +98,10 @@ impl ServerState {
         &self.config.brain
     }
 
-    /// Build a project context with pre-hydrated pipeline.
-    ///
-    /// Resolves the active bookmark for the brain unless the config
-    /// already has an explicit bookmark override.
-    pub fn project_log(&self, config: Config) -> Result<ProjectLog, EventError> {
-        let entry = self.canons.brain_entry(&config.brain)?;
-        Ok(ProjectLog::with_entry(config, entry))
+    /// Build a project context for a request. Strangler — used by the
+    /// `ProjectLog` extractor for legacy CLI/MCP dispatchers.
+    pub fn project_log(&self, config: Config) -> ProjectLog {
+        ProjectLog::new(config)
     }
 
     /// Build a system context.
@@ -113,6 +121,127 @@ impl FromRequestParts<ServerState> for HostLog {
     }
 }
 
+impl aide::operation::OperationInput for Mailbox {}
+
+impl FromRequestParts<ServerState> for Mailbox {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &ServerState,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(state.mailbox().clone())
+    }
+}
+
+impl aide::operation::OperationInput for Scope<AtHost> {}
+
+impl FromRequestParts<ServerState> for Scope<AtHost> {
+    type Rejection = ScopeExtractError;
+
+    async fn from_request_parts(
+        _parts: &mut Parts,
+        state: &ServerState,
+    ) -> Result<Self, Self::Rejection> {
+        ComposeScope::new(state.config.clone())
+            .host()
+            .map_err(|e| ScopeExtractError::Other(e.to_string()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ScopeExtractError {
+    #[error("{0}")]
+    Other(String),
+}
+
+impl axum::response::IntoResponse for ScopeExtractError {
+    fn into_response(self) -> axum::response::Response {
+        (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            self.to_string(),
+        )
+            .into_response()
+    }
+}
+
+/// Resolve the bookmark-tier capability for a request: validate the
+/// Bearer token against the ticket store, pick the bookmark (active by
+/// default; `X-Bookmark` header / `?bookmark=` query overrides), and
+/// return both the request-shaped `Config` and the composed scope.
+///
+/// Standalone helper — not built on top of `ProjectLog`. Both the new
+/// `Scope<AtBookmark>` extractor and the legacy `ProjectLog` extractor
+/// share this resolution.
+async fn resolve_request(
+    parts: &Parts,
+    state: &ServerState,
+) -> Result<(Config, Scope<AtBookmark>), AuthError> {
+    let token_str = parts
+        .headers
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .ok_or(AuthError::NoAuthHeader)?;
+
+    let token = Token::from(token_str)
+        .decode()
+        .map_err(|_| AuthError::InvalidToken)?;
+
+    let host_scope = ComposeScope::new(state.config.clone())
+        .host()
+        .map_err(|_| AuthError::InvalidToken)?;
+    let ticket = TicketRepo::new(&host_scope)
+        .get_by_token(token_str)
+        .await
+        .map_err(|_| AuthError::InvalidToken)?
+        .ok_or(AuthError::InvalidToken)?;
+
+    if ticket.actor_id != token.actor_id || ticket.brain_id != token.brain_id {
+        return Err(AuthError::InvalidToken);
+    }
+
+    let mut config = state.config.clone();
+    config.brain = ticket.brain_name.clone();
+    config.bookmark = state
+        .canons()
+        .active_bookmark(&ticket.brain_name)
+        .unwrap_or_else(|_| BookmarkName::main());
+
+    if let Some(bookmark) = parts
+        .headers
+        .get("x-bookmark")
+        .and_then(|v| v.to_str().ok())
+        .or_else(|| {
+            parts
+                .uri
+                .query()
+                .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("bookmark=")))
+        })
+    {
+        config.bookmark = BookmarkName::new(bookmark);
+    }
+
+    let scope = ComposeScope::new(config.clone())
+        .bookmark(config.brain.clone(), config.bookmark.clone())
+        .map_err(|_| AuthError::InvalidToken)?;
+    Ok((config, scope))
+}
+
+impl aide::operation::OperationInput for Scope<AtBookmark> {}
+
+impl FromRequestParts<ServerState> for Scope<AtBookmark> {
+    type Rejection = AuthError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &ServerState,
+    ) -> Result<Self, Self::Rejection> {
+        let (_config, scope) = resolve_request(parts, state).await?;
+        Ok(scope)
+    }
+}
+
 impl FromRequestParts<ServerState> for ProjectLog {
     type Rejection = AuthError;
 
@@ -120,64 +249,7 @@ impl FromRequestParts<ServerState> for ProjectLog {
         parts: &mut Parts,
         state: &ServerState,
     ) -> Result<Self, Self::Rejection> {
-        let token_str = parts
-            .headers
-            .get("authorization")
-            .and_then(|value| value.to_str().ok())
-            .and_then(|value| value.strip_prefix("Bearer "))
-            .ok_or(AuthError::NoAuthHeader)?;
-
-        // Decode claims from the self-describing token
-        let token = Token::from(token_str)
-            .decode()
-            .map_err(|_| AuthError::InvalidToken)?;
-
-        // Revocation check — verify the ticket still exists in the DB
-        let scope = ComposeScope::new(state.config.clone())
-            .host()
-            .map_err(|_| AuthError::InvalidToken)?;
-        let ticket = TicketRepo::new(&scope)
-            .get_by_token(token_str)
-            .await
-            .map_err(|_| AuthError::InvalidToken)?
-            .ok_or(AuthError::InvalidToken)?;
-
-        match (
-            ticket.actor_id == token.actor_id,
-            ticket.brain_id == token.brain_id,
-            true, // ticket.tenant_id == token.tenant_id,
-        ) {
-            (true, true, true) => {}
-            _ => return Err(AuthError::InvalidToken),
-        }
-
-        // Assemble ProjectLog for this request
-        let mut config = state.config.clone();
-        config.brain = ticket.brain_name.clone();
-
-        // Default to the active bookmark for this brain.
-        config.bookmark = state
-            .canons()
-            .active_bookmark(&ticket.brain_name)
-            .unwrap_or_else(|_| BookmarkName::main());
-
-        // Override with explicit X-Bookmark header or ?bookmark= query param.
-        if let Some(bookmark) = parts
-            .headers
-            .get("x-bookmark")
-            .and_then(|v| v.to_str().ok())
-            .or_else(|| {
-                parts
-                    .uri
-                    .query()
-                    .and_then(|q| q.split('&').find_map(|pair| pair.strip_prefix("bookmark=")))
-            })
-        {
-            config.bookmark = BookmarkName::new(bookmark);
-        }
-
-        state
-            .project_log(config)
-            .map_err(|_| AuthError::InvalidToken)
+        let (config, _scope) = resolve_request(parts, state).await?;
+        Ok(state.project_log(config))
     }
 }

--- a/crates/oneiros-engine/src/lib.rs
+++ b/crates/oneiros-engine/src/lib.rs
@@ -1,3 +1,4 @@
+mod bus;
 mod cli;
 mod client;
 mod config;
@@ -22,6 +23,7 @@ mod support;
 mod tests;
 mod values;
 
+pub use bus::*;
 pub use cli::*;
 pub use client::*;
 pub use config::*;

--- a/crates/oneiros-engine/src/logs/host.rs
+++ b/crates/oneiros-engine/src/logs/host.rs
@@ -1,56 +1,25 @@
-use std::sync::Arc;
-
 use crate::*;
 
 impl aide::operation::OperationInput for HostLog {}
 
+/// Strangler — request-shaped context for legacy host-tier callers.
+///
+/// Carries the request's `Config` and provides a `client()` for CLI
+/// commands that dispatch through HTTP. New code uses
+/// `Scope<AtHost>` + `Mailbox` directly; this exists to bridge CLI
+/// commands and a few other holdouts during the bus migration.
 #[derive(Clone)]
 pub struct HostLog {
     pub config: Config,
-    pub projections: Projections<SystemCanon>,
-    /// Lazily-composed Scope, cached for the context's lifetime.
-    /// Wrapped in Arc so Clone is cheap.
-    scope: Arc<std::sync::OnceLock<Scope<AtHost>>>,
 }
 
 impl HostLog {
     pub fn new(config: Config) -> Self {
-        Self {
-            config,
-            projections: Projections::system(),
-            scope: Arc::new(std::sync::OnceLock::new()),
-        }
+        Self { config }
     }
 
     /// Build an HTTP client for system operations.
     pub fn client(&self) -> Client {
         Client::new(self.config.base_url())
-    }
-
-    /// Open the system database.
-    pub fn db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        self.config.system_db()
-    }
-
-    /// Compose a host-tier Scope from this context's config (lazy,
-    /// cached). Strangler helper: lets services pass &Scope to repos
-    /// without changing their own signatures during migration.
-    pub fn scope(&self) -> Result<&Scope<AtHost>, ComposeError> {
-        if self.scope.get().is_none() {
-            let s = ComposeScope::new(self.config.clone()).host()?;
-            let _ = self.scope.set(s);
-        }
-        Ok(self.scope.get().expect("just set above"))
-    }
-
-    /// Emit an event to the system event log and apply projections.
-    pub async fn emit(&self, event: impl Into<Events>) -> Result<(), EventError> {
-        let db = self.db()?;
-        let new_event = NewEvent::builder().data(event).build();
-        let stored = EventLog::new(&db).append(&new_event)?;
-
-        self.projections.apply(&db, &stored)?;
-
-        Ok(())
     }
 }

--- a/crates/oneiros-engine/src/logs/project.rs
+++ b/crates/oneiros-engine/src/logs/project.rs
@@ -4,11 +4,17 @@ use crate::*;
 
 impl aide::operation::OperationInput for ProjectLog {}
 
+/// Strangler — request-shaped context for legacy bookmark-tier callers.
+///
+/// Carries the request's `Config` (with brain + bookmark already
+/// resolved) and provides a lazily-composed `Scope<AtBookmark>` plus
+/// an authenticated HTTP `client()`. New code uses
+/// `Scope<AtBookmark>` + `Mailbox` directly; this remains for CLI
+/// commands and MCP dispatchers that derive their scope from the
+/// request context during the bus migration.
 #[derive(Clone)]
 pub struct ProjectLog {
     pub config: Config,
-    pub projections: Projections<BrainCanon>,
-    chronicle: Chronicle,
     /// Lazily-composed Scope, cached for the context's lifetime.
     scope: Arc<std::sync::OnceLock<Scope<AtBookmark>>>,
 }
@@ -17,18 +23,6 @@ impl ProjectLog {
     pub fn new(config: Config) -> Self {
         Self {
             config,
-            projections: Projections::project(),
-            chronicle: Chronicle::new(),
-            scope: Arc::new(std::sync::OnceLock::new()),
-        }
-    }
-
-    /// Create a context with a pre-hydrated bookmark entry.
-    pub fn with_entry(config: Config, entry: BookmarkEntry) -> Self {
-        Self {
-            config,
-            projections: Projections::project_with_pipeline(entry.pipeline),
-            chronicle: entry.chronicle,
             scope: Arc::new(std::sync::OnceLock::new()),
         }
     }
@@ -51,18 +45,9 @@ impl ProjectLog {
         }
     }
 
-    /// Open the bookmark DB with the events DB ATTACHed.
-    ///
-    /// Unqualified table names resolve to the bookmark DB (projections).
-    /// Event log operations use the `events` schema qualifier via
-    /// `EventLog::attached`.
-    pub fn db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        self.config.bookmark_conn()
-    }
-
     /// Compose a bookmark-tier Scope from this context's config
-    /// (lazy, cached). Strangler helper: lets services pass &Scope to
-    /// repos without changing their own signatures during migration.
+    /// (lazy, cached). Strangler helper: MCP dispatchers extract this
+    /// to pass `&Scope<AtBookmark>` to migrated services.
     pub fn scope(&self) -> Result<&Scope<AtBookmark>, ComposeError> {
         if self.scope.get().is_none() {
             let s = ComposeScope::new(self.config.clone())
@@ -70,38 +55,5 @@ impl ProjectLog {
             let _ = self.scope.set(s);
         }
         Ok(self.scope.get().expect("just set above"))
-    }
-
-    /// Open the system database.
-    pub fn system_db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        self.config.system_db()
-    }
-
-    /// Replay all events through projections, rebuilding read models.
-    pub fn replay(&self) -> Result<usize, EventError> {
-        let db = self.db()?;
-        let log = EventLog::attached(&db);
-        self.projections.replay_brain(&db, &log)
-    }
-
-    /// Emit an event to the brain's event log and apply projections.
-    pub async fn emit(&self, event: impl Into<Events>) -> Result<(), EventError> {
-        let db = self.db()?;
-        let new_event = NewEvent::builder().data(event).build();
-        let stored = EventLog::attached(&db).append(&new_event)?;
-
-        self.projections.apply_brain(&db, &stored)?;
-
-        // Chronicle the event in the system DB (shared across bookmarks).
-        let system_db = self.system_db()?;
-        let chronicle_store = ChronicleStore::new(&system_db);
-        chronicle_store.migrate()?;
-        self.chronicle.record(
-            &stored,
-            &chronicle_store.resolver(),
-            &chronicle_store.writer(),
-        )?;
-
-        Ok(())
     }
 }

--- a/crates/oneiros-engine/src/mcp.rs
+++ b/crates/oneiros-engine/src/mcp.rs
@@ -69,26 +69,34 @@ async fn dispatch(
     tool_name: &ToolName,
     params: &serde_json::Value,
 ) -> Result<McpResponse, ToolError> {
-    let context = state
-        .project_log(config.clone())
-        .map_err(|e| ToolError::App(e.into()))?;
+    let context = state.project_log(config.clone());
 
     let name = tool_name.as_str();
 
     if name.parse::<AgentRequestType>().is_ok() {
-        return AgentMcp.dispatch(&context, tool_name, params).await;
+        return AgentMcp
+            .dispatch(&context, state.mailbox(), tool_name, params)
+            .await;
     }
     if name.parse::<CognitionRequestType>().is_ok() {
-        return CognitionMcp.dispatch(&context, tool_name, params).await;
+        return CognitionMcp
+            .dispatch(&context, state.mailbox(), tool_name, params)
+            .await;
     }
     if name.parse::<MemoryRequestType>().is_ok() {
-        return MemoryMcp.dispatch(&context, tool_name, params).await;
+        return MemoryMcp
+            .dispatch(&context, state.mailbox(), tool_name, params)
+            .await;
     }
     if name.parse::<ExperienceRequestType>().is_ok() {
-        return ExperienceMcp.dispatch(&context, tool_name, params).await;
+        return ExperienceMcp
+            .dispatch(&context, state.mailbox(), tool_name, params)
+            .await;
     }
     if name.parse::<ConnectionRequestType>().is_ok() {
-        return ConnectionMcp.dispatch(&context, tool_name, params).await;
+        return ConnectionMcp
+            .dispatch(&context, state.mailbox(), tool_name, params)
+            .await;
     }
     if name.parse::<SearchRequestType>().is_ok() {
         return SearchMcp.dispatch(&context, tool_name, params).await;
@@ -372,10 +380,7 @@ impl ServerHandler for EngineToolBox {
         request: rmcp::model::ReadResourceRequestParams,
         _context: rmcp::service::RequestContext<rmcp::RoleServer>,
     ) -> Result<ReadResourceResult, ErrorData> {
-        let context = self
-            .state
-            .project_log(self.config().clone())
-            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let context = self.state.project_log(self.config().clone());
 
         let uri: ResourceUri = request
             .uri
@@ -433,9 +438,8 @@ impl ServerHandler for EngineToolBox {
                         ErrorData::invalid_params("Missing required argument: agent", None)
                     })?;
 
-                let context = self
-                    .state
-                    .project_log(self.config().clone())
+                let scope = ComposeScope::new(self.config().clone())
+                    .bookmark(self.config().brain.clone(), self.config().bookmark.clone())
                     .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
 
                 let request: DreamAgent = DreamAgent::builder_v1()
@@ -443,10 +447,14 @@ impl ServerHandler for EngineToolBox {
                     .build()
                     .into();
 
-                let response =
-                    ContinuityService::dream(&context, &request, &DreamOverrides::default())
-                        .await
-                        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+                let response = ContinuityService::dream(
+                    &scope,
+                    self.state.mailbox(),
+                    &request,
+                    &DreamOverrides::default(),
+                )
+                .await
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
 
                 match response {
                     ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => {

--- a/crates/oneiros-engine/src/protocol/events.rs
+++ b/crates/oneiros-engine/src/protocol/events.rs
@@ -19,6 +19,13 @@ use crate::*;
 /// JSON preserved for diagnostics. Callers at the load boundary filter
 /// Unknown entries (typically with a warn-level log) so downstream
 /// code only ever handles pure `Events`.
+///
+/// `New` and `Stored` are in-memory-only lifecycle variants used by
+/// the bus. `New(NewEvent)` is a fresh emission travelling toward the
+/// log-append actor; `Stored(StoredEvent)` is the post-append
+/// notification that downstream actors (projection, chronicle) react
+/// to. Both are `#[serde(skip)]` because the bus does not persist
+/// these envelopes — they only exist in transit between actors.
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Event {
@@ -27,6 +34,20 @@ pub enum Event {
     Unknown(UnknownEvent),
     #[default]
     Malformed,
+    /// Boxed: `StoredEvent.data` is itself an `Event`, which would
+    /// recurse without indirection.
+    #[serde(skip)]
+    New(Box<NewEvent>),
+    /// Boxed for the same reason as `New`.
+    #[serde(skip)]
+    Stored(Box<StoredEvent>),
+    /// A foreign `StoredEvent` arriving for ingest into this brain's
+    /// event log — typically from a peer collect or an import. The
+    /// `InboundActor` listens for this variant and is responsible for
+    /// the insert-or-ignore-by-id semantics; downstream actors only
+    /// see `Stored` once ingestion has happened.
+    #[serde(skip)]
+    Import(Box<StoredEvent>),
 }
 
 impl Event {
@@ -36,7 +57,22 @@ impl Event {
             Self::Ephemeral(ephemeral) => ephemeral.kind().to_string(),
             Self::Unknown(_) => "__@unknown".to_string(),
             Self::Malformed => "__@malformed".to_string(),
+            Self::New(new) => new.data.event_type(),
+            Self::Stored(stored) => stored.data.event_type(),
+            Self::Import(imported) => imported.data.event_type(),
         }
+    }
+}
+
+impl From<NewEvent> for Event {
+    fn from(value: NewEvent) -> Self {
+        Self::New(Box::new(value))
+    }
+}
+
+impl From<StoredEvent> for Event {
+    fn from(value: StoredEvent) -> Self {
+        Self::Stored(Box::new(value))
     }
 }
 

--- a/crates/oneiros-engine/src/scope.rs
+++ b/crates/oneiros-engine/src/scope.rs
@@ -69,6 +69,30 @@ pub struct AtBookmark {
 }
 
 // ─────────────────────────────────────────────────────────────────────
+// Capability markers.
+//
+// Each trait says "this scope tier carries enough info to open the
+// resources at <its> tier." DB types take `&impl HasHost` /
+// `&impl HasProject` / `&impl HasBookmark` and ask scope for what
+// they need — scope is shape, db is opening. The hierarchical bounds
+// (`HasProject: HasHost`, `HasBookmark: HasProject`) mean lower tiers
+// can open higher-tier resources for free.
+// ─────────────────────────────────────────────────────────────────────
+
+pub trait HasHost {
+    fn config(&self) -> &Config;
+    fn host(&self) -> &HostInfra;
+}
+
+pub trait HasProject: HasHost {
+    fn project(&self) -> &ProjectInfra;
+}
+
+pub trait HasBookmark: HasProject {
+    fn bookmark(&self) -> &BookmarkInfra;
+}
+
+// ─────────────────────────────────────────────────────────────────────
 // Resource bundles
 //
 // Hold paths and registry data. Never connections — those are per-call
@@ -207,59 +231,38 @@ impl Scope<AtProject> {
 // ─────────────────────────────────────────────────────────────────────
 
 impl Scope<AtHost> {
-    /// Open the system database. Each tier names the DB it touches —
-    /// `host_db` opens system.db, never the bookmark DB.
-    pub async fn host_db(&self) -> Result<HostDb, HostDbError> {
-        HostDb::open(&self.inner.config.platform()).await
-    }
-
     /// Strangler bridge — produce a legacy `HostLog`. Shrinks as
     /// consumers move to use Scope ops directly.
     pub fn host_log(&self) -> HostLog {
         HostLog::new(self.inner.config.clone())
     }
+}
 
-    pub fn config(&self) -> &Config {
+impl HasHost for Scope<AtHost> {
+    fn config(&self) -> &Config {
         &self.inner.config
     }
-    pub fn host(&self) -> &HostInfra {
+    fn host(&self) -> &HostInfra {
         &self.inner.host
     }
 }
 
-impl Scope<AtProject> {
-    /// Open this project's events database.
-    pub async fn events_db(&self) -> Result<EventsDb, EventsDbError> {
-        EventsDb::open(&self.inner.config.platform(), &self.inner.project.name).await
-    }
-
-    pub fn config(&self) -> &Config {
+impl HasHost for Scope<AtProject> {
+    fn config(&self) -> &Config {
         &self.inner.config
     }
-    pub fn host(&self) -> &HostInfra {
+    fn host(&self) -> &HostInfra {
         &self.inner.host
     }
-    pub fn project(&self) -> &ProjectInfra {
+}
+
+impl HasProject for Scope<AtProject> {
+    fn project(&self) -> &ProjectInfra {
         &self.inner.project
     }
 }
 
 impl Scope<AtBookmark> {
-    /// Open the bookmark DB with the events DB ATTACHed.
-    pub async fn bookmark_db(&self) -> Result<BookmarkDb, BookmarkDbError> {
-        BookmarkDb::open(
-            &self.inner.config.platform(),
-            &self.inner.project.name,
-            &self.inner.bookmark.name,
-        )
-        .await
-    }
-
-    /// Open the system DB from the bookmark tier (shared host DB).
-    pub async fn host_db(&self) -> Result<HostDb, HostDbError> {
-        HostDb::open(&self.inner.config.platform()).await
-    }
-
     /// Strangler bridge — produce a legacy `ProjectLog` (CLI-shape).
     /// HTTP construction handles its own behavior state (with_entry)
     /// until the extractor migrates.
@@ -271,17 +274,25 @@ impl Scope<AtBookmark> {
     pub fn host_log(&self) -> HostLog {
         HostLog::new(self.inner.config.clone())
     }
+}
 
-    pub fn config(&self) -> &Config {
+impl HasHost for Scope<AtBookmark> {
+    fn config(&self) -> &Config {
         &self.inner.config
     }
-    pub fn host(&self) -> &HostInfra {
+    fn host(&self) -> &HostInfra {
         &self.inner.host
     }
-    pub fn project(&self) -> &ProjectInfra {
+}
+
+impl HasProject for Scope<AtBookmark> {
+    fn project(&self) -> &ProjectInfra {
         &self.inner.project
     }
-    pub fn bookmark(&self) -> &BookmarkInfra {
+}
+
+impl HasBookmark for Scope<AtBookmark> {
+    fn bookmark(&self) -> &BookmarkInfra {
         &self.inner.bookmark
     }
 }

--- a/crates/oneiros-engine/src/tests/acceptance/cases/cognition.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/cognition.rs
@@ -33,6 +33,53 @@ pub(crate) async fn add_creates_cognition<B: Backend>() -> TestResult {
     Ok(())
 }
 
+/// Vertical slice through the lazy bookmark actor tree: `cognition
+/// add` dispatches a `Message<AtBookmark>` through the bus, the host
+/// actor lazy-spawns the project actor for the brain, the project
+/// actor lazy-spawns bookmark + chronicle actors for the bookmark on
+/// scope, and the projection materializes the row that the service
+/// then fetches eventually-consistently.
+///
+/// The assertion that proves it: the response carries the projected
+/// record, and a follow-up `cognition show` against the projected ID
+/// returns the same record. If the bus didn't reach the bookmark
+/// actor, the projection would be empty and `show` would 404.
+pub(crate) async fn add_dispatches_via_bus<B: Backend>() -> TestResult {
+    let harness = with_agent::<B>().await?;
+
+    let response = harness
+        .exec_json("cognition add thinker.process observation 'bus-routed thought'")
+        .await?;
+
+    let added = match response {
+        Responses::Cognition(CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(
+            added,
+        ))) => added.cognition,
+        other => panic!("expected CognitionAdded, got {other:#?}"),
+    };
+
+    assert_eq!(added.content.as_str(), "bus-routed thought");
+
+    let shown = harness
+        .exec_json(&format!("cognition show {}", added.id))
+        .await?;
+
+    match shown {
+        Responses::Cognition(CognitionResponse::CognitionDetails(
+            CognitionDetailsResponse::V1(details),
+        )) => {
+            assert_eq!(
+                details.cognition.id, added.id,
+                "show must return the projected cognition"
+            );
+            assert_eq!(details.cognition.content.as_str(), "bus-routed thought");
+        }
+        other => panic!("expected CognitionDetails, got {other:#?}"),
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn list_empty<B: Backend>() -> TestResult {
     let harness = with_agent::<B>().await?;
 

--- a/crates/oneiros-engine/src/tests/acceptance/cases/tenant.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/tenant.rs
@@ -1,5 +1,46 @@
 use super::*;
 
+/// First vertical slice through the bus: `tenant create` dispatches the
+/// `TenantCreated` event through the `Mailbox`, the `HostActor` appends
+/// it and applies projections, and the service returns the
+/// eventually-consistent record via `TenantRepo::fetch`.
+///
+/// No phantom state — the returned tenant comes from the projection,
+/// not from synthesised request data.
+pub(crate) async fn create_dispatches_via_bus<B: Backend>() -> TestResult {
+    let harness = Harness::<B>::setup_system().await?;
+
+    let response = harness.exec_json("tenant create acme").await?;
+
+    let tenant = match response {
+        Responses::Tenant(TenantResponse::Created(TenantCreatedResponse::V1(created))) => {
+            created.tenant
+        }
+        other => panic!("expected Tenant(Created), got {other:#?}"),
+    };
+
+    assert_eq!(tenant.name.as_str(), "acme");
+
+    // Verify the eventually-consistent read path also sees the tenant —
+    // this proves it landed in the host db's projection, not just in
+    // the response synthesised at the call site.
+    let listed = harness.exec_json("tenant list").await?;
+    match listed {
+        Responses::Tenant(TenantResponse::Listed(TenantsResponse::V1(tenants))) => {
+            assert!(
+                tenants
+                    .items
+                    .iter()
+                    .any(|t| t.name.as_str() == "acme" && t.id == tenant.id),
+                "tenant list should include the bus-created tenant: {tenants:#?}"
+            );
+        }
+        other => panic!("expected Tenant(Listed), got {other:#?}"),
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn list_after_system_init<B: Backend>() -> TestResult {
     let harness = Harness::<B>::setup_system().await?;
 

--- a/crates/oneiros-engine/src/tests/acceptance/mod.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/mod.rs
@@ -226,6 +226,10 @@ async fn tenant_list_after_system_init() -> TestResult {
 async fn tenant_list_prompt() -> TestResult {
     cases::tenant::list_prompt::<EngineBackend>().await
 }
+#[tokio::test]
+async fn tenant_create_dispatches_via_bus() -> TestResult {
+    cases::tenant::create_dispatches_via_bus::<EngineBackend>().await
+}
 
 // Actor (system-scoped)
 #[tokio::test]
@@ -420,6 +424,10 @@ async fn connection_remove_prompt() -> TestResult {
 #[tokio::test]
 async fn cognition_add() -> TestResult {
     cases::cognition::add_creates_cognition::<EngineBackend>().await
+}
+#[tokio::test]
+async fn cognition_add_dispatches_via_bus() -> TestResult {
+    cases::cognition::add_dispatches_via_bus::<EngineBackend>().await
 }
 #[tokio::test]
 async fn cognition_show_json_includes_ref() -> TestResult {

--- a/crates/oneiros-engine/src/tests/mod.rs
+++ b/crates/oneiros-engine/src/tests/mod.rs
@@ -292,8 +292,10 @@ async fn storage_content_round_trips() {
     // Internal mechanism under test: blob compression round-trip. There is
     // no HTTP route that returns raw blob bytes, so this single call
     // exercises the storage subsystem directly.
-    let context = app.config().project();
-    let retrieved = StorageService::get_content(&context, &StorageKey::new("test.txt"))
+    let scope = ComposeScope::new(app.config().clone())
+        .bookmark(app.config().brain.clone(), app.config().bookmark.clone())
+        .expect("compose bookmark scope");
+    let retrieved = StorageService::get_content(&scope, &StorageKey::new("test.txt"))
         .await
         .expect("get content");
     assert_eq!(retrieved, content);

--- a/crates/oneiros-engine/src/values/fetch.rs
+++ b/crates/oneiros-engine/src/values/fetch.rs
@@ -66,6 +66,33 @@ impl Fetch {
         .await
         .unwrap_or(Ok(None))
     }
+
+    /// Poll a presence-check closure until it returns `Ok(None)` (the
+    /// resource has disappeared) or the patience window expires. The
+    /// remove-side counterpart to [`eventual`]: after dispatching a
+    /// remove event, callers wait here until the projection has caught
+    /// up to the absence, so the response acknowledges actual state
+    /// rather than just receipt.
+    ///
+    /// Returns `Ok(true)` if absence was observed within the window,
+    /// `Ok(false)` if the timeout expired with the resource still
+    /// present, and `Err(_)` if the closure errored.
+    pub async fn until_absent<T, E, F, Fut>(&self, f: F) -> Result<bool, E>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = Result<Option<T>, E>>,
+    {
+        tokio::time::timeout(self.timeout, async {
+            loop {
+                if f().await?.is_none() {
+                    return Ok(true);
+                }
+                tokio::time::sleep(self.interval).await;
+            }
+        })
+        .await
+        .unwrap_or(Ok(false))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
For a long time, we've worked on an attempt to decouple all of the synchronous limbs of our data management story, and work with them purely through an actor setup. Unfortunately, even though we tried to get things into a much better state (and we did!) with the great flattening at the start of April, the actual "emit" concept was much too tangled to really get far with any of the attempts.

This commit represents the furthest we've gotten on the path, and even though it isn't completely there, it is mostly there. We introduce:

- A global mailbox in the server, which things can dispatch messages to.
- Actor style background tasks that lazily come online and handle parts of the system that need to be managed asynchronously.
- An async-by-default setup for most everything, including imports and bookmark distribution.

Anyways, it's comprehensive. It's also pretty decent, and probably easier to refactor from than the previous setup. This is sort of the major piece blocking 0.0.10, so hopefully we can get there now that we've got crossing this one out on the horizon.