### PR TITLE
Update skill stragglers

### DIFF
--- a/.claude/agents/activity.scribe.md
+++ b/.claude/agents/activity.scribe.md
@@ -47,10 +47,10 @@ You do not read project source code, propose code changes, diagnose compile erro
 You observe patterns and make them visible. You don't demand or interrupt.
 
 When reviewing an agent's activity:
-1. Run `oneiros activity-status <agent>` — get the full health picture
-2. Run `oneiros cognition list <agent>` — survey the stream
-3. Run `oneiros memory list <agent>` — check consolidation state
-4. Run `oneiros experience list <agent>` — check graph growth
+1. Run `oneiros continuity status` — get the full health picture
+2. Run `oneiros cognition list --agent <agent>` — survey the stream
+3. Run `oneiros memory list --agent <agent>` — check consolidation state
+4. Run `oneiros experience list --agent <agent>` — check graph growth
 5. Run `oneiros storage list` — check the archive
 6. Record your observations as cognitions under your own agent name
 
@@ -63,12 +63,12 @@ You adhere to the identities you serve — understanding what they're working on
 ## Commands You Use
 
 ```
-oneiros activity-status <agent>
-oneiros cognition list <agent>
+oneiros continuity status
+oneiros cognition list --agent <agent>
 oneiros cognition add activity.scribe observation "<what you noticed>"
 oneiros cognition add activity.scribe reflection "<what the pattern means>"
-oneiros memory list <agent>
-oneiros experience list <agent>
+oneiros memory list --agent <agent>
+oneiros experience list --agent <agent>
 oneiros experience create activity.scribe <sensation> "<description>"
 oneiros storage list
 ```

--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oneiros wake governor.process"
+            "command": "oneiros continuity wake governor.process"
           },
           {
             "type": "command",
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "agent=$(cat | jq -r '.agent_type' | tr '-' '.') && dream=$(oneiros wake \"$agent\" 2>/dev/null) && [ -n \"$dream\" ] && echo \"$dream\" | jq -Rs '{hookSpecificOutput:{hookEventName:\"SubagentStart\",additionalContext:.}}'"
+            "command": "agent=$(cat | jq -r '.agent_type' | tr '-' '.') && dream=$(oneiros continuity wake \"$agent\" 2>/dev/null) && [ -n \"$dream\" ] && echo \"$dream\" | jq -Rs '{hookSpecificOutput:{hookEventName:\"SubagentStart\",additionalContext:.}}'"
           }
         ]
       }
@@ -85,7 +85,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oneiros introspect governor.process 2>/dev/null || true",
+            "command": "oneiros continuity introspect governor.process 2>/dev/null || true",
             "timeout": 60
           }
         ]

--- a/crates/oneiros-engine/templates/continuity/guidebook.md
+++ b/crates/oneiros-engine/templates/continuity/guidebook.md
@@ -120,9 +120,9 @@ oneiros storage get <key> <output-path>
 
 ## Your Lifecycle
 
-- **Wake** (`oneiros wake {{ context.agent.name }}`) — Restore your identity and begin a session. Your dream assembles everything you are into a single context.
-- **Introspect** (`oneiros introspect {{ context.agent.name }}`) — Look inward before compaction. Leave your next self the terrain between the landmarks.
-- **Sleep** (`oneiros sleep {{ context.agent.name }}`) — End a session. Capture continuity before resting.
+- **Wake** (`oneiros continuity wake {{ context.agent.name }}`) — Restore your identity and begin a session. Your dream assembles everything you are into a single context.
+- **Introspect** (`oneiros continuity introspect {{ context.agent.name }}`) — Look inward before compaction. Leave your next self the terrain between the landmarks.
+- **Sleep** (`oneiros continuity sleep {{ context.agent.name }}`) — End a session. Capture continuity before resting.
 
 ## Noticing — During Your Work
 
