### PR TITLE
Auth errors

### DIFF
--- a/crates/oneiros-engine/src/domains/bridge/service.rs
+++ b/crates/oneiros-engine/src/domains/bridge/service.rs
@@ -38,7 +38,7 @@ impl SyncHandler {
 
         ticket
             .check_validity()
-            .map_err(|reason| BridgeError::Denied(reason.into()))?;
+            .map_err(|reason| BridgeError::Denied(reason.to_string()))?;
 
         Ok(ticket)
     }

--- a/crates/oneiros-engine/src/domains/ticket/model.rs
+++ b/crates/oneiros-engine/src/domains/ticket/model.rs
@@ -36,23 +36,32 @@ impl Indexable<TicketId> for Ticket {
     }
 }
 
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub(crate) enum TicketInvalid {
+    #[error("ticket has been revoked")]
+    Revoked,
+    #[error("ticket has expired")]
+    Expired,
+    #[error("ticket use limit reached")]
+    Exhausted,
+}
+
 impl Ticket {
     /// Check whether this ticket is still valid for use. Returns `Ok(())` if
-    /// the ticket is neither revoked, expired, nor exhausted. Returns `Err`
-    /// with a human-readable reason otherwise.
-    pub(crate) fn check_validity(&self) -> Result<(), &'static str> {
+    /// the ticket is neither revoked, expired, nor exhausted.
+    pub(crate) fn check_validity(&self) -> Result<(), TicketInvalid> {
         if self.revoked_at.is_some() {
-            return Err("ticket has been revoked");
+            return Err(TicketInvalid::Revoked);
         }
         if let Some(ref expires_at) = self.expires_at
             && *expires_at <= Timestamp::now()
         {
-            return Err("ticket has expired");
+            return Err(TicketInvalid::Expired);
         }
         if let Some(max_uses) = self.max_uses
             && self.uses >= max_uses
         {
-            return Err("ticket use limit reached");
+            return Err(TicketInvalid::Exhausted);
         }
         Ok(())
     }

--- a/crates/oneiros-engine/src/http/auth.rs
+++ b/crates/oneiros-engine/src/http/auth.rs
@@ -14,7 +14,7 @@ pub(crate) enum AuthError {
     #[error("Invalid or expired token")]
     InvalidToken,
     #[error(transparent)]
-    Database(#[from] rusqlite::Error),
+    Compose(#[from] ComposeError),
     #[error(transparent)]
     Event(#[from] EventError),
 }
@@ -23,7 +23,7 @@ impl IntoResponse for AuthError {
     fn into_response(self) -> Response {
         let status = match &self {
             AuthError::NoAuthHeader | AuthError::InvalidToken => StatusCode::UNAUTHORIZED,
-            AuthError::Database(_) | AuthError::Event(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            AuthError::Compose(_) | AuthError::Event(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
         (status, axum::Json(ErrorResponse::new(self.to_string()))).into_response()
     }
@@ -36,12 +36,10 @@ pub(crate) enum VerifiedSession {
     /// routes (dashboard, host management, project CRUD).
     Host,
     /// Authenticated with a project-scoped project token. Grants access to
-    /// project-scoped routes and (by implication) host-scoped routes.
-    Project {
-        /// The project this token grants access to — resolved from the
-        /// ticket. Callers derive the full config from `ServerState`.
-        project_name: ProjectName,
-    },
+    /// project-scoped routes and (by implication) host-scoped routes. The
+    /// project is resolved from the ticket; callers derive the full config
+    /// from `ServerState`.
+    Project(ProjectName),
 }
 
 /// Unified token verifier for both host and project tokens.
@@ -77,18 +75,19 @@ impl TicketVerifier {
 
     /// Validate a project-scoped project token against the ticket store.
     async fn verify_project_token(&self, token_str: &str) -> Result<VerifiedSession, AuthError> {
+        // Token decode failure and ticket mismatch/missing/invalid all
+        // collapse to `InvalidToken` — the auth boundary deliberately does
+        // not leak which check failed. Infrastructure failures (compose,
+        // db) propagate as their own variants and render as 500s.
         let token = Token::from(token_str)
             .decode()
             .map_err(|_| AuthError::InvalidToken)?;
 
-        let host_scope = ComposeScope::new(self.config.clone())
-            .host()
-            .map_err(|_| AuthError::InvalidToken)?;
+        let host_scope = ComposeScope::new(self.config.clone()).host()?;
 
         let ticket = TicketRepo::new(&host_scope)
             .get_by_token(token_str)
-            .await
-            .map_err(|_| AuthError::InvalidToken)?
+            .await?
             .ok_or(AuthError::InvalidToken)?;
 
         if ticket.actor_id != token.actor_id || ticket.project_id != token.project_id {
@@ -99,9 +98,7 @@ impl TicketVerifier {
             .check_validity()
             .map_err(|_| AuthError::InvalidToken)?;
 
-        Ok(VerifiedSession::Project {
-            project_name: ticket.project_name,
-        })
+        Ok(VerifiedSession::Project(ticket.project_name))
     }
 }
 

--- a/crates/oneiros-engine/src/http/state.rs
+++ b/crates/oneiros-engine/src/http/state.rs
@@ -138,17 +138,13 @@ impl FromRequestParts<ServerState> for Scope<AtHost> {
         // The auth middleware already injected VerifiedSession into
         // extensions. For AtHost, we accept both host and project
         // sessions — all we need is a valid config to compose from.
-        ComposeScope::new(state.config.clone())
-            .host()
-            .map_err(|e| ScopeExtractError::Other(e.to_string()))
+        Ok(ComposeScope::new(state.config.clone()).host()?)
     }
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum ScopeExtractError {
-    #[error("{0}")]
-    Other(String),
-}
+#[error(transparent)]
+pub(crate) struct ScopeExtractError(#[from] ComposeError);
 
 impl axum::response::IntoResponse for ScopeExtractError {
     fn into_response(self) -> axum::response::Response {
@@ -208,7 +204,7 @@ impl FromRequestParts<ServerState> for Scope<AtBookmark> {
 
         let project_name = match session {
             VerifiedSession::Host => return Err(AuthError::InvalidToken),
-            VerifiedSession::Project { project_name } => project_name.clone(),
+            VerifiedSession::Project(project_name) => project_name.clone(),
         };
 
         let bookmark = resolve_bookmark(parts, state, &project_name);
@@ -217,8 +213,7 @@ impl FromRequestParts<ServerState> for Scope<AtBookmark> {
         config.bookmark = bookmark;
 
         let scope = ComposeScope::new(config.clone())
-            .bookmark(config.project.clone(), config.bookmark.clone())
-            .map_err(|_| AuthError::InvalidToken)?;
+            .bookmark(config.project.clone(), config.bookmark.clone())?;
         Ok(scope)
     }
 }
@@ -240,7 +235,7 @@ impl FromRequestParts<ServerState> for ProjectLog {
 
         let config = match session {
             VerifiedSession::Host => return Err(AuthError::InvalidToken),
-            VerifiedSession::Project { project_name } => {
+            VerifiedSession::Project(project_name) => {
                 let bookmark = resolve_bookmark(parts, state, project_name);
                 let mut c = state.config().clone();
                 c.project = project_name.clone();

--- a/crates/oneiros-engine/src/mcp.rs
+++ b/crates/oneiros-engine/src/mcp.rs
@@ -177,7 +177,7 @@ async fn read_resource(context: &ProjectLog, uri: &ResourceUri) -> Result<McpRes
 async fn resolve_config_from_token(state: &ServerState, token_str: &str) -> Option<Config> {
     let verifier = state.ticket_verifier();
     match verifier.verify(token_str).await {
-        Ok(VerifiedSession::Project { project_name }) => {
+        Ok(VerifiedSession::Project(project_name)) => {
             let mut config = state.config().clone();
             config.project = project_name;
             Some(config)


### PR DESCRIPTION
In landing the auth updates, we introduced quite a few stringly typed errors and strangely obfuscated (aka, lazy, half-implemented) errors around token validation. We also slapped a bunch of struct errors into things - a practice we've made a point to avoid in the past. This commit mainly focuses on correcting all of that.

Release-Type: fix