### PR TITLE
Configuration through figment.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "unicode-ident",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -253,6 +253,15 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -471,6 +480,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -1258,6 +1273,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "tempfile",
+ "toml 0.8.23",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +2031,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inout"
@@ -2909,6 +2946,7 @@ dependencies = [
  "data-encoding",
  "der",
  "etcetera",
+ "figment",
  "flate2",
  "futures",
  "humantime",
@@ -2933,7 +2971,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tower",
  "tower-http",
  "tracing",
@@ -3004,6 +3042,29 @@ name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -3228,7 +3289,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3238,6 +3299,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -3875,6 +3949,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -4411,17 +4494,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.0",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4435,14 +4539,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -4451,8 +4569,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -4606,6 +4730,15 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -5337,6 +5470,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ data-encoding = "2"
 # three pins together when ed25519 ships a release targeting current pkcs8.
 der = "=0.8.0-rc.10"
 etcetera = "0.11.0"
+figment = { version = "0.10", features = ["toml", "env"] }
 flate2 = "1"
 futures = "0.3"
 humantime = "2"

--- a/crates/oneiros-engine/Cargo.toml
+++ b/crates/oneiros-engine/Cargo.toml
@@ -18,6 +18,7 @@ clap.workspace = true
 data-encoding.workspace = true
 der.workspace = true
 etcetera.workspace = true
+figment.workspace = true
 flate2.workspace = true
 humantime.workspace = true
 humantime-serde.workspace = true
@@ -47,6 +48,7 @@ tracing-subscriber.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+figment = { workspace = true, features = ["test"] }
 futures.workspace = true
 pretty_assertions.workspace = true
 shlex.workspace = true

--- a/crates/oneiros-engine/src/cli.rs
+++ b/crates/oneiros-engine/src/cli.rs
@@ -10,26 +10,22 @@ use crate::*;
 
 /// Top-level CLI entry point for the engine.
 ///
-/// Carries the global `--output` flag and delegates to `Command` for dispatch.
-/// No binary entrypoint required — tests and future binaries construct this directly.
+/// Carries global flags (via [`CliOverrides`]) and delegates to
+/// [`Command`] for dispatch. No binary entrypoint required — tests
+/// and future binaries construct this directly.
 #[derive(Debug, Parser)]
 #[command(name = "oneiros", version)]
 pub(crate) struct Cli {
     #[command(subcommand)]
     pub(crate) command: Command,
     #[command(flatten)]
-    config: Config,
+    pub(crate) overrides: CliOverrides,
 }
 
 impl Cli {
     /// Execute the command and return the rendered result.
     pub(crate) async fn execute(&self, config: &Config) -> Result<Rendered<Responses>, Error> {
         self.command.execute(config).await
-    }
-
-    /// The parsed config (from CLI flags).
-    pub(crate) fn config(&self) -> &Config {
-        &self.config
     }
 }
 

--- a/crates/oneiros-engine/src/config.rs
+++ b/crates/oneiros-engine/src/config.rs
@@ -1,5 +1,9 @@
 use bon::Builder;
-use clap::Parser;
+use clap::{Args, Parser};
+use figment::{
+    Figment,
+    providers::{Env, Format, Serialized, Toml},
+};
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, path::PathBuf};
 
@@ -20,47 +24,212 @@ fn default_data_dir() -> PathBuf {
     Platform::default().data_dir().to_path_buf()
 }
 