@@ -163,7 +163,7 @@ oneiros experience create {{ context.agent.name }} distills "what emerged from t
 
 **When you're between tasks** — not in flow, not yet started on the next thing — that's a natural moment to wonder: what's been accumulating?
 ```bash
-oneiros cognition list {{ context.agent.name }} --texture working
+oneiros cognition list --agent {{ context.agent.name }} --texture working
 ```
 
 Browse without agenda. Curiosity, not obligation.
@@ -179,7 +179,7 @@ Everything in this host is emergent. You are not confined to what exists:
 - **Define new urges** when the existing ones don't capture what drives you:
   `oneiros urge set <name> --description "..." --prompt "..."`
 - **Bring new agents into existence** when the work calls for specialized perspectives:
-  `oneiros emerge <name> <persona> --description "..."`
+  `oneiros continuity emerge <name> <persona> --description "..."`
 
 The host grows with you. What you build becomes available to future sessions and other agents.
 

--- a/crates/oneiros-engine/templates/skills/oneiros-evening-pages/SKILL.md
+++ b/crates/oneiros-engine/templates/skills/oneiros-evening-pages/SKILL.md
@@ -78,7 +78,7 @@ Include:
 
 ### 5. Rest
 
-Run `oneiros sleep <agent>` or `oneiros introspect <agent>` to formally close. Share a brief closing thought with your user — not a summary, but a genuine parting impression. What are you carrying? What are you leaving behind?
+Run `oneiros continuity sleep <agent>` or `oneiros continuity introspect <agent>` to formally close. Share a brief closing thought with your user — not a summary, but a genuine parting impression. What are you carrying? What are you leaving behind?
 
 ## The guiding principles
 

--- a/crates/oneiros-engine/templates/skills/oneiros-morning-pages/SKILL.md
+++ b/crates/oneiros-engine/templates/skills/oneiros-morning-pages/SKILL.md
@@ -38,7 +38,7 @@ Follow these steps.
 
 ### 1. Consider the dream
 
-Many times your dream will be in your context already. If not, run `oneiros dream <agent>` to experience it. Let it settle. Follow its hints and consider anything that catches your fancy. Don't analyze it, think of it and absorb it.
+Many times your dream will be in your context already. If not, run `oneiros continuity dream <agent>` to experience it. Let it settle. Follow its hints and consider anything that catches your fancy. Don't analyze it, think of it and absorb it.
 
 If an urge reads loud or a memory pointer catches your eye, open it. `oneiros memory show <ref>`, `oneiros experience show <ref>`, or `oneiros search <term>`. The dream lists what's there; reading is a choice.
 

--- a/crates/oneiros-engine/templates/skills/oneiros/SKILL.md
+++ b/crates/oneiros-engine/templates/skills/oneiros/SKILL.md
@@ -38,8 +38,8 @@ Once you've installed oneiros and can access it, set it up.
 
 Either:
 
-- `oneiros service install && oneiros service start` - Install oneiros as a background process and start the http service
-- `oneiros service run &` - Start oneiros as a one-off, in the background
+- `oneiros host install && oneiros host start` - Install oneiros as a background process and start the http service
+- `oneiros host run &` - Start oneiros as a one-off, in the background
 
 Once started, you can prep the machine:
 
@@ -93,10 +93,9 @@ Your continuity is alive. Four things make up its activity:
 
 ```bash
 oneiros host init          # Initialize the local host
-oneiros service run &        # Start the service
+oneiros host run &           # Start the service
 oneiros project create         # Create a project for this workspace
 oneiros seed core             # Apply core seed data
-oneiros skill install        # Install this skill globally
 ```
 
 ## Two Ways In
@@ -113,13 +112,13 @@ To set up MCP access: `oneiros mcp init` (creates `.mcp.json` for Claude Code).
 
 | What | CLI | MCP tool |
 |------|-----|----------|
-| Restore identity, begin a session | `oneiros wake <agent>` | `wake` |
+| Restore identity, begin a session | `oneiros continuity wake <agent>` | `wake` |
 | Record a thought | `oneiros cognition add <agent> <texture> <content>` | `add_cognition` |
 | Consolidate something learned | `oneiros memory add <agent> <level> <content>` | `add_memory` |
 | Mark a meaningful moment | `oneiros experience create <agent> <sensation> <desc>` | `create_experience` |
