### PR TITLE
Oh, Clipford.

### DIFF
--- a/crates/oneiros-engine/clippy.toml
+++ b/crates/oneiros-engine/clippy.toml
@@ -1,0 +1,14 @@
+disallowed-methods = [
+  { path = "std::fs::read", reason = "use Platform instead" },
+  { path = "std::fs::read_to_string", reason = "use Platform instead" },
+  { path = "std::fs::write", reason = "use Platform instead" },
+  { path = "std::fs::read_dir", reason = "use Platform instead" },
+  { path = "std::fs::create_dir", reason = "use Platform instead" },
+  { path = "std::fs::create_dir_all", reason = "use Platform instead" },
+  { path = "std::fs::remove_file", reason = "use Platform instead" },
+  { path = "std::fs::remove_dir_all", reason = "use Platform instead" },
+  { path = "std::fs::metadata", reason = "use Platform instead" },
+  { path = "std::fs::File::open", reason = "use Platform instead" },
+  { path = "std::fs::File::create", reason = "use Platform instead" },
+  { path = "std::fs::OpenOptions::open", reason = "use Platform instead" },
+]

--- a/crates/oneiros-engine/src/config.rs
+++ b/crates/oneiros-engine/src/config.rs
@@ -97,11 +97,6 @@ impl Config {
         Platform::new(&self.data_dir)
     }
 
-    /// Path to the config file in the data directory.
-    pub(crate) fn config_path(&self) -> PathBuf {
-        self.platform().config_path()
-    }
-
     /// Open the system database.
     pub(crate) fn system_db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
         let conn = rusqlite::Connection::open(self.platform().system_db_path())?;
@@ -147,14 +142,11 @@ impl Config {
         Ok(conn)
     }
 
-    /// Path to the token file for the current brain.
-    pub(crate) fn token_path(&self) -> PathBuf {
-        self.platform().token_path(&self.brain)
-    }
-
     /// Read the token for the current brain, if one exists.
     pub(crate) fn token(&self) -> Option<Token> {
-        std::fs::read_to_string(self.token_path())
+        let platform = self.platform();
+        platform
+            .read_to_string(platform.token_path(&self.brain))
             .ok()
             .map(|s| Token::from(s.trim()))
     }