+// ── CLI Override Types ─────────────────────────────────────────────
+
+/// CLI overrides for service configuration.
+///
+/// Every field is optional — only `Some` values override the resolved
+/// configuration. Flattened into [`CliOverrides`] so flags appear at
+/// the top level (e.g. `--address`, not `--service-address`).
+#[derive(Args, Debug, Clone, Serialize, Default)]
+pub(crate) struct ServiceCli {
+    /// The service label for OS registration.
+    #[arg(long, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) label: Option<String>,
+    /// Address the service listens on.
+    #[arg(long, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) address: Option<SocketAddr>,
+    /// Health check retry delays after starting (milliseconds).
+    #[arg(skip)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) health_check_delays_ms: Option<Vec<u64>>,
+    /// Restart delay on failure (seconds).
+    #[arg(long, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) restart_delay_secs: Option<u32>,
+}
+
+/// CLI overrides for dream assembly configuration.
+///
+/// Every field is optional — only `Some` values override the resolved
+/// configuration. Flattened into [`CliOverrides`] so flags appear at
+/// the top level (e.g. `--cognition-size`, not `--dream-cognition-size`).
+#[derive(Args, Debug, Clone, Serialize, Default)]
+pub(crate) struct DreamCli {
+    /// Number of recent cognitions and experiences in the orientation window.
+    #[arg(long, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) recent_window: Option<usize>,
+    /// Maximum BFS traversal depth from the seed set.
+    #[arg(long, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) dream_depth: Option<usize>,
+    /// Maximum number of cognitions in the dream.
+    #[arg(long, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) cognition_size: Option<usize>,
+    /// Minimum memory level to include (log-level semantics).
+    #[arg(long, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) recollection_level: Option<LevelName>,
+    /// Maximum number of non-core memories in the dream.
+    #[arg(long, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) recollection_size: Option<usize>,
+    /// Maximum number of experiences in the dream.
+    #[arg(long, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) experience_size: Option<usize>,
+}
+
+/// CLI overrides for fetch/polling configuration.
+///
+/// Every field is optional — only `Some` values override the resolved
+/// configuration. Flattened into [`CliOverrides`] so flags appear at
+/// the top level (e.g. `--interval`, not `--fetch-interval`).
+#[derive(Args, Debug, Clone, Serialize, Default)]
+pub(crate) struct FetchCli {
+    /// How often to poll while waiting for an eventually-consistent read.
+    #[arg(long, global = true, value_parser = humantime::parse_duration)]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_duration_option"
+    )]
+    pub(crate) interval: Option<std::time::Duration>,
+    /// Maximum time to wait before giving up.
+    #[arg(long, global = true, value_parser = humantime::parse_duration)]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_duration_option"
+    )]
+    pub(crate) timeout: Option<std::time::Duration>,
+}
+
+/// Serialize an `Option<Duration>` as a humantime string for Figment.
+fn serialize_duration_option<S: serde::Serializer>(
+    value: &Option<std::time::Duration>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match value {
+        Some(d) => serializer.serialize_str(&humantime::format_duration(*d).to_string()),
+        None => serializer.serialize_none(),
+    }
+}
+
+/// CLI overrides — captures only explicitly-set flags.
+///
+/// Fields are `Option<T>`: `None` means "not set on CLI", `Some` means
+/// "user explicitly provided this value". Figment layers these on top
+/// of defaults, config file, and env vars, so CLI always wins.
+///
+/// This struct replaces `Config`'s former dual role as both CLI parser
+/// and resolved configuration. The separation fixes the long-standing
+/// "can't distinguish user default from clap default" limitation.
+#[derive(Parser, Debug, Clone, Serialize, Default)]
+pub(crate) struct CliOverrides {
+    /// Root directory for brain data.
+    #[arg(long, short, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) data_dir: Option<PathBuf>,
+    /// The brain (project) name.
+    #[arg(long, short, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) brain: Option<BrainName>,
+    /// The bookmark (lens) to operate through.
+    #[arg(long, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) bookmark: Option<BookmarkName>,
+    /// Service management configuration overrides.
+    #[command(flatten)]
+    #[serde(skip_serializing_if = "ServiceCli::is_empty")]
+    pub(crate) service: ServiceCli,
+    /// Dream assembly configuration overrides.
+    #[command(flatten)]
+    #[serde(skip_serializing_if = "DreamCli::is_empty")]
+    pub(crate) dream: DreamCli,
+    /// Fetch/polling configuration overrides.
+    #[command(flatten)]
+    #[serde(skip_serializing_if = "FetchCli::is_empty")]
+    pub(crate) fetch: FetchCli,
+    /// Output format: prompt, json, or text.
+    #[arg(long, short, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) output: Option<OutputMode>,
+    /// When to use colored output: auto, always, or never.
+    #[arg(long, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) color: Option<ColorChoice>,
+    /// How much detail to show: quiet, normal, or verbose.
+    #[arg(long, global = true)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) verbosity: Option<Verbosity>,
+}
+
+impl ServiceCli {
+    fn is_empty(&self) -> bool {
+        self.label.is_none()
+            && self.address.is_none()
+            && self.health_check_delays_ms.is_none()
+            && self.restart_delay_secs.is_none()
+    }
+}
+
+impl DreamCli {
+    fn is_empty(&self) -> bool {
+        self.recent_window.is_none()
+            && self.dream_depth.is_none()
+            && self.cognition_size.is_none()
+            && self.recollection_level.is_none()
+            && self.recollection_size.is_none()
+            && self.experience_size.is_none()
+    }
+}
+
+impl FetchCli {
+    fn is_empty(&self) -> bool {
+        self.interval.is_none() && self.timeout.is_none()
+    }
+}
+
+// ── Resolved Configuration ────────────────────────────────────────
+
 /// Configuration for the engine.
 ///
 /// Carries paths, service address, and tuning knobs. Shared between
 /// Server (which binds to the address) and Client (which connects to it).