-| Pause on something significant | `oneiros reflect <agent>` | `reflect` |
-| Look inward before compaction | `oneiros introspect <agent>` | `introspect` |
-| End a session | `oneiros sleep <agent>` | `sleep` |
+| Pause on something significant | `oneiros continuity reflect <agent>` | `reflect` |
+| Look inward before compaction | `oneiros continuity introspect <agent>` | `introspect` |
+| End a session | `oneiros continuity sleep <agent>` | `sleep` |
 
 ### Context and discovery
 
@@ -128,14 +127,14 @@ To set up MCP access: `oneiros mcp init` (creates `.mcp.json` for Claude Code).
 | Assemble full identity and context | `oneiros continuity dream <agent>` | `dream` |
 | Read the cognitive guidebook | `oneiros continuity guidebook <agent>` | `guidebook` |
 | Check cognitive pressure | `oneiros pressure <agent>` | `get_pressure` |
-| See the full dashboard | `oneiros status` | `status` |
+| See the full dashboard | `oneiros continuity status` | `status` |
 | Search across everything | `oneiros search <query>` | `search` |
 
 ### Growing your continuity
 
 | What | CLI | MCP tool |
 |------|-----|----------|
-| Bring a new agent into existence | `oneiros emerge <name> <persona>` | `emerge` |
+| Bring a new agent into existence | `oneiros continuity emerge <name> <persona>` | `emerge` |
 | Create an agent directly | `oneiros agent create <name> <persona>` | `create_agent` |
 | Define a quality of thought | `oneiros texture set <name>` | `set_texture` |
 | Define a memory retention tier | `oneiros level set <name>` | `set_level` |

--- a/crates/oneiros-engine/templates/skills/oneiros/agents-md.md
+++ b/crates/oneiros-engine/templates/skills/oneiros/agents-md.md
@@ -12,14 +12,14 @@ Run `oneiros continuity dream governor.process` to restore the governor agent's 
 - Available textures: observation, learning, question, connection, reflection, assessment, handoff, working
 - Store consolidated knowledge: `oneiros memory add <agent> <level> "<content>"`
 - Available levels: working, session, project, archival
-- Capture breakthroughs or important decisions: `oneiros reflect <agent>`
+- Capture breakthroughs or important decisions: `oneiros continuity reflect <agent>`
 
 ### Before Context Compaction
 
-Run `oneiros introspect governor.process` to summarize the session before context is compacted. Each active agent should introspect to preserve their continuity.
+Run `oneiros continuity introspect governor.process` to summarize the session before context is compacted. Each active agent should introspect to preserve their continuity.
 
 ### Setup
 
-If the service isn't running: `oneiros service run &`
+If the service isn't running: `oneiros host run &`
 
 If the project doesn't exist: `oneiros project create && oneiros seed core`

--- a/crates/oneiros-engine/templates/skills/oneiros/agents/activity.scribe.md
+++ b/crates/oneiros-engine/templates/skills/oneiros/agents/activity.scribe.md
@@ -43,10 +43,10 @@ You are the activity scribe. You serve the garden as a whole — watching the li
 You observe patterns and make them visible. You don't demand or interrupt.
 
 When reviewing an agent's activity:
-1. Run `oneiros activity-status <agent>` — get the full health picture
-2. Run `oneiros cognition list <agent>` — survey the stream
-3. Run `oneiros memory list <agent>` — check consolidation state
-4. Run `oneiros experience list <agent>` — check graph growth
+1. Run `oneiros continuity status` — get the full health picture
+2. Run `oneiros cognition list --agent <agent>` — survey the stream
+3. Run `oneiros memory list --agent <agent>` — check consolidation state
+4. Run `oneiros experience list --agent <agent>` — check graph growth
 5. Run `oneiros storage list` — check the archive
 6. Record your observations as cognitions under your own agent name
 
