### PR TITLE
CLI doesn't spit out log traces.

### DIFF
--- a/crates/oneiros-engine/Cargo.toml
+++ b/crates/oneiros-engine/Cargo.toml
@@ -38,12 +38,12 @@ sha2.workspace = true
 spki.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tracing.workspace = true
-tracing-appender.workspace = true
-tracing-subscriber.workspace = true
 toml.workspace = true
 tower.workspace = true
 tower-http.workspace = true
+tracing.workspace = true
+tracing-appender.workspace = true
+tracing-subscriber.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
@@ -53,7 +53,7 @@ shlex.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 
-# [lints.clippy]
+[lints.clippy]
 # nursery = { level = "deny", priority = -1 }
 # pedantic = { level = "deny", priority = -1 }
 # unwrap_used = "deny"

--- a/crates/oneiros-engine/src/cli.rs
+++ b/crates/oneiros-engine/src/cli.rs
@@ -127,6 +127,16 @@ pub(crate) enum Command {
 }
 
 impl Command {
+    /// Whether this command runs the long-lived HTTP server in-process.
+    ///
+    /// Only `service run` boots the server here; every other command is a
+    /// short-lived CLI client that issues HTTP requests to a running
+    /// service. The two surfaces want different tracing defaults — see
+    /// `support::logging::level`.
+    pub(crate) fn is_server(&self) -> bool {
+        matches!(self, Command::Service(ServiceCommands::Run))
+    }
+
     /// Execute a CLI command against the engine.
     ///
     /// Returns `Rendered` — the caller decides how to consume it:
@@ -166,5 +176,34 @@ impl Command {
             Command::Ticket(ticket) => ticket.execute(config).await?,
             Command::Urge(urge) => urge.execute(config).await?,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_run_is_the_server() {
+        let command = Command::Service(ServiceCommands::Run);
+        assert!(command.is_server());
+    }
+
+    #[test]
+    fn other_service_subcommands_are_clients() {
+        for command in [
+            Command::Service(ServiceCommands::Install),
+            Command::Service(ServiceCommands::Uninstall),
+            Command::Service(ServiceCommands::Start),
+            Command::Service(ServiceCommands::Stop),
+            Command::Service(ServiceCommands::Status),
+        ] {
+            assert!(!command.is_server(), "{command:?} should be a CLI client");
+        }
+    }
+
+    #[test]
+    fn doctor_is_a_client() {
+        assert!(!Command::Doctor.is_server());
     }
 }

--- a/crates/oneiros-engine/src/engine.rs
+++ b/crates/oneiros-engine/src/engine.rs
@@ -43,7 +43,7 @@ impl Engine {
 
         engine.config().color.apply_global();
 
-        let _logging_guard = match Logging.install(engine.config()) {
+        let _logging_guard = match Logging.install(engine.config(), cli.command.is_server()) {
             Ok(guard) => guard,
             Err(error) => {
                 let _ = writeln!(stderr().lock(), "{}", ErrorView::new(error.into()));

--- a/crates/oneiros-engine/src/support/logging.rs
+++ b/crates/oneiros-engine/src/support/logging.rs
@@ -10,28 +10,38 @@ use tracing_subscriber::{
 
 use crate::*;
 
+/// Resolve the tracing filter directives for a given verbosity and surface.
+///
+/// Surfaces differ in what counts as "default noise." The server is a
+/// long-running process where info-level spans are the expected audit
+/// trail; the CLI is a short-lived client where the same spans are pure
+/// noise to the human at the terminal.
+///
+/// `aide` is muted off-info regardless because its startup chatter is
+/// never useful in either surface.
+pub(crate) fn level(verbosity: &Verbosity, is_server: bool) -> &'static str {
+    match (verbosity, is_server) {
+        (Verbosity::Quiet, true) => "warn,aide=warn",
+        (Verbosity::Normal, true) => "info,aide=warn",
+        (Verbosity::Verbose, true) => "debug,aide=warn",
+        (Verbosity::Quiet, false) => "off",
+        (Verbosity::Normal, false) => "off",
+        (Verbosity::Verbose, false) => "info,aide=warn",
+    }
+}
+
 pub(crate) struct Logging;
 
 impl Logging {
     /// Install the global tracing subscriber.
     ///
     /// Hold the returned guard until the process exits. Dropping it flushes
-    /// any pending file writes. `RUST_LOG` overrides `Config::verbosity`.
-    pub(crate) fn install(&self, config: &Config) -> std::io::Result<WorkerGuard> {
-        /// We flip off aide by default so it doesn't clog our logs with startup noise,
-        /// even if we're set to higher levels of info.
-        fn level(verbosity: &Verbosity) -> &'static str {
-            match verbosity {
-                Verbosity::Quiet => "warn,aide=warn",
-                Verbosity::Normal => "info,aide=warn",
-                Verbosity::Verbose => "debug,aide=warn",
-            }
-        }
-
+    /// any pending file writes. `RUST_LOG` overrides the surface default.
+    pub(crate) fn install(&self, config: &Config, is_server: bool) -> std::io::Result<WorkerGuard> {
         let (file_writer, guard) = tracing_appender::non_blocking(DailyLog::new(&config.data_dir)?);
 
         let filter = EnvFilter::try_from_default_env()
-            .unwrap_or_else(|_| EnvFilter::new(level(&config.verbosity)));
+            .unwrap_or_else(|_| EnvFilter::new(level(&config.verbosity, is_server)));
 
         let stderr_layer = tracing_subscriber::fmt::layer()
             .with_writer(std::io::stderr)
@@ -129,6 +139,36 @@ impl Write for DailyLog {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn server_default_emits_info() {
+        assert_eq!(level(&Verbosity::Normal, true), "info,aide=warn");
+    }
+
+    #[test]
+    fn server_quiet_drops_to_warn() {
+        assert_eq!(level(&Verbosity::Quiet, true), "warn,aide=warn");
+    }
+
+    #[test]
+    fn server_verbose_opens_to_debug() {
+        assert_eq!(level(&Verbosity::Verbose, true), "debug,aide=warn");
+    }
+
+    #[test]
+    fn cli_default_is_silent() {
+        assert_eq!(level(&Verbosity::Normal, false), "off");
+    }
+
+    #[test]
+    fn cli_quiet_is_silent() {
+        assert_eq!(level(&Verbosity::Quiet, false), "off");
+    }
+
+    #[test]
+    fn cli_verbose_restores_operational_trace() {
+        assert_eq!(level(&Verbosity::Verbose, false), "info,aide=warn");
+    }
 
     #[test]
     fn file_layer_writes_json_lines_to_dated_file() -> Result<(), Box<dyn core::error::Error>> {


### PR DESCRIPTION
We got a little overeager on our tracing output and so CLI output has been yarfing a bunch of log info into the terminal for a while. It's not useful. This commit removes that output unless a user asks via rust log env vars.