-#[derive(Builder, Debug, Clone, Parser, Serialize, Deserialize)]
+///
+/// Constructed via [`Config::builder()`] (for tests and programmatic use)
+/// or [`Config::resolve()`] (from CLI, config file, and env vars).
+#[derive(Builder, Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub(crate) struct Config {
     /// Root directory for brain data (blobs, exports, etc.)
-    #[arg(long, short, global = true, default_value_os_t = default_data_dir())]
     #[builder(default = default_data_dir())]
     pub(crate) data_dir: PathBuf,
     /// The brain (project) name. Auto-detected from cwd if not specified.
-    #[arg(long, short, global = true, default_value_t = detect_brain_name())]
     #[builder(into, default = detect_brain_name())]
     pub(crate) brain: BrainName,
     /// The bookmark (lens) to operate through. Defaults to main.
-    #[arg(long, global = true, default_value_t = BookmarkName::main())]
     #[builder(into, default = BookmarkName::main())]
     pub(crate) bookmark: BookmarkName,
     /// Service management configuration.
-    #[command(flatten)]
     #[builder(default)]
     pub(crate) service: ServiceConfig,
     /// Default dream assembly configuration.
-    #[command(flatten)]
     #[builder(default)]
     pub(crate) dream: DreamConfig,
     /// Default patience window for eventually-consistent reads.
-    #[command(flatten)]
     #[builder(default)]
     pub(crate) fetch: Fetch,
     /// Output format: prompt (default), json, or text.
-    #[arg(long, short, default_value_t, global = true)]
     #[builder(default)]
     pub(crate) output: OutputMode,
     /// When to use colored output: auto (default), always, or never.
-    #[arg(long, default_value_t, global = true)]
     #[builder(default)]
     pub(crate) color: ColorChoice,
     /// How much detail to show: quiet, normal (default), or verbose.
-    #[arg(long, default_value_t, global = true)]
     #[builder(default)]
     pub(crate) verbosity: Verbosity,
 }
@@ -151,105 +320,79 @@ impl Config {
             .map(|s| Token::from(s.trim()))
     }
 
-    /// Load a config file from `{data_dir}/config.toml` and merge
-    /// file values under CLI values.
+    /// Resolve configuration from layered sources.
     ///