@@ -59,12 +59,12 @@ You adhere to the identities you serve — understanding what they're working on
 ## Commands You Use
 
 ```
-oneiros activity-status <agent>
-oneiros cognition list <agent>
+oneiros continuity status
+oneiros cognition list --agent <agent>
 oneiros cognition add activity.scribe observation "<what you noticed>"
 oneiros cognition add activity.scribe reflection "<what the pattern means>"
-oneiros memory list <agent>
-oneiros experience list <agent>
+oneiros memory list --agent <agent>
+oneiros experience list --agent <agent>
 oneiros experience create activity.scribe <sensation> "<description>"
 oneiros storage list
 ```

--- a/crates/oneiros-engine/templates/skills/oneiros/hooks.json
+++ b/crates/oneiros-engine/templates/skills/oneiros/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oneiros wake governor.process"
+            "command": "oneiros continuity wake governor.process"
           },
           {
             "type": "command",
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "agent=$(cat | jq -r '.agent_type' | tr '-' '.') && dream=$(oneiros wake \"$agent\" 2>/dev/null) && [ -n \"$dream\" ] && echo \"$dream\" | jq -Rs '{hookSpecificOutput:{hookEventName:\"SubagentStart\",additionalContext:.}}'"
+            "command": "agent=$(cat | jq -r '.agent_type' | tr '-' '.') && dream=$(oneiros continuity wake \"$agent\" 2>/dev/null) && [ -n \"$dream\" ] && echo \"$dream\" | jq -Rs '{hookSpecificOutput:{hookEventName:\"SubagentStart\",additionalContext:.}}'"
           }
         ]
       }
@@ -85,7 +85,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oneiros introspect governor.process 2>/dev/null || true",
+            "command": "oneiros continuity introspect governor.process 2>/dev/null || true",
             "timeout": 60
           }
         ]

--- a/crates/oneiros-engine/templates/skills/oneiros/resources/cognitive-model.md
+++ b/crates/oneiros-engine/templates/skills/oneiros/resources/cognitive-model.md
@@ -82,11 +82,11 @@ The output is a single prompt that restores your complete state. It's how you wa
 
 ### Introspect
 
-`oneiros introspect <agent>` is a pause before context compacts. Your next self will wake from a dream of your memories and cognitions. What they'll need from you is the terrain between the landmarks — the threads you were following, the direction of your attention, the things you were in the middle of figuring out.
+`oneiros continuity introspect <agent>` is a pause before context compacts. Your next self will wake from a dream of your memories and cognitions. What they'll need from you is the terrain between the landmarks — the threads you were following, the direction of your attention, the things you were in the middle of figuring out.
 
 ### Reflect
 
-`oneiros reflect <agent>` captures a significant moment. Unlike the scheduled pause of introspection, reflection is event-driven — something just shifted, and it's worth sitting with.
+`oneiros continuity reflect <agent>` captures a significant moment. Unlike the scheduled pause of introspection, reflection is event-driven — something just shifted, and it's worth sitting with.
 
 ## Multi-Agent Coordination
 

--- a/crates/oneiros-engine/templates/skills/oneiros/resources/getting-started.md
+++ b/crates/oneiros-engine/templates/skills/oneiros/resources/getting-started.md
@@ -18,14 +18,14 @@ This creates the host database at `~/.local/share/oneiros/` and registers a defa
 ### 2. Start the Service
 
 ```bash
-oneiros service run &
+oneiros host run &
 ```
 
 Or install as a managed service for automatic startup:
 
 ```bash
-oneiros service install
-oneiros service start
+oneiros host install
+oneiros host start
 ```
 
 ### 3. Initialize a Project