@@ -165,16 +157,16 @@ impl Config {
     /// File values provide the base; CLI-provided values override them.
     /// If no file exists or is empty, returns self unchanged.
     pub(crate) fn with_config_file(mut self) -> Self {
-        let path = self.config_path();
+        let platform = self.platform();
 
-        let file_config = match std::fs::read_to_string(&path) {
+        let file_config = match platform.read_to_string(platform.config_path()) {
             Ok(contents) if !contents.trim().is_empty() => {
                 match toml::from_str::<Config>(&contents) {
                     Ok(config) => config,
                     Err(err) => {
                         eprintln!(
                             "warning: ignoring malformed config file {}: {err}",
-                            path.display()
+                            platform.config_path().display()
                         );
                         return self;
                     }
@@ -268,8 +260,9 @@ mod tests {
     }
 
     fn write_config(dir: &std::path::Path, contents: &str) {
-        std::fs::create_dir_all(dir).unwrap();
-        std::fs::write(dir.join("config.toml"), contents).unwrap();
+        let platform = Platform::new(dir);
+        platform.ensure_dir(platform.data_dir()).unwrap();
+        platform.write(platform.config_path(), contents).unwrap();
     }
 
     #[test]

--- a/crates/oneiros-engine/src/domains/bookmark/service.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/service.rs
@@ -506,7 +506,9 @@ impl BookmarkService {
         brain_config.bookmark = bookmark.clone();
 
         let bookmarks_dir = brain_config.bookmarks_dir();
-        std::fs::create_dir_all(&bookmarks_dir)
+        brain_config
+            .platform()
+            .ensure_dir(&bookmarks_dir)
             .map_err(|e| BookmarkError::InvalidUri(e.to_string()))?;
 
         // Open the new bookmark DB with events ATTACHed and replay.

--- a/crates/oneiros-engine/src/domains/doctor/service.rs
+++ b/crates/oneiros-engine/src/domains/doctor/service.rs
@@ -59,7 +59,7 @@ impl DoctorService {
         checks.push(DoctorCheck::DatabaseOk(DatabaseLabel::new("system.db")));
 
         // Host keypair check — identity for distribution
-        if HostKey::new(&config.data_dir).path().exists() {
+        if HostKey::new(config.platform()).path().exists() {
             checks.push(DoctorCheck::HostKeyOk);
         } else {
             checks.push(DoctorCheck::HostKeyMissing);

--- a/crates/oneiros-engine/src/domains/mcp/service.rs
+++ b/crates/oneiros-engine/src/domains/mcp/service.rs
@@ -41,7 +41,7 @@ impl McpConfigService {
         }
 
         let content = serde_json::to_string_pretty(&mcp_json)?;
-        std::fs::write(&path, content)?;
+        config.platform().write(&path, content)?;
 
         Ok(McpResponses::McpConfigWritten(
             McpConfigWrittenResponse::builder_v1()

--- a/crates/oneiros-engine/src/domains/project/service.rs
+++ b/crates/oneiros-engine/src/domains/project/service.rs
@@ -67,9 +67,10 @@ impl ProjectService {
         // Create the brain's database layout:
         //   {brain_dir}/events.db         — event log (append-only)
         //   {brain_dir}/bookmarks/main.db — projection tables for the default bookmark
+        let platform = scope.config().platform();
         let brain_dir = scope.config().data_dir.join(brain_name.as_str());
         let bookmarks_dir = brain_dir.join("bookmarks");
-        std::fs::create_dir_all(&bookmarks_dir)?;
+        platform.ensure_dir(&bookmarks_dir)?;
 
         // Event log — standalone, no ATTACH needed during init.
         let events_db = rusqlite::Connection::open(brain_dir.join("events.db"))?;
@@ -112,11 +113,11 @@ impl ProjectService {
 
         let tickets_dir = scope.config().data_dir.join("tickets");
 
-        std::fs::create_dir_all(&tickets_dir)?;
+        platform.ensure_dir(&tickets_dir)?;
 
         let token_path = tickets_dir.join(format!("{brain_name}.token"));
 
-        std::fs::write(&token_path, format!("{token}"))?;
+        platform.write(&token_path, format!("{token}"))?;
 
         Ok(ProjectResponse::Initialized(
             InitializedResponse::builder_v1()
@@ -167,13 +168,14 @@ impl ProjectService {
             buffer.push('\n');
         }
 
-        std::fs::create_dir_all(target_dir)?;
+        let platform = scope.config().platform();
+        platform.ensure_dir(target_dir)?;
 
         let date = chrono::Utc::now().format("%Y-%m-%d");
         let file_name = format!("{project_name}-{date}-export.jsonl");
         let file_path = target_dir.join(file_name);
 
-        std::fs::write(&file_path, buffer)?;
+        platform.write(&file_path, buffer)?;
 
         Ok(ProjectResponse::WroteExport(
             WroteExportResponse::builder_v1()
@@ -199,7 +201,8 @@ impl ProjectService {
         request: &ImportProject,
     ) -> Result<ProjectResponse, ProjectError> {
         let details = request.current()?;
-        let file = std::fs::File::open(&details.file)?;
+        let platform = config.platform();
+        let file = platform.open_file(&details.file)?;
         let reader = std::io::BufReader::new(file);
         let mut imported = 0usize;
 
@@ -278,12 +281,13 @@ impl ProjectService {
     pub(crate) async fn replay(config: &Config) -> Result<ProjectResponse, ProjectError> {
         // Ensure a clean schema by deleting the old bookmark DB.
         // WAL sidecar files are silently cleaned up if present.
+        let platform = config.platform();
         let db_path = config.bookmark_db_path();
         if db_path.exists() {
-            std::fs::remove_file(&db_path)?;
+            platform.remove_file(&db_path)?;
         }
-        let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
-        let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+        let _ = platform.remove_file(db_path.with_extension("db-wal"));
+        let _ = platform.remove_file(db_path.with_extension("db-shm"));
 
         // Open a fresh DB, create tables with current schema, then replay.
         let db = BookmarkDb::open_with(&config.platform(), &config.brain, &config.bookmark).await?;

--- a/crates/oneiros-engine/src/domains/service/service.rs
+++ b/crates/oneiros-engine/src/domains/service/service.rs
@@ -35,7 +35,7 @@ impl ServiceService {
         let label = Self::parse_label(&config.service.label)?;
 
         // Ensure log directory exists.
-        std::fs::create_dir_all(config.data_dir.join("logs"))?;
+        config.platform().ensure_dir(config.data_dir.join("logs"))?;
 
         manager
             .install(ServiceInstallCtx {

--- a/crates/oneiros-engine/src/domains/storage/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/storage/features/cli.rs
@@ -40,7 +40,7 @@ impl StorageCommands {
                 file,
                 description,
             } => {
-                let data = std::fs::read(file)?;
+                let data = config.platform().read(file)?;
                 storage_client
                     .upload(
                         &UploadStorage::builder_v1()
@@ -58,7 +58,7 @@ impl StorageCommands {
                 match out {
                     Some(path) => {
                         let len = bytes.len();
-                        std::fs::write(path, &bytes)?;
+                        config.platform().write(path, &bytes)?;
                         return Ok(Rendered::new(
                             Responses::Storage(StorageResponse::NoEntries),
                             format!("Wrote {} bytes to {}", len, path.display()),

--- a/crates/oneiros-engine/src/domains/system/service.rs
+++ b/crates/oneiros-engine/src/domains/system/service.rs
@@ -18,8 +18,8 @@ impl SystemService {
     ) -> Result<SystemResponse, SystemError> {
         let details = request.current()?;
 
-        std::fs::create_dir_all(&config.data_dir)?;
-        HostKey::new(&config.data_dir).ensure()?;
+        config.platform().ensure_dir(&config.data_dir)?;
+        HostKey::new(config.platform()).ensure()?;
         let host_db = HostDb::open_with(&config.platform()).await?;
         EventLog::new(&host_db).init()?;
         Projections::system().migrate(&host_db)?;

--- a/crates/oneiros-engine/src/http/state.rs
+++ b/crates/oneiros-engine/src/http/state.rs
@@ -31,7 +31,7 @@ impl ServerState {
     /// generates) the host secret key from disk, binds a `Bridge`, and
     /// spawns the host actor that consumes the bus.
     pub(crate) async fn bind(config: Config) -> Result<Self, ServerStateError> {
-        let secret = HostKey::new(&config.data_dir).ensure()?;
+        let secret = HostKey::new(config.platform()).ensure()?;
         let bridge = Bridge::bind(secret).await?;
 
         let canons = CanonIndex::new();

--- a/crates/oneiros-engine/src/keys.rs
+++ b/crates/oneiros-engine/src/keys.rs
@@ -7,6 +7,8 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::*;
+
 const HOST_KEY_FILE: &str = "host.key";
 
 #[derive(Debug, thiserror::Error)]
@@ -16,19 +18,17 @@ pub(crate) enum HostKeyError {
 }
 
 pub(crate) struct HostKey {
-    data_dir: PathBuf,
+    platform: Platform,
 }
 
 impl HostKey {
-    pub(crate) fn new(data_dir: impl Into<PathBuf>) -> Self {
-        Self {
-            data_dir: data_dir.into(),
-        }
+    pub(crate) fn new(platform: Platform) -> Self {
+        Self { platform }
     }
 
     /// Path where the host's secret key is persisted.
     pub(crate) fn path(&self) -> PathBuf {
-        self.data_dir.join(HOST_KEY_FILE)
+        self.platform.data_dir().join(HOST_KEY_FILE)
     }
 
     /// Load the persisted host secret key, if one exists. Returns
@@ -39,7 +39,7 @@ impl HostKey {
             return Ok(None);
         }
 
-        let bytes = std::fs::read(&path)?;
+        let bytes = self.platform.read(&path)?;
         let bytes: [u8; 32] = bytes.try_into().map_err(|byte_error: Vec<u8>| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -68,41 +68,40 @@ impl HostKey {
 
         let path = self.path();
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
+            self.platform.ensure_dir(parent)?;
         }
 
         let secret = iroh::SecretKey::generate();
         let bytes = secret.to_bytes();
 
-        write_with_owner_only_perms(&path, &bytes)?;
+        write_with_owner_only_perms(&self.platform, &path, &bytes)?;
 
         Ok(secret)
     }
 }
 
-/// Borrowing constructor for transient use.
-impl<'a> From<&'a Path> for HostKey {
-    fn from(data_dir: &'a Path) -> Self {
-        Self::new(data_dir.to_path_buf())
-    }
-}
-
 #[cfg(unix)]
-fn write_with_owner_only_perms(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+fn write_with_owner_only_perms(
+    platform: &Platform,
+    path: &Path,
+    bytes: &[u8],
+) -> std::io::Result<()> {
     use std::io::Write;
     use std::os::unix::fs::OpenOptionsExt;
 
-    let mut file = std::fs::OpenOptions::new()
-        .create_new(true)
-        .write(true)
-        .mode(0o600)
-        .open(path)?;
+    let mut options = std::fs::OpenOptions::new();
+    options.create_new(true).write(true).mode(0o600);
+    let mut file = platform.open_with(path, &options)?;
     file.write_all(bytes)
 }
 
 #[cfg(not(unix))]
-fn write_with_owner_only_perms(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    std::fs::write(path, bytes)
+fn write_with_owner_only_perms(
+    platform: &Platform,
+    path: &Path,
+    bytes: &[u8],
+) -> std::io::Result<()> {
+    platform.write(path, bytes)
 }
 
 #[cfg(test)]
@@ -112,7 +111,7 @@ mod tests {
     #[test]
     fn ensure_generates_when_missing() {
         let dir = tempfile::tempdir().unwrap();
-        let keys = HostKey::new(dir.path());
+        let keys = HostKey::new(Platform::new(dir.path()));
 
         assert!(!keys.path().exists());
 
@@ -132,7 +131,7 @@ mod tests {
     #[test]
     fn ensure_is_idempotent() {
         let dir = tempfile::tempdir().unwrap();
-        let keys = HostKey::new(dir.path());
+        let keys = HostKey::new(Platform::new(dir.path()));
 
         let first = keys.ensure().unwrap();
         let second = keys.ensure().unwrap();
@@ -147,7 +146,7 @@ mod tests {
     #[test]
     fn load_returns_none_when_missing() {
         let dir = tempfile::tempdir().unwrap();
-        let keys = HostKey::new(dir.path());
+        let keys = HostKey::new(Platform::new(dir.path()));
 
         let result = keys.load().unwrap();
         assert!(result.is_none());
@@ -159,11 +158,11 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().unwrap();
-        let keys = HostKey::new(dir.path());
+        let keys = HostKey::new(Platform::new(dir.path()));
 
         keys.ensure().unwrap();
 
-        let metadata = std::fs::metadata(keys.path()).unwrap();
+        let metadata = Platform::new(dir.path()).metadata(keys.path()).unwrap();
         let mode = metadata.permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "host key file should be owner-only (0o600)");
     }

--- a/crates/oneiros-engine/src/scope.rs
+++ b/crates/oneiros-engine/src/scope.rs
@@ -364,9 +364,10 @@ mod tests {
     /// Seed a brain on both sides of the intersection: filesystem
     /// (brain dir + events.db) AND projection (`brains` row).
     fn seed_brain(config: &Config, name: &str) -> PathBuf {
+        let platform = config.platform();
         let brain_dir = config.data_dir.join(name);
-        std::fs::create_dir_all(&brain_dir).unwrap();
-        std::fs::write(brain_dir.join("events.db"), b"").unwrap();
+        platform.ensure_dir(&brain_dir).unwrap();
+        platform.write(brain_dir.join("events.db"), b"").unwrap();
 
         let conn = config.system_db().unwrap();
         BrainStore::new(&conn).migrate().unwrap();
@@ -382,9 +383,12 @@ mod tests {
     /// Seed a bookmark on both sides: filesystem (`bookmarks/{name}.db`)
     /// AND projection (`bookmarks` row scoped to brain).
     fn seed_bookmark(config: &Config, brain: &str, name: &str) {
+        let platform = config.platform();
         let bookmarks_dir = config.data_dir.join(brain).join("bookmarks");
-        std::fs::create_dir_all(&bookmarks_dir).unwrap();
-        std::fs::write(bookmarks_dir.join(format!("{name}.db")), b"").unwrap();
+        platform.ensure_dir(&bookmarks_dir).unwrap();
+        platform
+            .write(bookmarks_dir.join(format!("{name}.db")), b"")
+            .unwrap();
 
         let conn = config.system_db().unwrap();
         BookmarkStore::new(&conn).migrate().unwrap();

--- a/crates/oneiros-engine/src/support/logging.rs
+++ b/crates/oneiros-engine/src/support/logging.rs
@@ -59,6 +59,7 @@ impl Logging {
 /// append-mode file opens so restarts during the same day continue an
 /// existing file rather than truncating.
 struct DailyLog {
+    platform: Platform,
     date: Timestamp,
     path: PathBuf,
     logs: PathBuf,
@@ -67,14 +68,16 @@ struct DailyLog {
 
 impl DailyLog {
     pub(crate) fn new(root: &Path) -> Result<Self, std::io::Error> {
+        let platform = Platform::new(root);
         let mut new_daily_log = Self {
+            platform,
             date: Timestamp::now(),
             logs: root.join("logs").clone(),
             path: PathBuf::default(),
             file: None,
         };
 
-        std::fs::create_dir_all(&new_daily_log.logs)?;
+        new_daily_log.platform.ensure_dir(&new_daily_log.logs)?;
 
         new_daily_log.construct_path();
         new_daily_log.set_file()?;
@@ -90,12 +93,9 @@ impl DailyLog {
     }
 
     fn set_file(&mut self) -> Result<(), std::io::Error> {
-        self.file = Some(
-            std::fs::OpenOptions::new()
-                .append(true)
-                .create(true)
-                .open(&self.path)?,
-        );
+        let mut options = std::fs::OpenOptions::new();
+        options.append(true).create(true);
+        self.file = Some(self.platform.open_with(&self.path, &options)?);
 
         Ok(())
     }
@@ -134,8 +134,9 @@ mod tests {
     fn file_layer_writes_json_lines_to_dated_file() -> Result<(), Box<dyn core::error::Error>> {
         let tmp = tempfile::TempDir::new()?;
         let log_dir = tmp.path().join("logs");
+        let platform = Platform::new(tmp.path());
 
-        std::fs::create_dir_all(&log_dir).unwrap();
+        platform.ensure_dir(&log_dir).unwrap();
 
         let writer = DailyLog::new(&log_dir)?;
         let path = writer.path.clone();
@@ -153,7 +154,7 @@ mod tests {
 
         drop(guard);
 
-        let content = std::fs::read_to_string(&path)?;
+        let content = platform.read_to_string(&path)?;
 
         assert!(
             content.contains("hello"),

--- a/crates/oneiros-engine/src/support/platform.rs
+++ b/crates/oneiros-engine/src/support/platform.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_methods)]
+
 use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_app_strategy};
 use std::path::{Path, PathBuf};
 
@@ -107,6 +109,79 @@ impl Platform {
     pub(crate) fn ensure_data_dir(&self) -> Result<(), PlatformError> {
         std::fs::create_dir_all(&self.data_dir)?;
         Ok(())
+    }
+
+    /// Read a UTF-8 file at the given path.
+    pub(crate) fn read_to_string(&self, path: impl AsRef<Path>) -> std::io::Result<String> {
+        std::fs::read_to_string(path)
+    }
+
+    /// Read the raw bytes of a file at the given path.
+    pub(crate) fn read(&self, path: impl AsRef<Path>) -> std::io::Result<Vec<u8>> {
+        std::fs::read(path)
+    }
+
+    /// Write bytes (or a string) to a file at the given path, creating or truncating it.
+    pub(crate) fn write(
+        &self,
+        path: impl AsRef<Path>,
+        contents: impl AsRef<[u8]>,
+    ) -> std::io::Result<()> {
+        std::fs::write(path, contents)
+    }
+
+    /// Ensure a directory exists at the given path, creating parents as needed.
+    pub(crate) fn ensure_dir(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        std::fs::create_dir_all(path)
+    }
+
+    /// Create a directory at the given path (parents must already exist).
+    #[allow(dead_code)]
+    pub(crate) fn create_dir(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        std::fs::create_dir(path)
+    }
+
+    /// Remove a file at the given path.
+    pub(crate) fn remove_file(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        std::fs::remove_file(path)
+    }
+
+    /// Recursively remove a directory and its contents.
+    #[allow(dead_code)]
+    pub(crate) fn remove_dir_all(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        std::fs::remove_dir_all(path)
+    }
+
+    /// Iterate the entries of a directory.
+    #[allow(dead_code)]
+    pub(crate) fn read_dir(&self, path: impl AsRef<Path>) -> std::io::Result<std::fs::ReadDir> {
+        std::fs::read_dir(path)
+    }
+
+    /// Fetch metadata for the entry at the given path.
+    #[allow(dead_code)]
+    pub(crate) fn metadata(&self, path: impl AsRef<Path>) -> std::io::Result<std::fs::Metadata> {
+        std::fs::metadata(path)
+    }
+
+    /// Open a file for reading.
+    pub(crate) fn open_file(&self, path: impl AsRef<Path>) -> std::io::Result<std::fs::File> {
+        std::fs::File::open(path)
+    }
+
+    /// Create (or truncate) a file for writing.
+    #[allow(dead_code)]
+    pub(crate) fn create_file(&self, path: impl AsRef<Path>) -> std::io::Result<std::fs::File> {
+        std::fs::File::create(path)
+    }
+
+    /// Open a file with custom [`std::fs::OpenOptions`].
+    pub(crate) fn open_with(
+        &self,
+        path: impl AsRef<Path>,
+        options: &std::fs::OpenOptions,
+    ) -> std::io::Result<std::fs::File> {
+        options.open(path)
     }
 
     /// Ensure a brain's directory exists.

--- a/crates/oneiros-engine/src/support/project_detection/directory.rs
+++ b/crates/oneiros-engine/src/support/project_detection/directory.rs
@@ -44,8 +44,9 @@ mod tests {
     fn does_not_walk_up() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let nested = dir.path().join("nested");
+        let platform = crate::Platform::new(dir.path());
 
-        std::fs::create_dir(&nested).unwrap();
+        platform.create_dir(&nested).unwrap();
 
         let root = Directory.detect(&nested).unwrap();
 

--- a/crates/oneiros-engine/src/support/project_detection/git.rs
+++ b/crates/oneiros-engine/src/support/project_detection/git.rs
@@ -35,15 +35,14 @@ impl DetectionStrategy for Git {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-
     use super::*;
 
     #[test]
     fn detects_git_repo() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let platform = crate::Platform::new(dir.path());
 
-        fs::create_dir(dir.path().join(".git")).unwrap();
+        platform.create_dir(dir.path().join(".git")).unwrap();
 
         let root = Git.detect(dir.path()).unwrap();
 
@@ -54,9 +53,10 @@ mod tests {
     fn walks_up_to_find_git() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let nested = dir.path().join("src").join("deep");
+        let platform = crate::Platform::new(dir.path());
 
-        fs::create_dir(dir.path().join(".git")).unwrap();
-        fs::create_dir_all(&nested).unwrap();
+        platform.create_dir(dir.path().join(".git")).unwrap();
+        platform.ensure_dir(&nested).unwrap();
 
         let root = Git.detect(&nested).unwrap();
 

--- a/crates/oneiros-engine/src/support/project_detection/mod.rs
+++ b/crates/oneiros-engine/src/support/project_detection/mod.rs
@@ -59,19 +59,21 @@ mod tests {
     #[test]
     fn workspace_wins_over_git() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let platform = crate::Platform::new(dir.path());
 
-        std::fs::write(
-            dir.path().join("Cargo.toml"),
-            r#"
+        platform
+            .write(
+                dir.path().join("Cargo.toml"),
+                r#"
     [workspace]
     members = []
 
     [workspace.package]
     name = "workspace-name"
     "#,
-        )
-        .unwrap();
-        std::fs::create_dir(dir.path().join(".git")).unwrap();
+            )
+            .unwrap();
+        platform.create_dir(dir.path().join(".git")).unwrap();
 
         let root = ProjectDetector::default_chain().detect(dir.path()).unwrap();
 
@@ -81,18 +83,20 @@ mod tests {
     #[test]
     fn package_wins_over_git() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let platform = crate::Platform::new(dir.path());
 
-        std::fs::write(
-            dir.path().join("Cargo.toml"),
-            r#"
+        platform
+            .write(
+                dir.path().join("Cargo.toml"),
+                r#"
     [package]
     name = "package-name"
     version = "0.1.0"
     "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        platform.create_dir(dir.path().join(".git")).unwrap();
 
         assert_eq!(
             ProjectDetector::default_chain()
@@ -107,9 +111,10 @@ mod tests {
     fn git_wins_over_directory() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let nested = dir.path().join("some-subdir");
+        let platform = crate::Platform::new(dir.path());
 
-        std::fs::create_dir(dir.path().join(".git")).unwrap();
-        std::fs::create_dir(&nested).unwrap();
+        platform.create_dir(dir.path().join(".git")).unwrap();
+        platform.create_dir(&nested).unwrap();
 
         assert_eq!(
             ProjectDetector::default_chain()

--- a/crates/oneiros-engine/src/support/project_detection/package.rs
+++ b/crates/oneiros-engine/src/support/project_detection/package.rs
@@ -13,13 +13,14 @@ impl DetectionStrategy for Package {
     fn detect(&self, start: &Path) -> Option<ProjectRoot> {
         let mut current = start.canonicalize().ok()?;
         let mut topmost: Option<ProjectRoot> = None;
+        let platform = crate::Platform::new(start);
 
         loop {
             let cargo_toml = current.join("Cargo.toml");
 
             if cargo_toml.exists() {
                 let maybe_package = {
-                    let contents = std::fs::read_to_string(cargo_toml).ok()?;
+                    let contents = platform.read_to_string(cargo_toml).ok()?;
                     let parsed: toml::Table = contents.parse().ok()?;
 
                     let package = parsed.get("package")?.as_table()?;
@@ -50,16 +51,18 @@ mod tests {
     fn detects_package() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let cargo_toml = dir.path().join("Cargo.toml");
+        let platform = crate::Platform::new(dir.path());
 
-        std::fs::write(
-            &cargo_toml,
-            r#"
+        platform
+            .write(
+                &cargo_toml,
+                r#"
     [package]
     name = "my-package"
     version = "0.1.0"
     "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let root = Package.detect(dir.path()).unwrap();
 
@@ -70,27 +73,30 @@ mod tests {
     fn finds_topmost_package() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let nested = dir.path().join("crates").join("nested");
+        let platform = crate::Platform::new(dir.path());
 
-        std::fs::write(
-            dir.path().join("Cargo.toml"),
-            r#"
+        platform
+            .write(
+                dir.path().join("Cargo.toml"),
+                r#"
     [package]
     name = "root-package"
     version = "0.1.0"
     "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-        std::fs::create_dir_all(&nested).unwrap();
-        std::fs::write(
-            nested.join("Cargo.toml"),
-            r#"
+        platform.ensure_dir(&nested).unwrap();
+        platform
+            .write(
+                nested.join("Cargo.toml"),
+                r#"
     [package]
     name = "nested-package"
     version = "0.1.0"
     "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let root = Package.detect(&nested).unwrap();
 
@@ -102,15 +108,17 @@ mod tests {
     fn ignores_workspace_only_cargo_toml() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let cargo_toml = dir.path().join("Cargo.toml");
+        let platform = crate::Platform::new(dir.path());
 
-        std::fs::write(
-            &cargo_toml,
-            r#"
+        platform
+            .write(
+                &cargo_toml,
+                r#"
     [workspace]
     members = ["crates/*"]
     "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let result = Package.detect(dir.path());
 

--- a/crates/oneiros-engine/src/support/project_detection/workspace.rs
+++ b/crates/oneiros-engine/src/support/project_detection/workspace.rs
@@ -12,13 +12,14 @@ pub(crate) struct Workspace;
 impl DetectionStrategy for Workspace {
     fn detect(&self, start: &Path) -> Option<ProjectRoot> {
         let mut current = start.canonicalize().ok()?;
+        let platform = crate::Platform::new(start);
 
         loop {
             let cargo_toml = current.join("Cargo.toml");
 
             if cargo_toml.exists() {
                 let maybe_workspace = {
-                    let contents = std::fs::read_to_string(cargo_toml).ok()?;
+                    let contents = platform.read_to_string(cargo_toml).ok()?;
                     let parsed: toml::Table = contents.parse().ok()?;
 
                     let workspace = parsed.get("workspace")?.as_table()?;
@@ -61,18 +62,20 @@ mod tests {
     fn detects_workspace_with_package_name() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let cargo_toml = dir.path().join("Cargo.toml");
+        let platform = crate::Platform::new(dir.path());
 
-        std::fs::write(
-            &cargo_toml,
-            r#"
+        platform
+            .write(
+                &cargo_toml,
+                r#"
     [workspace]
     members = ["crates/*"]
 
     [workspace.package]
     name = "my-workspace"
     "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let root = Workspace.detect(dir.path()).unwrap();
 
@@ -84,15 +87,17 @@ mod tests {
     fn detects_workspace_falls_back_to_dir_name() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let cargo_toml = dir.path().join("Cargo.toml");
+        let platform = crate::Platform::new(dir.path());
 
-        std::fs::write(
-            &cargo_toml,
-            r#"
+        platform
+            .write(
+                &cargo_toml,
+                r#"
     [workspace]
     members = ["crates/*"]
     "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let root = Workspace.detect(dir.path()).unwrap();
 
@@ -113,20 +118,22 @@ mod tests {
     fn walks_up_to_find_workspace() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let nested = dir.path().join("crates").join("sub-crate");
+        let platform = crate::Platform::new(dir.path());
 
-        std::fs::write(
-            dir.path().join("Cargo.toml"),
-            r#"
+        platform
+            .write(
+                dir.path().join("Cargo.toml"),
+                r#"
     [workspace]
     members = ["crates/*"]
 
     [workspace.package]
     name = "root-workspace"
     "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-        std::fs::create_dir_all(&nested).unwrap();
+        platform.ensure_dir(&nested).unwrap();
 
         let root = Workspace.detect(&nested).unwrap();
 
@@ -138,16 +145,18 @@ mod tests {
     fn ignores_package_only_cargo_toml() {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
         let cargo_toml = dir.path().join("Cargo.toml");
+        let platform = crate::Platform::new(dir.path());
 
-        std::fs::write(
-            &cargo_toml,
-            r#"
+        platform
+            .write(
+                &cargo_toml,
+                r#"
     [package]
     name = "just-a-package"
     version = "0.1.0"
     "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
         let result = Workspace.detect(dir.path());
 

--- a/crates/oneiros-engine/src/tests/acceptance/cases/import_export.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/import_export.rs
@@ -24,7 +24,8 @@ pub(crate) async fn export_produces_file<B: Backend>() -> TestResult {
 
     // Verify file was created and is not empty
     assert!(export_path.exists(), "export file should exist");
-    let content = std::fs::read_to_string(&export_path)?;
+    let content = crate::Platform::new(export_path.parent().unwrap_or(std::path::Path::new(".")))
+        .read_to_string(&export_path)?;
     assert!(!content.is_empty(), "export file should not be empty");
 
     // Count lines — should have at least a few events
@@ -97,7 +98,7 @@ pub(crate) async fn export_import_preserves_storage<B: Backend>() -> TestResult 
     // Create a temp file and store it on brain A
     let temp_dir = tempfile::TempDir::new()?;
     let file_path = temp_dir.path().join("test.txt");
-    std::fs::write(&file_path, "Portable blob content")?;
+    crate::Platform::new(temp_dir.path()).write(&file_path, "Portable blob content")?;
 
     let cmd = format!(
         "storage set portable-doc {} --description 'A portable document'",

--- a/crates/oneiros-engine/src/tests/acceptance/cases/storage.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/storage.rs
@@ -6,7 +6,7 @@ pub(crate) async fn set_and_show<B: Backend>() -> TestResult {
     // Create a temp file to upload
     let temp_dir = tempfile::TempDir::new()?;
     let file_path = temp_dir.path().join("test-doc.txt");
-    std::fs::write(&file_path, "Hello, storage!")?;
+    crate::Platform::new(temp_dir.path()).write(&file_path, "Hello, storage!")?;
 
     let set_cmd = format!(
         "storage set test-doc {} --description 'A test document'",
@@ -53,7 +53,7 @@ pub(crate) async fn list_populated<B: Backend>() -> TestResult {
 
     let temp_dir = tempfile::TempDir::new()?;
     let file_path = temp_dir.path().join("doc.txt");
-    std::fs::write(&file_path, "content")?;
+    crate::Platform::new(temp_dir.path()).write(&file_path, "content")?;
 
     let cmd = format!("storage set my-doc {}", file_path.display());
     harness.exec_json(&cmd).await?;
@@ -75,7 +75,7 @@ pub(crate) async fn set_prompt<B: Backend>() -> TestResult {
 
     let temp_dir = tempfile::TempDir::new()?;
     let file_path = temp_dir.path().join("doc.txt");
-    std::fs::write(&file_path, "content")?;
+    crate::Platform::new(temp_dir.path()).write(&file_path, "content")?;
 
     let prompt = harness
         .exec_prompt(&format!("storage set my-doc {}", file_path.display()))
@@ -91,7 +91,7 @@ pub(crate) async fn show_prompt<B: Backend>() -> TestResult {
 
     let temp_dir = tempfile::TempDir::new()?;
     let file_path = temp_dir.path().join("doc.txt");
-    std::fs::write(&file_path, "content")?;
+    crate::Platform::new(temp_dir.path()).write(&file_path, "content")?;
 
     harness
         .exec_json(&format!("storage set my-doc {}", file_path.display()))
@@ -116,7 +116,7 @@ pub(crate) async fn list_prompt<B: Backend>() -> TestResult {
 
     let temp_dir = tempfile::TempDir::new()?;
     let file_path = temp_dir.path().join("doc.txt");
-    std::fs::write(&file_path, "content")?;
+    crate::Platform::new(temp_dir.path()).write(&file_path, "content")?;
 
     harness
         .exec_json(&format!("storage set my-doc {}", file_path.display()))
@@ -137,7 +137,7 @@ pub(crate) async fn remove_prompt<B: Backend>() -> TestResult {
 
     let temp_dir = tempfile::TempDir::new()?;
     let file_path = temp_dir.path().join("doc.txt");
-    std::fs::write(&file_path, "content")?;
+    crate::Platform::new(temp_dir.path()).write(&file_path, "content")?;
 
     harness
         .exec_json(&format!("storage set removable {}", file_path.display()))
@@ -158,7 +158,7 @@ pub(crate) async fn remove<B: Backend>() -> TestResult {
 
     let temp_dir = tempfile::TempDir::new()?;
     let file_path = temp_dir.path().join("removable.txt");
-    std::fs::write(&file_path, "temporary")?;
+    crate::Platform::new(temp_dir.path()).write(&file_path, "temporary")?;
 
     let cmd = format!("storage set removable {}", file_path.display());
     harness.exec_json(&cmd).await?;

--- a/crates/oneiros-engine/src/tests/mod.rs
+++ b/crates/oneiros-engine/src/tests/mod.rs
@@ -202,9 +202,10 @@ async fn replay_recovers_from_deleted_bookmark_db() {
 
     // Simulate schema-change / corruption: delete the bookmark DB file
     let db_path = app.config().bookmark_db_path();
-    std::fs::remove_file(&db_path).unwrap();
-    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
-    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let platform = app.config().platform();
+    platform.remove_file(&db_path).unwrap();
+    let _ = platform.remove_file(db_path.with_extension("db-wal"));
+    let _ = platform.remove_file(db_path.with_extension("db-shm"));
 
     // Replay through the CLI should recreate the DB and restore all data.
     app.command("project replay")

--- a/crates/oneiros-engine/src/tests/workflows/distribution.rs
+++ b/crates/oneiros-engine/src/tests/workflows/distribution.rs
@@ -59,7 +59,8 @@ async fn multi_source_dream() -> Result<(), Box<dyn core::error::Error>> {
         ))
         .await?;
 
-    let export_file = std::fs::read_dir(export_dir.path())?
+    let export_file = crate::Platform::new(export_dir.path())
+        .read_dir(export_dir.path())?
         .filter_map(|e| e.ok())
         .find(|e| e.path().extension().is_some_and(|ext| ext == "jsonl"))
         .expect("export should produce a .jsonl file");

--- a/crates/oneiros-engine/src/tests/workflows/portability.rs
+++ b/crates/oneiros-engine/src/tests/workflows/portability.rs
@@ -112,7 +112,8 @@ async fn continuity_survives_export_import() -> Result<(), Box<dyn core::error::
         .await?;
 
     // Find the exported file
-    let export_file = std::fs::read_dir(export_dir.path())?
+    let export_file = crate::Platform::new(export_dir.path())
+        .read_dir(export_dir.path())?
         .filter_map(|e| e.ok())
         .find(|e| e.path().extension().is_some_and(|ext| ext == "jsonl"))
         .expect("export should produce a .jsonl file");

--- a/crates/oneiros-engine/src/tests/workflows/storage.rs
+++ b/crates/oneiros-engine/src/tests/workflows/storage.rs
@@ -108,7 +108,8 @@ async fn storage_via_cli() -> Result<(), Box<dyn core::error::Error>> {
 
     // Storage CLI takes a file path
     let temp = tempfile::NamedTempFile::new()?;
-    std::fs::write(temp.path(), b"Hello from a temp file")?;
+    crate::Platform::new(temp.path().parent().unwrap_or(std::path::Path::new(".")))
+        .write(temp.path(), b"Hello from a temp file")?;
 
     let path = temp.path().display();
     app.command(&format!(
@@ -186,7 +187,8 @@ async fn storage_content_survives_export_import() -> Result<(), Box<dyn core::er
         ))
         .await?;
 
-    let export_file = std::fs::read_dir(export_dir.path())?
+    let export_file = crate::Platform::new(export_dir.path())
+        .read_dir(export_dir.path())?
         .filter_map(|e| e.ok())
         .find(|e| e.path().extension().is_some_and(|ext| ext == "jsonl"))
         .expect("export should produce a .jsonl file");

--- a/crates/oneiros-engine/src/tests/workflows/system.rs
+++ b/crates/oneiros-engine/src/tests/workflows/system.rs
@@ -219,7 +219,7 @@ async fn system_administration() -> Result<(), Box<dyn core::error::Error>> {
 #[tokio::test]
 async fn system_init_creates_host_keypair() -> Result<(), Box<dyn core::error::Error>> {
     let app = TestApp::new().await?;
-    let keys = HostKey::new(&app.config().data_dir);
+    let keys = HostKey::new(app.config().platform());
 
     // The server's bind path generates the host key (see `ServerState::bind`),
     // but `Server::spawn` returns before that bind completes. Wait for the


### PR DESCRIPTION
I found out that clippy can let me disallow methods and types, and boy is that a relief. The `std::fs` thing was just so damn convenient for the robots to leverage and none of them would listen to me when I'd say to quit it. Except, now, lints nitpick for me. Thanks, Clipford!