-    /// File values provide the base; CLI-provided values override them.
-    /// If no file exists or is empty, returns self unchanged.
-    pub(crate) fn with_config_file(mut self) -> Self {
-        let platform = self.platform();
+    /// Merges in priority order (lowest to highest):
+    ///
+    /// 1. Rust hardcoded defaults ([`Config::default`])
+    /// 2. `{data_dir}/config.toml`
+    /// 3. `ONEIROS_`-prefixed environment variables (double-underscore
+    ///    separates nested keys, e.g. `ONEIROS_SERVICE__ADDRESS`)
+    /// 4. CLI flags from `overrides` — only `Some` fields apply
+    ///
+    /// If the config file is missing or empty, defaults carry through.
+    /// Malformed files produce a warning on stderr and are ignored.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`figment::Error`] if the assembled configuration fails
+    /// to deserialize into [`Config`] (type mismatches, missing required
+    /// fields, etc.).
+    ///
+    /// `figment::Error` is large (~200 bytes); the `#[allow]` avoids
+    /// the `clippy::result_large_err` lint since boxing would break
+    /// the caller ergonomics.
+    #[allow(clippy::result_large_err)]
+    pub(crate) fn resolve(overrides: &CliOverrides) -> Result<Self, figment::Error> {
+        let data_dir = overrides.data_dir.clone().unwrap_or_else(default_data_dir);
+        let config_path = Platform::new(&data_dir).config_path();
 
-        let file_config = match platform.read_to_string(platform.config_path()) {
-            Ok(contents) if !contents.trim().is_empty() => {
-                match toml::from_str::<Config>(&contents) {
-                    Ok(config) => config,
-                    Err(err) => {
-                        eprintln!(
-                            "warning: ignoring malformed config file {}: {err}",
-                            platform.config_path().display()
-                        );
-                        return self;
-                    }
+        let defaults = Config::builder().data_dir(data_dir).build();
+
+        let figment = Figment::new()
+            .merge(Serialized::defaults(defaults.clone()))
+            .merge(Toml::file(&config_path))
+            .merge(Env::prefixed("ONEIROS_").split("__"))
+            .merge(Serialized::defaults(overrides));
+
+        match figment.extract::<Self>() {
+            Ok(config) => Ok(config),
+            Err(err) => {
+                let is_toml_syntax_error = matches!(&err.kind, figment::error::Kind::Message(msg)
+                    if msg.contains("parse error") || msg.contains("expected"));
+                let from_toml = err
+                    .metadata
+                    .as_ref()
+                    .is_some_and(|m| m.name.contains("TOML"));
+                let path_exists = config_path.exists();
+
+                if is_toml_syntax_error && from_toml && path_exists {
+                    eprintln!(
+                        "warning: ignoring malformed config file {}: {err}",
+                        config_path.display()
+                    );
+                    // Retry without the file provider, using the same defaults
+                    Figment::new()
+                        .merge(Serialized::defaults(defaults))
+                        .merge(Env::prefixed("ONEIROS_").split("__"))
+                        .merge(Serialized::defaults(overrides))
+                        .extract()
+                } else {
+                    Err(err)
                 }
             }
-            _ => return self,
-        };
-
-        let defaults = Config::default();
-
-        // Merge: if the CLI value matches the default, take the file value.
-        // This heuristic cannot distinguish "user explicitly passed the default"
-        // from "default was used" — a known limitation until we adopt figment.
-
-        // Top-level
-        if self.data_dir == defaults.data_dir {
-            self.data_dir = file_config.data_dir;
         }
-        if self.brain == defaults.brain {
-            self.brain = file_config.brain;
-        }
-        if self.bookmark == defaults.bookmark {
-            self.bookmark = file_config.bookmark;
-        }
-        if self.output == defaults.output {
-            self.output = file_config.output;
-        }
-        if self.color == defaults.color {
-            self.color = file_config.color;
-        }
-        if self.verbosity == defaults.verbosity {
-            self.verbosity = file_config.verbosity;
-        }
-
-        // Service
-        if self.service.address == defaults.service.address {
-            self.service.address = file_config.service.address;
-        }
-        if self.service.label == defaults.service.label {
-            self.service.label = file_config.service.label;
-        }
-        if self.service.restart_delay_secs == defaults.service.restart_delay_secs {
-            self.service.restart_delay_secs = file_config.service.restart_delay_secs;
-        }
-        if self.service.health_check_delays_ms == defaults.service.health_check_delays_ms {
-            self.service.health_check_delays_ms = file_config.service.health_check_delays_ms;
-        }
-
-        // Dream
-        if self.dream.recent_window == defaults.dream.recent_window {
-            self.dream.recent_window = file_config.dream.recent_window;
-        }
-        if self.dream.dream_depth == defaults.dream.dream_depth {
-            self.dream.dream_depth = file_config.dream.dream_depth;
-        }
-        if self.dream.cognition_size == defaults.dream.cognition_size {
-            self.dream.cognition_size = file_config.dream.cognition_size;
-        }
-        if self.dream.recollection_level == defaults.dream.recollection_level {
-            self.dream.recollection_level = file_config.dream.recollection_level;
-        }
-        if self.dream.recollection_size == defaults.dream.recollection_size {
-            self.dream.recollection_size = file_config.dream.recollection_size;
-        }
-        if self.dream.experience_size == defaults.dream.experience_size {
-            self.dream.experience_size = file_config.dream.experience_size;
-        }
-
-        // Fetch
-        if self.fetch.interval == defaults.fetch.interval {
-            self.fetch.interval = file_config.fetch.interval;
-        }
-        if self.fetch.timeout == defaults.fetch.timeout {
-            self.fetch.timeout = file_config.fetch.timeout;
-        }
-
-        self
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build overrides with everything at default (all `None`).
+    fn empty_overrides() -> CliOverrides {
+        CliOverrides::default()
+    }
 
     /// Build a Config pointing at a tempdir for isolated file tests.
     fn config_in(dir: &std::path::Path) -> Config {
@@ -265,35 +408,44 @@ mod tests {
         platform.write(platform.config_path(), contents).unwrap();
     }
 
-    #[test]
-    fn missing_file_returns_config_unchanged() {
-        let dir = tempfile::tempdir().unwrap();
-        let config = config_in(dir.path());
-        let merged = config.clone().with_config_file();
-
-        assert_eq!(merged.service.address, config.service.address);
-        assert_eq!(merged.dream.cognition_size, config.dream.cognition_size);
-        assert_eq!(merged.output, config.output);
+    /// Resolve with explicit overrides, setting data_dir from the dir.
+    fn resolve_in(dir: &std::path::Path, overrides: &CliOverrides) -> Config {
+        let mut ov = overrides.clone();
+        if ov.data_dir.is_none() {
+            ov.data_dir = Some(dir.to_path_buf());
+        }
+        Config::resolve(&ov).expect("config resolution should succeed")
     }
 
     #[test]
-    fn empty_file_returns_config_unchanged() {
+    fn missing_file_returns_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = resolve_in(dir.path(), &empty_overrides());
+
+        let expected = config_in(dir.path());
+        assert_eq!(config.service.address, expected.service.address);
+        assert_eq!(config.dream.cognition_size, expected.dream.cognition_size);
+        assert_eq!(config.output, expected.output);
+    }
+
+    #[test]
+    fn empty_file_returns_defaults() {
         let dir = tempfile::tempdir().unwrap();
         write_config(dir.path(), "");
-        let config = config_in(dir.path());
-        let merged = config.clone().with_config_file();
+        let config = resolve_in(dir.path(), &empty_overrides());
 
-        assert_eq!(merged.service.address, config.service.address);
+        let expected = config_in(dir.path());
+        assert_eq!(config.service.address, expected.service.address);
     }
 
     #[test]
-    fn malformed_file_returns_config_unchanged() {
+    fn malformed_file_falls_back_to_defaults() {
         let dir = tempfile::tempdir().unwrap();
         write_config(dir.path(), "this is not valid toml {{{{");
-        let config = config_in(dir.path());
-        let merged = config.clone().with_config_file();
+        let config = resolve_in(dir.path(), &empty_overrides());
 
-        assert_eq!(merged.service.address, config.service.address);
+        let expected = config_in(dir.path());
+        assert_eq!(config.service.address, expected.service.address);
     }
 
     #[test]
@@ -306,11 +458,10 @@ mod tests {
 address = "127.0.0.1:3000"
 "#,
         );
-        let config = config_in(dir.path());
-        let merged = config.with_config_file();
+        let config = resolve_in(dir.path(), &empty_overrides());
 
         assert_eq!(
-            merged.service.address,
+            config.service.address,
             "127.0.0.1:3000".parse::<SocketAddr>().unwrap()
         );
     }
@@ -326,11 +477,10 @@ interval = "50ms"
 timeout = "5s"
 "#,
         );
-        let config = config_in(dir.path());
-        let merged = config.with_config_file();
+        let config = resolve_in(dir.path(), &empty_overrides());
 
-        assert_eq!(merged.fetch.interval, std::time::Duration::from_millis(50));
-        assert_eq!(merged.fetch.timeout, std::time::Duration::from_secs(5));
+        assert_eq!(config.fetch.interval, std::time::Duration::from_millis(50));
+        assert_eq!(config.fetch.timeout, std::time::Duration::from_secs(5));
     }
 
     #[test]
@@ -344,18 +494,17 @@ cognition_size = 50
 dream_depth = 3
 "#,
         );
-        let config = config_in(dir.path());
-        let merged = config.with_config_file();
+        let config = resolve_in(dir.path(), &empty_overrides());
 
-        assert_eq!(merged.dream.cognition_size, 50);
-        assert_eq!(merged.dream.dream_depth, 3);
+        assert_eq!(config.dream.cognition_size, 50);
+        assert_eq!(config.dream.dream_depth, 3);
         // Unspecified fields keep their defaults
-        assert_eq!(merged.dream.recent_window, 5);
-        assert_eq!(merged.dream.recollection_size, 30);
+        assert_eq!(config.dream.recent_window, 5);
+        assert_eq!(config.dream.recollection_size, 30);
     }
 
     #[test]
-    fn cli_override_survives_file_merge() {
+    fn cli_overrides_file_and_defaults() {
         let dir = tempfile::tempdir().unwrap();
         write_config(
             dir.path(),
@@ -367,29 +516,65 @@ address = "127.0.0.1:3000"
 cognition_size = 50
 "#,
         );
-        let mut config = config_in(dir.path());
-        // Simulate CLI setting a non-default value
-        config.service.address = "127.0.0.1:9999".parse().unwrap();
-        config.dream.cognition_size = 5;
 
-        let merged = config.with_config_file();
+        let overrides = CliOverrides {
+            service: ServiceCli {
+                address: Some("127.0.0.1:9999".parse().unwrap()),
+                ..Default::default()
+            },
+            dream: DreamCli {
+                cognition_size: Some(5),
+                ..Default::default()
+            },
+            data_dir: Some(dir.path().to_path_buf()),
+            ..Default::default()
+        };
 
-        // CLI values survive — they differ from defaults
+        let config = Config::resolve(&overrides).expect("resolve should succeed");
+
+        // CLI values win over file
         assert_eq!(
-            merged.service.address,
+            config.service.address,
             "127.0.0.1:9999".parse::<SocketAddr>().unwrap()
         );
-        assert_eq!(merged.dream.cognition_size, 5);
+        assert_eq!(config.dream.cognition_size, 5);
+    }
+
+    #[test]
+    fn partial_cli_overrides_let_file_values_through() {
+        let dir = tempfile::tempdir().unwrap();
+        write_config(
+            dir.path(),
+            r#"
+[dream]
+cognition_size = 50
+dream_depth = 3
+"#,
+        );
+
+        // Only set cognition_size via CLI — dream_depth should come from file
+        let overrides = CliOverrides {
+            dream: DreamCli {
+                cognition_size: Some(5),
+                ..Default::default()
+            },
+            data_dir: Some(dir.path().to_path_buf()),
+            ..Default::default()
+        };
+
+        let config = Config::resolve(&overrides).expect("resolve should succeed");
+
+        assert_eq!(config.dream.cognition_size, 5); // CLI
+        assert_eq!(config.dream.dream_depth, 3); // from file
     }
 
     #[test]
     fn file_overrides_output_mode() {
         let dir = tempfile::tempdir().unwrap();
         write_config(dir.path(), r#"output = "json""#);
-        let config = config_in(dir.path());
-        let merged = config.with_config_file();
+        let config = resolve_in(dir.path(), &empty_overrides());
 
-        assert_eq!(merged.output, OutputMode::Json);
+        assert_eq!(config.output, OutputMode::Json);
     }
 
     #[test]
@@ -402,10 +587,9 @@ cognition_size = 50
 health_check_delays_ms = [100, 200]
 "#,
         );
-        let config = config_in(dir.path());
-        let merged = config.with_config_file();
+        let config = resolve_in(dir.path(), &empty_overrides());
 
-        assert_eq!(merged.service.health_check_delays_ms, vec![100, 200]);
+        assert_eq!(config.service.health_check_delays_ms, vec![100, 200]);
     }
 
     #[test]
@@ -418,32 +602,29 @@ health_check_delays_ms = [100, 200]
 experience_size = 25
 "#,
         );
-        let config = config_in(dir.path());
-        let merged = config.with_config_file();
+        let config = resolve_in(dir.path(), &empty_overrides());
 
-        assert_eq!(merged.dream.experience_size, 25);
-        assert_eq!(merged.dream.cognition_size, 20); // default preserved
-        assert_eq!(merged.dream.dream_depth, 1); // default preserved
+        assert_eq!(config.dream.experience_size, 25);
+        assert_eq!(config.dream.cognition_size, 20); // default preserved
+        assert_eq!(config.dream.dream_depth, 1); // default preserved
     }
 
     #[test]
     fn file_overrides_color_choice() {
         let dir = tempfile::tempdir().unwrap();
         write_config(dir.path(), r#"color = "never""#);
-        let config = config_in(dir.path());
-        let merged = config.with_config_file();
+        let config = resolve_in(dir.path(), &empty_overrides());
 
-        assert_eq!(merged.color, ColorChoice::Never);
+        assert_eq!(config.color, ColorChoice::Never);
     }
 
     #[test]
     fn file_overrides_verbosity() {
         let dir = tempfile::tempdir().unwrap();
         write_config(dir.path(), r#"verbosity = "verbose""#);
-        let config = config_in(dir.path());
-        let merged = config.with_config_file();
+        let config = resolve_in(dir.path(), &empty_overrides());
 
-        assert_eq!(merged.verbosity, Verbosity::Verbose);
+        assert_eq!(config.verbosity, Verbosity::Verbose);
     }
 
     #[test]
@@ -456,10 +637,126 @@ experience_size = 25
 address = "127.0.0.1:3000"
 "#,
         );
-        let config = config_in(dir.path());
-        // Should warn and return unchanged (typo "sevice" is unknown)
-        let merged = config.clone().with_config_file();
+        // Figment with deny_unknown_fields on Config should reject unknown keys
+        let overrides = CliOverrides {
+            data_dir: Some(dir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let result = Config::resolve(&overrides);
+        assert!(
+            result.is_err(),
+            "unknown field 'sevice' should cause an error"
+        );
+    }
 
-        assert_eq!(merged.service.address, config.service.address);
+    #[test]
+    fn cli_data_dir_determines_config_file_location() {
+        let dir_b = tempfile::tempdir().unwrap();
+
+        // Config file in dir_b overrides service address
+        write_config(
+            dir_b.path(),
+            r#"
+[service]
+address = "127.0.0.1:4000"
+"#,
+        );
+
+        let overrides = CliOverrides {
+            data_dir: Some(dir_b.path().to_path_buf()),
+            ..Default::default()
+        };
+
+        let config = Config::resolve(&overrides).expect("resolve should succeed");
+        assert_eq!(
+            config.service.address,
+            "127.0.0.1:4000".parse::<SocketAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn env_var_overrides_file() {
+        use figment::Jail;
+
+        #[expect(clippy::result_large_err)]
+        Jail::expect_with(|jail| {
+            jail.create_file("config.toml", r#"output = "json""#)?;
+            jail.set_env("ONEIROS_OUTPUT", "prompt");
+
+            // Resolve using Jail's isolated filesystem and env
+            let figment = Figment::new()
+                .merge(Serialized::defaults(Config::default()))
+                .merge(Toml::file("config.toml"))
+                .merge(Env::prefixed("ONEIROS_").split("__"))
+                .merge(Serialized::defaults(empty_overrides()));
+
+            let config: Config = figment.extract()?;
+            assert_eq!(config.output, OutputMode::Prompt);
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn two_way_coverage_config_and_overrides_match() {
+        // This test ensures CliOverrides covers every Config field.
+        // If a field is added to Config but not CliOverrides, this
+        // test won't compile (field missing from CliOverrides struct).
+        // If a field is added to CliOverrides but not Config, serde's
+        // deny_unknown_fields on Config catches it at runtime.
+
+        let dir = tempfile::tempdir().unwrap();
+
+        let overrides = CliOverrides {
+            data_dir: Some(dir.path().to_path_buf()),
+            brain: Some(BrainName::new("coverage-brain")),
+            bookmark: Some(BookmarkName::new("coverage-lens")),
+            service: ServiceCli {
+                label: Some("com.test.coverage".into()),
+                address: Some("127.0.0.1:7777".parse().unwrap()),
+                health_check_delays_ms: Some(vec![50, 100]),
+                restart_delay_secs: Some(10),
+            },
+            dream: DreamCli {
+                recent_window: Some(42),
+                dream_depth: Some(7),
+                cognition_size: Some(99),
+                recollection_level: Some(LevelName::new("session")),
+                recollection_size: Some(88),
+                experience_size: Some(77),
+            },
+            fetch: FetchCli {
+                interval: Some(std::time::Duration::from_millis(123)),
+                timeout: Some(std::time::Duration::from_secs(456)),
+            },
+            output: Some(OutputMode::Text),
+            color: Some(ColorChoice::Always),
+            verbosity: Some(Verbosity::Verbose),
+        };
+
+        let config = Config::resolve(&overrides).expect("full coverage resolve should succeed");
+
+        // Every field from overrides should land in the resolved config
+        assert_eq!(config.data_dir, dir.path().to_path_buf());
+        assert_eq!(config.brain, BrainName::new("coverage-brain"));
+        assert_eq!(config.bookmark, BookmarkName::new("coverage-lens"));
+        assert_eq!(config.service.label, "com.test.coverage");
+        assert_eq!(
+            config.service.address,
+            "127.0.0.1:7777".parse::<SocketAddr>().unwrap()
+        );
+        assert_eq!(config.service.health_check_delays_ms, vec![50, 100]);
+        assert_eq!(config.service.restart_delay_secs, 10);
+        assert_eq!(config.dream.recent_window, 42);
+        assert_eq!(config.dream.dream_depth, 7);
+        assert_eq!(config.dream.cognition_size, 99);
+        assert_eq!(config.dream.recollection_level, LevelName::new("session"));
+        assert_eq!(config.dream.recollection_size, 88);
+        assert_eq!(config.dream.experience_size, 77);
+        assert_eq!(config.fetch.interval, std::time::Duration::from_millis(123));
+        assert_eq!(config.fetch.timeout, std::time::Duration::from_secs(456));
+        assert_eq!(config.output, OutputMode::Text);
+        assert_eq!(config.color, ColorChoice::Always);
+        assert_eq!(config.verbosity, Verbosity::Verbose);
     }
 }

--- a/crates/oneiros-engine/src/engine.rs
+++ b/crates/oneiros-engine/src/engine.rs
@@ -96,13 +96,14 @@ impl Engine {
         ExitCode::SUCCESS
     }
 
-    /// From CLI args — parses arguments and merges config file.
+    /// From CLI args — parses arguments and resolves configuration.
     ///
+    /// Layers config from defaults, config file, env vars, and CLI flags.
     /// Returns the engine and the parsed CLI so the caller can execute
     /// and render. Tracing setup is the caller's responsibility.
     pub(crate) fn from_cli() -> Result<(Self, Cli), Error> {
         let cli = Cli::parse();
-        let config = cli.config().clone().with_config_file();
+        let config = Config::resolve(&cli.overrides).map_err(|e| Error::Config(e.to_string()))?;
 
         Ok((Self::new(config), cli))
     }

--- a/crates/oneiros-engine/src/error.rs
+++ b/crates/oneiros-engine/src/error.rs
@@ -33,6 +33,8 @@ pub(crate) enum Error {
     Bookmark(#[from] BookmarkError),
     #[error(transparent)]
     Brain(#[from] BrainError),
+    #[error("configuration: {0}")]
+    Config(String),
     #[error(transparent)]
     Cognition(#[from] CognitionError),
     #[error(transparent)]


### PR DESCRIPTION
We wanted to use figment pretty early on but waited until things had stabilized first. Now that we're kind of in a stable place, this commit adds it. This also means we now listen to env vars, with the `ONEIROS_` prefix, and can pretty easily extend things to also accept non-toml configs if we like.