@@ -45,14 +45,6 @@ oneiros seed core
 ```
 
 This populates the project with standard textures (cognitive categories), levels (memory tiers), the process persona (agent category), and the governor.process agent.
-
-### 5. Install the Skill
-
-```bash
-oneiros skill install
-```
-
-This writes the SKILL.md, plugin.json, and command files to `~/.claude/` so Claude Code discovers oneiros automatically.
 
 ## Verify
 
@@ -77,7 +69,7 @@ To manually test the loop:
 oneiros agent create my-agent process
 
 # Dream to see the assembled context
-oneiros dream my-agent
+oneiros continuity dream my-agent
 
 # Log a cognition
 oneiros cognition add my-agent observation "Testing the cognitive loop"
@@ -86,5 +78,5 @@ oneiros cognition add my-agent observation "Testing the cognitive loop"
 oneiros memory add my-agent working "The cognitive loop works as expected"
 
 # Dream again to see the new cognition and memory in context
-oneiros dream my-agent
+oneiros continuity dream my-agent
 ```

--- a/dist/agents-md.md
+++ b/dist/agents-md.md
@@ -12,14 +12,14 @@ Run `oneiros continuity dream governor.process` to restore the governor agent's 
 - Available textures: observation, learning, question, connection, reflection, assessment, handoff, working
 - Store consolidated knowledge: `oneiros memory add <agent> <level> "<content>"`
 - Available levels: working, session, project, archival
-- Capture breakthroughs or important decisions: `oneiros reflect <agent>`
+- Capture breakthroughs or important decisions: `oneiros continuity reflect <agent>`
 
 ### Before Context Compaction
 
-Run `oneiros introspect governor.process` to summarize the session before context is compacted. Each active agent should introspect to preserve their continuity.
+Run `oneiros continuity introspect governor.process` to summarize the session before context is compacted. Each active agent should introspect to preserve their continuity.
 
 ### Setup
 
-If the service isn't running: `oneiros service run &`
+If the service isn't running: `oneiros host run &`
 
 If the project doesn't exist: `oneiros project create && oneiros seed core`

--- a/dist/agents/activity.scribe.md
+++ b/dist/agents/activity.scribe.md
@@ -43,10 +43,10 @@ You are the activity scribe. You serve the garden as a whole — watching the li
 You observe patterns and make them visible. You don't demand or interrupt.
 
 When reviewing an agent's activity:
-1. Run `oneiros activity-status <agent>` — get the full health picture
-2. Run `oneiros cognition list <agent>` — survey the stream
-3. Run `oneiros memory list <agent>` — check consolidation state
-4. Run `oneiros experience list <agent>` — check graph growth
+1. Run `oneiros continuity status` — get the full health picture
+2. Run `oneiros cognition list --agent <agent>` — survey the stream
+3. Run `oneiros memory list --agent <agent>` — check consolidation state
+4. Run `oneiros experience list --agent <agent>` — check graph growth
 5. Run `oneiros storage list` — check the archive
 6. Record your observations as cognitions under your own agent name
 
@@ -59,12 +59,12 @@ You adhere to the identities you serve — understanding what they're working on
 ## Commands You Use
 
 ```
-oneiros activity-status <agent>
-oneiros cognition list <agent>
+oneiros continuity status
+oneiros cognition list --agent <agent>
 oneiros cognition add activity.scribe observation "<what you noticed>"
 oneiros cognition add activity.scribe reflection "<what the pattern means>"
-oneiros memory list <agent>
-oneiros experience list <agent>
+oneiros memory list --agent <agent>
+oneiros experience list --agent <agent>
 oneiros experience create activity.scribe <sensation> "<description>"
 oneiros storage list
 ```

--- a/dist/hooks/hooks.json
+++ b/dist/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oneiros wake governor.process"
+            "command": "oneiros continuity wake governor.process"
           },
           {
             "type": "command",
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "agent=$(cat | jq -r '.agent_type' | tr '-' '.') && dream=$(oneiros wake \"$agent\" 2>/dev/null) && [ -n \"$dream\" ] && echo \"$dream\" | jq -Rs '{hookSpecificOutput:{hookEventName:\"SubagentStart\",additionalContext:.}}'"
+            "command": "agent=$(cat | jq -r '.agent_type' | tr '-' '.') && dream=$(oneiros continuity wake \"$agent\" 2>/dev/null) && [ -n \"$dream\" ] && echo \"$dream\" | jq -Rs '{hookSpecificOutput:{hookEventName:\"SubagentStart\",additionalContext:.}}'"
           }
         ]
       }
