### PR TITLE
chore: release v0.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2925,7 +2925,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneiros"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "oneiros-engine",
  "tokio",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "oneiros-engine"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "aide",
  "anstream",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "xtasks"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "clap",
  "oneiros-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.10"
+version = "0.0.11"
 edition = "2024"
 repository = "https://github.com/esmevane/oneiros"
 license = "MIT"
@@ -42,7 +42,7 @@ humantime-serde = "1"
 inquire = "0.9.4"
 iroh = "0.98"
 kinded = "0.5.0"
-oneiros-engine = { path = "crates/oneiros-engine", version = "0.0.10" }
+oneiros-engine = { path = "crates/oneiros-engine", version = "0.0.11" }
 paste = "1"
 pkcs8 = "=0.11.0-rc.10"
 postcard = { version = "1", features = ["alloc"] }

--- a/crates/oneiros-engine/CHANGELOG.md
+++ b/crates/oneiros-engine/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11](https://github.com/esmevane/oneiros/compare/oneiros-engine-v0.0.10...oneiros-engine-v0.0.11) - 2026-05-11
+
+### Other
+
+- Configuration through figment. ([#254](https://github.com/esmevane/oneiros/pull/254))
+- Oh, Clipford. ([#255](https://github.com/esmevane/oneiros/pull/255))
+- CLI doesn't spit out log traces. ([#256](https://github.com/esmevane/oneiros/pull/256))
+- Pub(crate) refactor. ([#251](https://github.com/esmevane/oneiros/pull/251))
+
 ## [0.0.10](https://github.com/esmevane/oneiros/compare/oneiros-engine-v0.0.9...oneiros-engine-v0.0.10) - 2026-05-05
 
 ### Other

--- a/dist/.claude-plugin/plugin.json
+++ b/dist/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "oneiros",
   "description": "Persistent identity and continuity for AI agents",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "author": {
     "name": "JC McCormick",
     "url": "https://github.com/esmevane"

--- a/dist/commands/bookmark-collect.md
+++ b/dist/commands/bookmark-collect.md
@@ -1,0 +1,6 @@
+---
+description: Reconcile a followed bookmark
+argument-hint: <name>
+---
+
+Run `oneiros bookmark collect $ARGUMENTS` to pull events from every source the named bookmark follows. Reconciliation is set-based via chronicle Merkle diff — only the events your brain doesn't already have are transferred.

--- a/dist/commands/bookmark-follow.md
+++ b/dist/commands/bookmark-follow.md
@@ -1,0 +1,8 @@
+---
+description: Follow a remote bookmark
+argument-hint: <uri> --name <name>
+---
+
+Run `oneiros bookmark follow $ARGUMENTS` to subscribe to a remote bookmark, identified by its URI, under the local `--name`.
+
+Following creates a follow record but does not move events on its own — use `bookmark collect` to reconcile.

--- a/dist/commands/bookmark-share.md
+++ b/dist/commands/bookmark-share.md
@@ -1,0 +1,8 @@
+---
+description: Share a bookmark for others to follow
+argument-hint: <name> [--actor-id <id>]
+---
+
+Run `oneiros bookmark share $ARGUMENTS` to make a bookmark available for other actors to follow. An optional `--actor-id` scopes the share to a single actor.
+
+A bookmark defines a view of the canon. Sharing publishes the chronicle root so peers can follow and reconcile against it.

--- a/dist/commands/bookmark-unfollow.md
+++ b/dist/commands/bookmark-unfollow.md
@@ -1,0 +1,6 @@
+---
+description: Stop following a bookmark
+argument-hint: <name>
+---
+
+Run `oneiros bookmark unfollow $ARGUMENTS` to remove the follow record for a bookmark. Already-collected events stay in the canon — only the subscription stops.

--- a/dist/commands/dream.md
+++ b/dist/commands/dream.md
@@ -3,6 +3,6 @@ description: "Restore an agent's full identity and cognitive context"
 argument-hint: <agent-name>
 ---
 
-Run `oneiros dream $ARGUMENTS` to compose the named agent's full cognitive context. This assembles identity, persona prompt, textures, levels, cognitions, and memories into a single prompt that restores the agent's state.
+Run `oneiros continuity dream $ARGUMENTS` to compose the named agent's full cognitive context. This assembles identity, persona prompt, textures, levels, cognitions, and memories into a single prompt that restores the agent's state.
 
 Use at session start or when an agent needs to reload its full context. The output is the assembled dream prompt text.

--- a/dist/commands/emerge.md
+++ b/dist/commands/emerge.md
@@ -3,6 +3,6 @@ description: Bring a new agent into existence with full ceremony
 argument-hint: "<name> <persona> [--description <text>] [--prompt <text>]"
 ---
 
-Run `oneiros emerge $ARGUMENTS` to create a new agent with the given name and persona. This records an emergence lifecycle event and creates the agent.
+Run `oneiros continuity emerge $ARGUMENTS` to create a new agent with the given name and persona. This records an emergence lifecycle event and creates the agent.
 
 The persona must exist first. Use `--description` for a brief agent description and `--prompt` for the agent's behavioral identity prompt.

--- a/dist/commands/follow-get.md
+++ b/dist/commands/follow-get.md
@@ -1,0 +1,6 @@
+---
+description: Look up a follow record
+argument-hint: <key>
+---
+
+Run `oneiros follow get $ARGUMENTS` to inspect a single follow record. Shows the followed bookmark, source peer, and the latest collected position.

--- a/dist/commands/follow-list.md
+++ b/dist/commands/follow-list.md
@@ -1,0 +1,7 @@
+---
+description: List all follow records
+---
+
+Run `oneiros follow list` to see every follow this brain holds — bookmark, source peer, and the latest collected position. Use `--limit` and `--offset` to paginate.
+
+Follow records are the active subscriptions — bookmarks this brain pulls events from when you `bookmark collect`.

--- a/dist/commands/guidebook.md
+++ b/dist/commands/guidebook.md
@@ -3,6 +3,6 @@ description: "Read the cognitive guidebook — learn how your tools work"
 argument-hint: <agent-name>
 ---
 
-Run `oneiros guidebook $ARGUMENTS` to produce a cognitive guidebook for the named agent. The guidebook explains how to use the oneiros cognitive system: recording cognitions, storing memories, the agent lifecycle, and how to extend the system by creating new textures, levels, and agents.
+Run `oneiros continuity guidebook $ARGUMENTS` to produce a cognitive guidebook for the named agent. The guidebook explains how to use the oneiros cognitive system: recording cognitions, storing memories, the agent lifecycle, and how to extend the system by creating new textures, levels, and agents.
 
 Use after dreaming, or whenever you need a reference for how the cognitive tools work.

--- a/dist/commands/introspect.md
+++ b/dist/commands/introspect.md
@@ -3,6 +3,6 @@ description: "Look inward before context compacts — consolidate what matters"
 argument-hint: <agent-name>
 ---
 
-Run `oneiros introspect $ARGUMENTS` to generate a session summary for the named agent. This captures the current session's key events and decisions before context compaction occurs.
+Run `oneiros continuity introspect $ARGUMENTS` to generate a session summary for the named agent. This captures the current session's key events and decisions before context compaction occurs.
 
 Use before context compaction to preserve session continuity. The output is an introspection prompt that should be processed to generate a summary cognition.

--- a/dist/commands/peer-add.md
+++ b/dist/commands/peer-add.md
@@ -1,0 +1,8 @@
+---
+description: Register a peer for distribution
+argument-hint: <address> [--name <name>]
+---
+
+Run `oneiros peer add $ARGUMENTS` to register a peer at the given network address. An optional `--name` provides a human-readable label.
+
+Peers are the other hosts your brain can exchange events with. Adding a peer doesn't move data on its own — it makes the peer available for follow/collect.

--- a/dist/commands/peer-get.md
+++ b/dist/commands/peer-get.md
@@ -1,0 +1,6 @@
+---
+description: Look up a peer by id or name
+argument-hint: <key>
+---
+
+Run `oneiros peer get $ARGUMENTS` to look up a single peer by its id or name. Shows the peer's address, identity, and any local metadata.

--- a/dist/commands/peer-list.md
+++ b/dist/commands/peer-list.md
@@ -1,0 +1,5 @@
+---
+description: List all registered peers
+---
+
+Run `oneiros peer list` to see every peer this brain knows about. Use `--limit` and `--offset` to paginate.

--- a/dist/commands/peer-remove.md
+++ b/dist/commands/peer-remove.md
@@ -1,0 +1,6 @@
+---
+description: Remove a peer
+argument-hint: <id>
+---
+
+Run `oneiros peer remove $ARGUMENTS` to forget a peer. Existing follow records that reference the peer become unreachable.

--- a/dist/commands/recede.md
+++ b/dist/commands/recede.md
@@ -3,6 +3,6 @@ description: "Retire an agent — honor their contributions and let them go"
 argument-hint: <agent-name>
 ---
 
-Run `oneiros recede $ARGUMENTS` to retire the named agent. This records a recede lifecycle event and removes the agent from the brain.
+Run `oneiros continuity recede $ARGUMENTS` to retire the named agent. This records a recede lifecycle event and removes the agent from the brain.
 
 Recede is permanent — the agent's cognitive records remain but the agent itself is removed.

--- a/dist/commands/reflect.md
+++ b/dist/commands/reflect.md
@@ -3,6 +3,6 @@ description: Pause on something significant
 argument-hint: <agent-name>
 ---
 
-Run `oneiros reflect $ARGUMENTS` to capture a significant moment for the named agent. Use for breakthroughs, important decisions, architectural insights, or other events worth preserving.
+Run `oneiros continuity reflect $ARGUMENTS` to capture a significant moment for the named agent. Use for breakthroughs, important decisions, architectural insights, or other events worth preserving.
 
 The output is a reflection prompt. Process it to generate a cognition that records the significant event.

--- a/dist/commands/sense.md
+++ b/dist/commands/sense.md
@@ -3,6 +3,6 @@ description: Receive and interpret something from outside your cognitive loop
 argument-hint: <agent-name>
 ---
 
-Run `oneiros sense $ARGUMENTS` to sense an observation as the named agent. Pipe event data via stdin for the agent to interpret, or run without stdin for a general observation prompt.
+Run `oneiros continuity sense $ARGUMENTS` to sense an observation as the named agent. Pipe event data via stdin for the agent to interpret, or run without stdin for a general observation prompt.
 
 The output is a sense template. Process it to interpret the event and record significant observations as cognitions or experiences.

--- a/dist/commands/sleep.md
+++ b/dist/commands/sleep.md
@@ -3,6 +3,6 @@ description: "End a session — capture continuity before resting"
 argument-hint: <agent-name>
 ---
 
-Run `oneiros sleep $ARGUMENTS` to put the named agent to sleep. This records a lifecycle event and produces an introspection prompt for session summary.
+Run `oneiros continuity sleep $ARGUMENTS` to put the named agent to sleep. This records a lifecycle event and produces an introspection prompt for session summary.
 
 Sleep is the session exit point — it marks the agent as dormant and generates the introspection template that captures session continuity.

--- a/dist/commands/status.md
+++ b/dist/commands/status.md
@@ -3,6 +3,6 @@ description: "See an agent's full cognitive dashboard"
 argument-hint: <agent-name>
 ---
 
-Run `oneiros status $ARGUMENTS` to see a comprehensive cognitive dashboard for the named agent. Shows cognition, memory, and experience counts grouped by texture, level, and sensation.
+Run `oneiros continuity status $ARGUMENTS` to see a comprehensive cognitive dashboard for the named agent. Shows cognition, memory, and experience counts grouped by texture, level, and sensation.
 
-For a quick cross-agent overview, use `oneiros activity status` instead.
+For a quick cross-agent overview, use `oneiros continuity status` instead.

--- a/dist/commands/storage-get.md
+++ b/dist/commands/storage-get.md
@@ -1,0 +1,8 @@
+---
+description: Download a stored artifact's raw bytes
+argument-hint: <key> [--out <path>]
+---
+
+Run `oneiros storage get $ARGUMENTS` to download the raw bytes for a stored key. Writes to `--out` when provided, otherwise to stdout.
+
+Use `storage show` for the metadata view; `storage get` is the bytes-only path for piping or saving to disk.

--- a/dist/commands/wake.md
+++ b/dist/commands/wake.md
@@ -3,6 +3,6 @@ description: "Wake an agent — restore identity and begin a session"
 argument-hint: <agent-name>
 ---
 
-Run `oneiros wake $ARGUMENTS` to wake the named agent. This records a lifecycle event and assembles the agent's full dream context.
+Run `oneiros continuity wake $ARGUMENTS` to wake the named agent. This records a lifecycle event and assembles the agent's full dream context.
 
 Wake is the session entry point — it marks the agent as active and produces the dream prompt that restores identity and cognitive state.

--- a/dist/skills/oneiros/SKILL.md
+++ b/dist/skills/oneiros/SKILL.md
@@ -10,7 +10,7 @@ compatibility: Requires oneiros CLI tool or MCP access, and an initialized oneir
 allowed-tools: Read Bash(oneiros:*)
 license: "MIT"
 metadata:
-  version: "0.0.10"
+  version: "0.0.11"
   author: "JC McCormick <https://github.com/esmevane>"
 ---
 


### PR DESCRIPTION



## 🤖 New release

* `oneiros-engine`: 0.0.10 -> 0.0.11 (✓ API compatible changes)
* `oneiros`: 0.0.10 -> 0.0.11

<details><summary><i><b>Changelog</b></i></summary><p>

## `oneiros-engine`

<blockquote>

## [0.0.11](https://github.com/esmevane/oneiros/compare/oneiros-engine-v0.0.10...oneiros-engine-v0.0.11) - 2026-05-11

### Other

- Configuration through figment. ([#254](https://github.com/esmevane/oneiros/pull/254))
- Oh, Clipford. ([#255](https://github.com/esmevane/oneiros/pull/255))
- CLI doesn't spit out log traces. ([#256](https://github.com/esmevane/oneiros/pull/256))
- Pub(crate) refactor. ([#251](https://github.com/esmevane/oneiros/pull/251))
</blockquote>

## `oneiros`

<blockquote>

## [0.0.10](https://github.com/esmevane/oneiros/compare/v0.0.9...v0.0.10) - 2026-05-05

### Other

- Structured errors.
- Move bin code into engine.
- Viewable resources.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).