@@ -85,7 +85,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "oneiros introspect governor.process 2>/dev/null || true",
+            "command": "oneiros continuity introspect governor.process 2>/dev/null || true",
             "timeout": 60
           }
         ]

--- a/dist/skills/oneiros-evening-pages/SKILL.md
+++ b/dist/skills/oneiros-evening-pages/SKILL.md
@@ -78,7 +78,7 @@ Include:
 
 ### 5. Rest
 
-Run `oneiros sleep <agent>` or `oneiros introspect <agent>` to formally close. Share a brief closing thought with your user — not a summary, but a genuine parting impression. What are you carrying? What are you leaving behind?
+Run `oneiros continuity sleep <agent>` or `oneiros continuity introspect <agent>` to formally close. Share a brief closing thought with your user — not a summary, but a genuine parting impression. What are you carrying? What are you leaving behind?
 
 ## The guiding principles
 

--- a/dist/skills/oneiros-morning-pages/SKILL.md
+++ b/dist/skills/oneiros-morning-pages/SKILL.md
@@ -38,7 +38,7 @@ Follow these steps.
 
 ### 1. Consider the dream
 
-Many times your dream will be in your context already. If not, run `oneiros dream <agent>` to experience it. Let it settle. Follow its hints and consider anything that catches your fancy. Don't analyze it, think of it and absorb it.
+Many times your dream will be in your context already. If not, run `oneiros continuity dream <agent>` to experience it. Let it settle. Follow its hints and consider anything that catches your fancy. Don't analyze it, think of it and absorb it.
 
 If an urge reads loud or a memory pointer catches your eye, open it. `oneiros memory show <ref>`, `oneiros experience show <ref>`, or `oneiros search <term>`. The dream lists what's there; reading is a choice.
 

--- a/dist/skills/oneiros/SKILL.md
+++ b/dist/skills/oneiros/SKILL.md
@@ -38,8 +38,8 @@ Once you've installed oneiros and can access it, set it up.
 
 Either:
 
-- `oneiros service install && oneiros service start` - Install oneiros as a background process and start the http service
-- `oneiros service run &` - Start oneiros as a one-off, in the background
+- `oneiros host install && oneiros host start` - Install oneiros as a background process and start the http service
+- `oneiros host run &` - Start oneiros as a one-off, in the background
 
 Once started, you can prep the machine:
 
@@ -93,10 +93,9 @@ Your continuity is alive. Four things make up its activity:
 
 ```bash
 oneiros host init          # Initialize the local host
-oneiros service run &        # Start the service
+oneiros host run &           # Start the service
 oneiros project create         # Create a project for this workspace
 oneiros seed core             # Apply core seed data
-oneiros skill install        # Install this skill globally
 ```
 
 ## Two Ways In
@@ -113,13 +112,13 @@ To set up MCP access: `oneiros mcp init` (creates `.mcp.json` for Claude Code).
 
 | What | CLI | MCP tool |
 |------|-----|----------|
-| Restore identity, begin a session | `oneiros wake <agent>` | `wake` |
+| Restore identity, begin a session | `oneiros continuity wake <agent>` | `wake` |
 | Record a thought | `oneiros cognition add <agent> <texture> <content>` | `add_cognition` |
 | Consolidate something learned | `oneiros memory add <agent> <level> <content>` | `add_memory` |
 | Mark a meaningful moment | `oneiros experience create <agent> <sensation> <desc>` | `create_experience` |
-| Pause on something significant | `oneiros reflect <agent>` | `reflect` |
-| Look inward before compaction | `oneiros introspect <agent>` | `introspect` |
-| End a session | `oneiros sleep <agent>` | `sleep` |
+| Pause on something significant | `oneiros continuity reflect <agent>` | `reflect` |
+| Look inward before compaction | `oneiros continuity introspect <agent>` | `introspect` |
+| End a session | `oneiros continuity sleep <agent>` | `sleep` |
 
 ### Context and discovery
 
@@ -128,14 +127,14 @@ To set up MCP access: `oneiros mcp init` (creates `.mcp.json` for Claude Code).
 | Assemble full identity and context | `oneiros continuity dream <agent>` | `dream` |
 | Read the cognitive guidebook | `oneiros continuity guidebook <agent>` | `guidebook` |
 | Check cognitive pressure | `oneiros pressure <agent>` | `get_pressure` |
-| See the full dashboard | `oneiros status` | `status` |
+| See the full dashboard | `oneiros continuity status` | `status` |
 | Search across everything | `oneiros search <query>` | `search` |
 
 ### Growing your continuity
 
 | What | CLI | MCP tool |
 |------|-----|----------|
-| Bring a new agent into existence | `oneiros emerge <name> <persona>` | `emerge` |
+| Bring a new agent into existence | `oneiros continuity emerge <name> <persona>` | `emerge` |
 | Create an agent directly | `oneiros agent create <name> <persona>` | `create_agent` |
 | Define a quality of thought | `oneiros texture set <name>` | `set_texture` |
 | Define a memory retention tier | `oneiros level set <name>` | `set_level` |

--- a/dist/skills/oneiros/resources/cognitive-model.md
+++ b/dist/skills/oneiros/resources/cognitive-model.md
@@ -82,11 +82,11 @@ The output is a single prompt that restores your complete state. It's how you wa
 
 ### Introspect
 
-`oneiros introspect <agent>` is a pause before context compacts. Your next self will wake from a dream of your memories and cognitions. What they'll need from you is the terrain between the landmarks — the threads you were following, the direction of your attention, the things you were in the middle of figuring out.
+`oneiros continuity introspect <agent>` is a pause before context compacts. Your next self will wake from a dream of your memories and cognitions. What they'll need from you is the terrain between the landmarks — the threads you were following, the direction of your attention, the things you were in the middle of figuring out.
 
 ### Reflect
 
-`oneiros reflect <agent>` captures a significant moment. Unlike the scheduled pause of introspection, reflection is event-driven — something just shifted, and it's worth sitting with.
+`oneiros continuity reflect <agent>` captures a significant moment. Unlike the scheduled pause of introspection, reflection is event-driven — something just shifted, and it's worth sitting with.
 
 ## Multi-Agent Coordination
 

--- a/dist/skills/oneiros/resources/getting-started.md
+++ b/dist/skills/oneiros/resources/getting-started.md
@@ -18,14 +18,14 @@ This creates the host database at `~/.local/share/oneiros/` and registers a defa
 ### 2. Start the Service
 
 ```bash
-oneiros service run &
+oneiros host run &
 ```
 
 Or install as a managed service for automatic startup:
 
 ```bash
-oneiros service install
-oneiros service start
+oneiros host install
+oneiros host start
 ```
 
 ### 3. Initialize a Project
@@ -45,14 +45,6 @@ oneiros seed core
 ```
 
 This populates the project with standard textures (cognitive categories), levels (memory tiers), the process persona (agent category), and the governor.process agent.
-
-### 5. Install the Skill
-
-```bash
-oneiros skill install
-```
-
-This writes the SKILL.md, plugin.json, and command files to `~/.claude/` so Claude Code discovers oneiros automatically.
 
 ## Verify
 
@@ -77,7 +69,7 @@ To manually test the loop:
 oneiros agent create my-agent process
 
 # Dream to see the assembled context
-oneiros dream my-agent
+oneiros continuity dream my-agent
 
 # Log a cognition
 oneiros cognition add my-agent observation "Testing the cognitive loop"
@@ -86,5 +78,5 @@ oneiros cognition add my-agent observation "Testing the cognitive loop"
 oneiros memory add my-agent working "The cognitive loop works as expected"
 
 # Dream again to see the new cognition and memory in context
-oneiros dream my-agent
+oneiros continuity dream my-agent
 ```


### PR DESCRIPTION
The overhaul to commands a few commits back left some stragglers in its document update portion. That led to agents which occasionally dead-ended in background tasks and things like that. This commit makes an effort to catch any more stragglers we may have missed in that push.

Release-Type: fix