### PR TITLE
Trails

### DIFF
--- a/crates/oneiros-engine/src/cli.rs
+++ b/crates/oneiros-engine/src/cli.rs
@@ -112,6 +112,10 @@ pub(crate) enum Command {
     #[command(subcommand)]
     Continuity(ContinuityCommands),
 
+    /// Walk the events ↔ entities bridge
+    #[command(subcommand)]
+    Trail(TrailCommands),
+
     /// Run diagnostics against the local host
     Doctor,
 }
@@ -162,6 +166,7 @@ impl Command {
             Command::Tenant(tenant) => tenant.execute(config).await?,
             Command::Texture(texture) => texture.execute(config).await?,
             Command::Ticket(ticket) => ticket.execute(config).await?,
+            Command::Trail(trail) => trail.execute(config).await?,
             Command::Urge(urge) => urge.execute(config).await?,
         })
     }

--- a/crates/oneiros-engine/src/docs.rs
+++ b/crates/oneiros-engine/src/docs.rs
@@ -49,6 +49,7 @@ impl AppDocs {
             TenantDocs::Create.tag(),
             TextureDocs::List.tag(),
             TicketDocs::Create.tag(),
+            TrailDocs::Of.tag(),
             UrgeDocs::List.tag(),
         ]
     }

--- a/crates/oneiros-engine/src/domains/event/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/event/protocol/errors.rs
@@ -16,6 +16,9 @@ pub(crate) enum EventError {
     TimestampParse(#[from] TimestampParseError),
 
     #[error(transparent)]
+    RefParse(#[from] RefError),
+
+    #[error(transparent)]
     Blob(#[from] BlobError),
 
     #[error(transparent)]

--- a/crates/oneiros-engine/src/domains/mod.rs
+++ b/crates/oneiros-engine/src/domains/mod.rs
@@ -26,6 +26,7 @@ mod storage;
 mod tenant;
 mod texture;
 mod ticket;
+mod trail;
 mod urge;
 
 pub(crate) mod event;
@@ -59,4 +60,5 @@ pub(crate) use storage::*;
 pub(crate) use tenant::*;
 pub(crate) use texture::*;
 pub(crate) use ticket::*;
+pub(crate) use trail::*;
 pub(crate) use urge::*;

--- a/crates/oneiros-engine/src/domains/trail/docs.rs
+++ b/crates/oneiros-engine/src/domains/trail/docs.rs
@@ -1,0 +1,35 @@
+use crate::*;
+
+pub(crate) enum TrailDocs {
+    Of,
+    From,
+}
+
+impl TrailDocs {
+    pub(crate) fn tag(&self) -> Tag {
+        Tag::builder()
+            .name("trail")
+            .description(
+                "Walk the events ↔ entities bridge — `of <ref>` lists the events that touched an entity; `from <event-id>` lists the entities an event emitted",
+            )
+            .build()
+    }
+
+    pub(crate) fn resource_docs(&self) -> ResourceDocs {
+        let tag = self.tag();
+        match self {
+            Self::Of => ResourceDocs::builder()
+                .tag(tag)
+                .nickname("trail-of")
+                .summary("Events that touched an entity")
+                .description("Return the events that touched the entity at this ref, oldest first.")
+                .build(),
+            Self::From => ResourceDocs::builder()
+                .tag(tag)
+                .nickname("trail-from")
+                .summary("Entities emitted by an event")
+                .description("Return the entity refs that this event emitted.")
+                .build(),
+        }
+    }
+}

--- a/crates/oneiros-engine/src/domains/trail/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/trail/features/cli.rs
@@ -1,0 +1,25 @@
+use clap::Subcommand;
+
+use crate::*;
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum TrailCommands {
+    /// Events that touched an entity
+    Of(TrailOf),
+    /// Entities emitted by an event
+    From(TrailFrom),
+}
+
+impl TrailCommands {
+    pub(crate) async fn execute(&self, config: &Config) -> Result<Rendered<Responses>, TrailError> {
+        let client = Client::from_config(config)?;
+
+        let bytes = match self {
+            Self::Of(of) => of.execute_request(&client).await?,
+            Self::From(from) => from.execute_request(&client).await?,
+        };
+
+        let response: TrailResponse = serde_json::from_slice(&bytes)?;
+        Ok(TrailView::new(response).render().map(Into::into))
+    }
+}

--- a/crates/oneiros-engine/src/domains/trail/features/http.rs
+++ b/crates/oneiros-engine/src/domains/trail/features/http.rs
@@ -1,0 +1,41 @@
+use aide::axum::{ApiRouter, routing};
+use axum::{Json, extract::Path};
+
+use crate::*;
+
+pub(crate) struct TrailRouter;
+
+impl TrailRouter {
+    pub(crate) fn routes(&self) -> ApiRouter<ServerState> {
+        ApiRouter::new().nest(
+            "/trail",
+            ApiRouter::<ServerState>::new()
+                .api_route(
+                    "/of/{ref}",
+                    routing::get_with(of, |op| {
+                        resource_op!(op, TrailDocs::Of).security_requirement("BearerToken")
+                    }),
+                )
+                .api_route(
+                    "/from/{event_id}",
+                    routing::get_with(from, |op| {
+                        resource_op!(op, TrailDocs::From).security_requirement("BearerToken")
+                    }),
+                ),
+        )
+    }
+}
+
+async fn of(
+    scope: Scope<AtBookmark>,
+    Path(entity_ref): Path<RefToken>,
+) -> Result<Json<TrailResponse>, TrailError> {
+    Ok(Json(TrailService::of(&scope, &entity_ref).await?))
+}
+
+async fn from(
+    scope: Scope<AtBookmark>,
+    Path(event_id): Path<EventId>,
+) -> Result<Json<TrailResponse>, TrailError> {
+    Ok(Json(TrailService::from(&scope, event_id).await?))
+}

--- a/crates/oneiros-engine/src/domains/trail/features/mod.rs
+++ b/crates/oneiros-engine/src/domains/trail/features/mod.rs
@@ -1,0 +1,9 @@
+mod cli;
+mod http;
+mod projections;
+mod skills;
+
+pub(crate) use cli::*;
+pub(crate) use http::*;
+pub(crate) use projections::*;
+pub(crate) use skills::*;

--- a/crates/oneiros-engine/src/domains/trail/features/projections.rs
+++ b/crates/oneiros-engine/src/domains/trail/features/projections.rs
@@ -1,0 +1,16 @@
+use crate::*;
+
+pub(crate) struct TrailProjections;
+
+impl TrailProjections {
+    pub(crate) const fn all(&self) -> &'static [Projection] {
+        PROJECTIONS
+    }
+}
+
+const PROJECTIONS: &[Projection] = &[Projection {
+    name: "trail",
+    migrate: |conn| TrailStore::new(conn).migrate(),
+    apply: |conn, event| TrailStore::new(conn).handle(event),
+    reset: |conn| TrailStore::new(conn).reset(),
+}];

--- a/crates/oneiros-engine/src/domains/trail/features/skills.rs
+++ b/crates/oneiros-engine/src/domains/trail/features/skills.rs
@@ -1,0 +1,12 @@
+use crate::Skill;
+
+pub(crate) struct TrailSkills;
+
+impl TrailSkills {
+    pub(crate) fn all() -> Vec<Skill> {
+        vec![
+            Skill::new("trail-of", include_str!("skills/of.md")),
+            Skill::new("trail-from", include_str!("skills/from.md")),
+        ]
+    }
+}

--- a/crates/oneiros-engine/src/domains/trail/features/skills/from.md
+++ b/crates/oneiros-engine/src/domains/trail/features/skills/from.md
@@ -1,0 +1,6 @@
+---
+name: trail-from
+description: Walk forward from an event to the entities it emitted
+---
+
+Run `oneiros trail from <event-id>` to list the entity refs that an event emitted. Use this when inspecting an event and you want to see which entities it produced or touched.

--- a/crates/oneiros-engine/src/domains/trail/features/skills/of.md
+++ b/crates/oneiros-engine/src/domains/trail/features/skills/of.md
@@ -1,0 +1,6 @@
+---
+name: trail-of
+description: Walk back from an entity to the events that touched it
+---
+
+Run `oneiros trail of <ref>` to list the events that touched an entity, oldest first. Use this when you have a ref (cognition, memory, agent, etc.) and want to see its event-level lineage.

--- a/crates/oneiros-engine/src/domains/trail/mod.rs
+++ b/crates/oneiros-engine/src/domains/trail/mod.rs
@@ -1,0 +1,17 @@
+mod docs;
+mod features;
+mod model;
+mod protocol;
+mod repo;
+mod service;
+mod store;
+mod view;
+
+pub(crate) use docs::*;
+pub(crate) use features::*;
+pub(crate) use model::*;
+pub(crate) use protocol::*;
+pub(crate) use repo::*;
+pub(crate) use service::*;
+pub(crate) use store::*;
+pub(crate) use view::*;

--- a/crates/oneiros-engine/src/domains/trail/model.rs
+++ b/crates/oneiros-engine/src/domains/trail/model.rs
@@ -1,0 +1,18 @@
+use bon::Builder;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::*;
+
+/// One row in the trail projection — the bridge between an event and an
+/// entity it touched. The shape is a set-many join on both sides: an event
+/// can emit many entities, an entity can be touched by many events. Initial
+/// derivation rules keep each side small (typically 1:1 at creation time).
+#[derive(Debug, Clone, PartialEq, Eq, Builder, Serialize, Deserialize, JsonSchema)]
+pub(crate) struct TrailEntry {
+    pub(crate) event_id: EventId,
+    pub(crate) event_type: String,
+    #[serde(rename = "ref")]
+    pub(crate) entity_ref: RefToken,
+    pub(crate) created_at: Timestamp,
+}

--- a/crates/oneiros-engine/src/domains/trail/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/trail/protocol/errors.rs
@@ -1,0 +1,52 @@
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+use crate::{ErrorResponse, resource_op_error};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum TrailError {
+    #[error("Database error: {0}")]
+    Database(#[from] rusqlite::Error),
+
+    #[error(transparent)]
+    Compose(#[from] crate::ComposeError),
+
+    #[error(transparent)]
+    Event(#[from] crate::EventError),
+
+    #[error(transparent)]
+    Client(#[from] crate::ClientError),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Ref(#[from] crate::RefError),
+}
+
+impl IntoResponse for TrailError {
+    fn into_response(self) -> Response {
+        let (status, body) = match &self {
+            TrailError::Database(_) | TrailError::Event(_) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorResponse::new(self.to_string()),
+            ),
+            TrailError::Compose(_) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ErrorResponse::new(self.to_string()),
+            ),
+            TrailError::Client(_) | TrailError::Json(_) => (
+                StatusCode::BAD_GATEWAY,
+                ErrorResponse::new(self.to_string()),
+            ),
+            TrailError::Ref(_) => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                ErrorResponse::new(self.to_string()).with_code("invalid_ref"),
+            ),
+        };
+        (status, Json(body)).into_response()
+    }
+}
+
+resource_op_error!(TrailError);

--- a/crates/oneiros-engine/src/domains/trail/protocol/mod.rs
+++ b/crates/oneiros-engine/src/domains/trail/protocol/mod.rs
@@ -1,0 +1,11 @@
+mod errors;
+mod requests;
+mod responses;
+
+pub(crate) use errors::*;
+pub(crate) use requests::*;
+pub(crate) use responses::*;
+
+// Trail emits no events — it's a projection over every other domain's
+// events. The derivation rule lives in the projection's `apply`. There is
+// no `TrailEvents`.

--- a/crates/oneiros-engine/src/domains/trail/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/trail/protocol/requests.rs
@@ -1,0 +1,68 @@
+use kinded::Kinded;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::*;
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub(crate) enum TrailOf {
+        #[derive(clap::Args)]
+        V1 => {
+            /// The entity ref to walk back from — events that touched this entity.
+            #[builder(into)]
+            #[serde(rename = "ref")]
+            #[arg(name = "ref")]
+            pub(crate) r#ref: RefToken,
+        }
+    }
+}
+
+impl ClientRequest for TrailOf {
+    type Error = ClientError;
+
+    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
+        let TrailOf::V1(of) = self;
+        client.get(&format!("/trail/of/{}", of.r#ref)).await
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub(crate) enum TrailFrom {
+        #[derive(clap::Args)]
+        V1 => {
+            /// The event id to walk forward from — entities this event emitted.
+            #[builder(into)]
+            pub(crate) event: EventId,
+        }
+    }
+}
+
+impl ClientRequest for TrailFrom {
+    type Error = ClientError;
+
+    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
+        let TrailFrom::V1(from) = self;
+        client.get(&format!("/trail/from/{}", from.event)).await
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]
+#[serde(tag = "type", content = "data", rename_all = "kebab-case")]
+#[kinded(kind = TrailRequestType, display = "kebab-case")]
+pub(crate) enum TrailRequest {
+    TrailOf(TrailOf),
+    TrailFrom(TrailFrom),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_types_are_kebab_cased() {
+        assert_eq!(&TrailRequestType::TrailOf.to_string(), "trail-of");
+        assert_eq!(&TrailRequestType::TrailFrom.to_string(), "trail-from");
+    }
+}

--- a/crates/oneiros-engine/src/domains/trail/protocol/responses.rs
+++ b/crates/oneiros-engine/src/domains/trail/protocol/responses.rs
@@ -1,0 +1,34 @@
+use kinded::Kinded;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::*;
+
+#[derive(Debug, Clone, Kinded, Serialize, Deserialize, JsonSchema)]
+#[kinded(kind = TrailResponseType, display = "kebab-case")]
+#[serde(tag = "type", content = "data", rename_all = "kebab-case")]
+pub(crate) enum TrailResponse {
+    TrailEvents(TrailEventsResponse),
+    EmittedRefs(EmittedRefsResponse),
+    NoTrail,
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub(crate) enum TrailEventsResponse {
+        V1 => {
+            pub(crate) items: Vec<TrailEntry>,
+            pub(crate) total: usize,
+        }
+    }
+}
+
+versioned! {
+    #[derive(JsonSchema)]
+    pub(crate) enum EmittedRefsResponse {
+        V1 => {
+            pub(crate) items: Vec<RefToken>,
+            pub(crate) total: usize,
+        }
+    }
+}

--- a/crates/oneiros-engine/src/domains/trail/repo.rs
+++ b/crates/oneiros-engine/src/domains/trail/repo.rs
@@ -1,0 +1,72 @@
+use rusqlite::params;
+
+use crate::*;
+
+/// Trail read model — async queries over the projection.
+pub(crate) struct TrailRepo<'a> {
+    scope: &'a Scope<AtBookmark>,
+}
+
+impl<'a> TrailRepo<'a> {
+    pub(crate) fn new(scope: &'a Scope<AtBookmark>) -> Self {
+        Self { scope }
+    }
+
+    /// Events that touched the given entity, oldest first.
+    pub(crate) async fn events_for(
+        &self,
+        entity_ref: &RefToken,
+    ) -> Result<Vec<TrailEntry>, EventError> {
+        let db = BookmarkDb::open(self.scope).await?;
+        let mut stmt = db.prepare(
+            "SELECT event_id, ref, event_type, created_at
+             FROM trail
+             WHERE ref = ?1
+             ORDER BY created_at ASC",
+        )?;
+
+        let rows: Vec<TrailRow> = stmt
+            .query_map(params![entity_ref.to_string()], read_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        rows.into_iter().map(entry_from_row).collect()
+    }
+
+    /// Entity refs the given event emitted, in insertion order.
+    pub(crate) async fn refs_from(&self, event_id: EventId) -> Result<Vec<RefToken>, EventError> {
+        let db = BookmarkDb::open(self.scope).await?;
+        let mut stmt = db.prepare(
+            "SELECT ref
+             FROM trail
+             WHERE event_id = ?1
+             ORDER BY ref ASC",
+        )?;
+
+        let rows = stmt
+            .query_map(params![event_id.to_string()], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut refs = Vec::with_capacity(rows.len());
+        for raw in rows {
+            refs.push(raw.parse()?);
+        }
+        Ok(refs)
+    }
+}
+
+type TrailRow = (String, String, String, String);
+
+fn read_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrailRow> {
+    Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+}
+
+fn entry_from_row(
+    (event_id, entity_ref, event_type, created_at): TrailRow,
+) -> Result<TrailEntry, EventError> {
+    Ok(TrailEntry::builder()
+        .event_id(event_id.parse()?)
+        .entity_ref(entity_ref.parse()?)
+        .event_type(event_type)
+        .created_at(Timestamp::parse_str(&created_at)?)
+        .build())
+}

--- a/crates/oneiros-engine/src/domains/trail/service.rs
+++ b/crates/oneiros-engine/src/domains/trail/service.rs
@@ -1,0 +1,43 @@
+use crate::*;
+
+pub(crate) struct TrailService;
+
+impl TrailService {
+    /// Events that touched the given entity, oldest first.
+    pub(crate) async fn of(
+        scope: &Scope<AtBookmark>,
+        entity_ref: &RefToken,
+    ) -> Result<TrailResponse, TrailError> {
+        let items = TrailRepo::new(scope).events_for(entity_ref).await?;
+        if items.is_empty() {
+            return Ok(TrailResponse::NoTrail);
+        }
+        let total = items.len();
+        Ok(TrailResponse::TrailEvents(
+            TrailEventsResponse::builder_v1()
+                .items(items)
+                .total(total)
+                .build()
+                .into(),
+        ))
+    }
+
+    /// Entity refs the given event emitted.
+    pub(crate) async fn from(
+        scope: &Scope<AtBookmark>,
+        event_id: EventId,
+    ) -> Result<TrailResponse, TrailError> {
+        let items = TrailRepo::new(scope).refs_from(event_id).await?;
+        if items.is_empty() {
+            return Ok(TrailResponse::NoTrail);
+        }
+        let total = items.len();
+        Ok(TrailResponse::EmittedRefs(
+            EmittedRefsResponse::builder_v1()
+                .items(items)
+                .total(total)
+                .build()
+                .into(),
+        ))
+    }
+}

--- a/crates/oneiros-engine/src/domains/trail/store.rs
+++ b/crates/oneiros-engine/src/domains/trail/store.rs
@@ -1,0 +1,234 @@
+use rusqlite::params;
+
+use crate::*;
+
+/// Trail projection store — the events ↔ entities bridge.
+///
+/// Each row joins one event with one entity it touched. Multiple rows per
+/// entity are expected (an entity is touched by many events). Multiple rows
+/// per event are allowed by the schema, even though current derivation rules
+/// usually emit 1:1 at creation time.
+///
+/// The primary key (`event_id`, `ref`) makes replay idempotent on its own —
+/// a second `apply` of the same event lands on the existing row.
+pub(crate) struct TrailStore<'a> {
+    conn: &'a rusqlite::Connection,
+}
+
+impl<'a> TrailStore<'a> {
+    pub(crate) fn new(conn: &'a rusqlite::Connection) -> Self {
+        Self { conn }
+    }
+
+    pub(crate) fn migrate(&self) -> Result<(), EventError> {
+        self.conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS trail (
+                event_id TEXT NOT NULL,
+                ref TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY (event_id, ref)
+            );
+             CREATE INDEX IF NOT EXISTS trail_ref_created_at
+                ON trail (ref, created_at);
+             CREATE INDEX IF NOT EXISTS trail_event_id
+                ON trail (event_id);",
+        )?;
+        Ok(())
+    }
+
+    pub(crate) fn reset(&self) -> Result<(), EventError> {
+        self.conn.execute("DELETE FROM trail", [])?;
+        Ok(())
+    }
+
+    /// Apply a single stored event: derive the refs it touches and insert a
+    /// row per ref. Replay-safe via `INSERT OR REPLACE` on the composite
+    /// primary key.
+    pub(crate) fn handle(&self, event: &StoredEvent) -> Result<(), EventError> {
+        let Event::Known(known) = &event.data else {
+            return Ok(());
+        };
+
+        let event_type = known.event_type();
+        let refs = derive_refs(known);
+
+        for entity_ref in refs {
+            let ref_token = RefToken::new(entity_ref).to_string();
+            self.conn.execute(
+                "INSERT OR REPLACE INTO trail (event_id, ref, event_type, created_at)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    event.id.to_string(),
+                    ref_token,
+                    event_type,
+                    event.created_at.as_string(),
+                ],
+            )?;
+        }
+        Ok(())
+    }
+}
+
+/// Pure derivation rule: given an event, return the refs of the entities it
+/// touched. Single source of truth for what the trail projection records.
+///
+/// Policy:
+/// - Entity-creating/mutating/removing events emit the touched entity's ref.
+/// - Cognition events emit ONLY the cognition's ref — the texture and the
+///   agent live on the cognition itself and are reached through that, not
+///   through trail. Trail is for event ↔ entity, not entity ↔ entity.
+/// - Events keyed by name (AgentRemoved, BookmarkSwitched, continuity
+///   events) emit nothing — Ref takes typed IDs, and we would need a
+///   name→id resolution at projection time that doesn't belong here. When
+///   in doubt, emit nothing rather than over-couple.
+fn derive_refs(event: &Events) -> Vec<Ref> {
+    match event {
+        // Vocabulary — set carries the entity (named), remove carries the name.
+        Events::Level(LevelEvents::LevelSet(set)) => {
+            one(set.clone().current(), |v| Ref::level(v.level.name))
+        }
+        Events::Level(LevelEvents::LevelRemoved(removed)) => {
+            one(removed.clone().current(), |v| Ref::level(v.name))
+        }
+        Events::Texture(TextureEvents::TextureSet(set)) => {
+            one(set.clone().current(), |v| Ref::texture(v.texture.name))
+        }
+        Events::Texture(TextureEvents::TextureRemoved(removed)) => {
+            one(removed.clone().current(), |v| Ref::texture(v.name))
+        }
+        Events::Sensation(SensationEvents::SensationSet(set)) => {
+            one(set.clone().current(), |v| Ref::sensation(v.sensation.name))
+        }
+        Events::Sensation(SensationEvents::SensationRemoved(removed)) => {
+            one(removed.clone().current(), |v| Ref::sensation(v.name))
+        }
+        Events::Nature(NatureEvents::NatureSet(set)) => {
+            one(set.clone().current(), |v| Ref::nature(v.nature.name))
+        }
+        Events::Nature(NatureEvents::NatureRemoved(removed)) => {
+            one(removed.clone().current(), |v| Ref::nature(v.name))
+        }
+        Events::Persona(PersonaEvents::PersonaSet(set)) => {
+            one(set.clone().current(), |v| Ref::persona(v.persona.name))
+        }
+        Events::Persona(PersonaEvents::PersonaRemoved(removed)) => {
+            one(removed.clone().current(), |v| Ref::persona(v.name))
+        }
+        Events::Urge(UrgeEvents::UrgeSet(set)) => {
+            one(set.clone().current(), |v| Ref::urge(v.urge.name))
+        }
+        Events::Urge(UrgeEvents::UrgeRemoved(removed)) => {
+            one(removed.clone().current(), |v| Ref::urge(v.name))
+        }
+
+        // Agents — name-keyed remove doesn't emit (no name→id resolution at
+        // projection time).
+        Events::Agent(AgentEvents::AgentCreated(created)) => {
+            one(created.clone().current(), |v| Ref::agent(v.agent.id))
+        }
+        Events::Agent(AgentEvents::AgentUpdated(updated)) => {
+            one(updated.clone().current(), |v| Ref::agent(v.agent.id))
+        }
+        Events::Agent(AgentEvents::AgentRemoved(_)) => Vec::new(),
+
+        // Cognition/memory/experience — content-bearing entities.
+        Events::Cognition(CognitionEvents::CognitionAdded(added)) => {
+            one(added.clone().current(), |v| Ref::cognition(v.cognition.id))
+        }
+        Events::Memory(MemoryEvents::MemoryAdded(added)) => {
+            one(added.clone().current(), |v| Ref::memory(v.memory.id))
+        }
+        Events::Experience(ExperienceEvents::ExperienceCreated(created)) => {
+            one(created.clone().current(), |v| {
+                Ref::experience(v.experience.id)
+            })
+        }
+        Events::Experience(ExperienceEvents::ExperienceDescriptionUpdated(updated)) => {
+            one(updated.clone().current(), |v| Ref::experience(v.id))
+        }
+        Events::Experience(ExperienceEvents::ExperienceSensationUpdated(updated)) => {
+            one(updated.clone().current(), |v| Ref::experience(v.id))
+        }
+
+        // Connections and storage.
+        Events::Connection(ConnectionEvents::ConnectionCreated(created)) => {
+            one(created.clone().current(), |v| {
+                Ref::connection(v.connection.id)
+            })
+        }
+        Events::Connection(ConnectionEvents::ConnectionRemoved(removed)) => {
+            one(removed.clone().current(), |v| Ref::connection(v.id))
+        }
+        Events::Storage(StorageEvents::StorageSet(set)) => {
+            one(set.clone().current(), |v| Ref::storage(v.entry.key))
+        }
+        Events::Storage(StorageEvents::StorageRemoved(removed)) => {
+            one(removed.clone().current(), |v| Ref::storage(v.key))
+        }
+
+        // Continuity — keyed by agent name. No emission (see policy above).
+        Events::Continuity(_) => Vec::new(),
+
+        // Host-tier entities.
+        Events::Tenant(TenantEvents::TenantCreated(created)) => {
+            one(created.clone().current(), |v| Ref::tenant(v.tenant.id))
+        }
+        Events::Actor(ActorEvents::ActorCreated(created)) => {
+            one(created.clone().current(), |v| Ref::actor(v.actor.id))
+        }
+        Events::Project(ProjectEvents::ProjectCreated(created)) => {
+            one(created.clone().current(), |v| Ref::project(v.project.id))
+        }
+        Events::Ticket(TicketEvents::TicketIssued(issued)) => {
+            one(issued.clone().current(), |v| Ref::ticket(v.ticket.id))
+        }
+        Events::Ticket(TicketEvents::TicketUsed(used)) => {
+            one(used.clone().current(), |v| Ref::ticket(v.ticket_id))
+        }
+        Events::Ticket(TicketEvents::TicketRejected(rejected)) => rejected
+            .clone()
+            .current()
+            .ok()
+            .and_then(|v| v.ticket_id.map(|id| vec![Ref::ticket(id)]))
+            .unwrap_or_default(),
+
+        // Bookmarks — id-keyed lifecycle events emit, name-keyed don't.
+        Events::Bookmark(BookmarkEvents::BookmarkCreated(created)) => {
+            one(created.clone().current(), |v| Ref::bookmark(v.bookmark.id))
+        }
+        Events::Bookmark(BookmarkEvents::BookmarkForked(forked)) => {
+            one(forked.clone().current(), |v| Ref::bookmark(v.bookmark.id))
+        }
+        Events::Bookmark(BookmarkEvents::BookmarkSwitched(_))
+        | Events::Bookmark(BookmarkEvents::BookmarkMerged(_))
+        | Events::Bookmark(BookmarkEvents::BookmarkShared(_)) => Vec::new(),
+        Events::Bookmark(BookmarkEvents::BookmarkFollowed(followed)) => {
+            one(followed.clone().current(), |v| Ref::follow(v.id))
+        }
+        Events::Bookmark(BookmarkEvents::BookmarkCollected(collected)) => {
+            one(collected.clone().current(), |v| Ref::follow(v.follow_id))
+        }
+        Events::Bookmark(BookmarkEvents::BookmarkUnfollowed(unfollowed)) => {
+            one(unfollowed.clone().current(), |v| Ref::follow(v.follow_id))
+        }
+
+        // Peers.
+        Events::Peer(PeerEvents::PeerAdded(added)) => {
+            one(added.clone().current(), |v| Ref::peer(v.id))
+        }
+        Events::Peer(PeerEvents::PeerUpdated(updated)) => {
+            one(updated.clone().current(), |v| Ref::peer(v.id))
+        }
+        Events::Peer(PeerEvents::PeerRemoved(removed)) => {
+            one(removed.clone().current(), |v| Ref::peer(v.id))
+        }
+    }
+}
+
+/// Lift a versioned event to its current variant and map it to a single ref.
+/// Returns an empty vec when upcasting fails — the event still entered the
+/// log, but its shape can't be honored, so we don't fabricate a ref.
+fn one<V, F: FnOnce(V) -> Ref>(versioned: Result<V, UpcastError>, to_ref: F) -> Vec<Ref> {
+    versioned.ok().map(|v| vec![to_ref(v)]).unwrap_or_default()
+}

--- a/crates/oneiros-engine/src/domains/trail/view.rs
+++ b/crates/oneiros-engine/src/domains/trail/view.rs
@@ -1,0 +1,71 @@
+//! Trail view — presentation authority for the trail domain.
+
+use crate::*;
+
+pub(crate) struct TrailView {
+    response: TrailResponse,
+}
+
+impl TrailView {
+    pub(crate) fn new(response: TrailResponse) -> Self {
+        Self { response }
+    }
+
+    pub(crate) fn render(self) -> Rendered<TrailResponse> {
+        match self.response {
+            TrailResponse::TrailEvents(TrailEventsResponse::V1(events)) => {
+                let prompt = format!(
+                    "{}\n\n{}",
+                    format_args!("{} event(s) touched this entity", events.items.len()).muted(),
+                    Self::events_table(&events.items),
+                );
+                Rendered::new(
+                    TrailResponse::TrailEvents(TrailEventsResponse::V1(events)),
+                    prompt,
+                    String::new(),
+                )
+            }
+            TrailResponse::EmittedRefs(EmittedRefsResponse::V1(refs)) => {
+                let prompt = format!(
+                    "{}\n\n{}",
+                    format_args!("{} entity(ies) emitted by this event", refs.items.len()).muted(),
+                    Self::refs_table(&refs.items),
+                );
+                Rendered::new(
+                    TrailResponse::EmittedRefs(EmittedRefsResponse::V1(refs)),
+                    prompt,
+                    String::new(),
+                )
+            }
+            TrailResponse::NoTrail => Rendered::new(
+                TrailResponse::NoTrail,
+                "No trail.".muted().to_string(),
+                String::new(),
+            ),
+        }
+    }
+
+    fn events_table(items: &[TrailEntry]) -> Table {
+        let mut table = Table::new(vec![
+            Column::new("Event"),
+            Column::new("Type"),
+            Column::new("At"),
+        ]);
+        for entry in items {
+            table.push_row(vec![
+                entry.event_id.to_string(),
+                entry.event_type.clone(),
+                entry.created_at.as_string(),
+            ]);
+        }
+        table
+    }
+
+    fn refs_table(items: &[RefToken]) -> Table {
+        let mut table = Table::new(vec![Column::new("Ref")]);
+        for entity_ref in items {
+            table.push_row(vec![entity_ref.to_string()]);
+        }
+        table
+    }
+}

--- a/crates/oneiros-engine/src/error.rs
+++ b/crates/oneiros-engine/src/error.rs
@@ -86,6 +86,8 @@ pub(crate) enum Error {
     #[error(transparent)]
     Ticket(#[from] TicketError),
     #[error(transparent)]
+    Trail(#[from] TrailError),
+    #[error(transparent)]
     Urge(#[from] UrgeError),
 
     #[error(transparent)]

--- a/crates/oneiros-engine/src/http/server.rs
+++ b/crates/oneiros-engine/src/http/server.rs
@@ -159,6 +159,7 @@ impl Server {
             .merge(TenantRouter.routes())
             .merge(TextureRouter.routes())
             .merge(TicketRouter.routes())
+            .merge(TrailRouter.routes())
             .merge(UrgeRouter.routes())
             // OpenAPI spec and docs
             .route("/api.json", api_routing::get(serve_api))

--- a/crates/oneiros-engine/src/projections.rs
+++ b/crates/oneiros-engine/src/projections.rs
@@ -193,6 +193,7 @@ impl Projections<ProjectCanon> {
                 Frames::new(&[
                     Frame::new(PressureProjections.all()),
                     Frame::new(SearchProjections.all()),
+                    Frame::new(TrailProjections.all()),
                 ]),
             ],
             pipeline,

--- a/crates/oneiros-engine/src/protocol/requests.rs
+++ b/crates/oneiros-engine/src/protocol/requests.rs
@@ -35,6 +35,7 @@ pub(crate) enum Requests {
     Tenant(TenantRequest),
     Texture(TextureRequest),
     Ticket(TicketRequest),
+    Trail(TrailRequest),
     Urge(UrgeRequest),
 }
 
@@ -61,5 +62,6 @@ collects_enum!(
     Requests::Tenant => TenantRequest,
     Requests::Texture => TextureRequest,
     Requests::Ticket => TicketRequest,
+    Requests::Trail => TrailRequest,
     Requests::Urge => UrgeRequest,
 );

--- a/crates/oneiros-engine/src/protocol/responses.rs
+++ b/crates/oneiros-engine/src/protocol/responses.rs
@@ -37,6 +37,7 @@ pub(crate) enum Responses {
     Tenant(TenantResponse),
     Texture(TextureResponse),
     Ticket(TicketResponse),
+    Trail(TrailResponse),
     Urge(UrgeResponse),
 }
 
@@ -67,5 +68,6 @@ collects_enum!(
     Responses::Tenant => TenantResponse,
     Responses::Texture => TextureResponse,
     Responses::Ticket => TicketResponse,
+    Responses::Trail => TrailResponse,
     Responses::Urge => UrgeResponse,
 );

--- a/crates/oneiros-engine/src/skill.rs
+++ b/crates/oneiros-engine/src/skill.rs
@@ -61,6 +61,7 @@ impl SkillInventory {
         skills.extend(TenantSkills::all());
         skills.extend(TextureSkills::all());
         skills.extend(TicketSkills::all());
+        skills.extend(TrailSkills::all());
         skills.extend(UrgeSkills::all());
 
         skills

--- a/crates/oneiros-engine/src/tests/harness.rs
+++ b/crates/oneiros-engine/src/tests/harness.rs
@@ -242,6 +242,10 @@ impl TestClient {
         SearchClient::new(&self.client)
     }
 
+    pub(crate) fn trail(&self) -> TrailClient<'_> {
+        TrailClient::new(&self.client)
+    }
+
     pub(crate) fn pressure(&self) -> PressureClient<'_> {
         PressureClient::new(&self.client)
     }
@@ -741,6 +745,26 @@ impl<'a> SearchClient<'a> {
     ) -> Result<SearchResponse, ClientError> {
         let bytes = request.execute_request(self.client).await?;
         decode(bytes, "search")
+    }
+}
+
+pub(crate) struct TrailClient<'a> {
+    client: &'a Client,
+}
+
+impl<'a> TrailClient<'a> {
+    pub(crate) fn new(client: &'a Client) -> Self {
+        Self { client }
+    }
+
+    pub(crate) async fn of(&self, request: &TrailOf) -> Result<TrailResponse, ClientError> {
+        let bytes = request.execute_request(self.client).await?;
+        decode(bytes, "trail")
+    }
+
+    pub(crate) async fn from(&self, request: &TrailFrom) -> Result<TrailResponse, ClientError> {
+        let bytes = request.execute_request(self.client).await?;
+        decode(bytes, "trail")
     }
 }
 

--- a/crates/oneiros-engine/src/tests/workflows/mod.rs
+++ b/crates/oneiros-engine/src/tests/workflows/mod.rs
@@ -12,5 +12,6 @@ mod pressure;
 mod search;
 mod skills;
 mod storage;
+mod trail;
 mod versioning;
 mod vocabulary;

--- a/crates/oneiros-engine/src/tests/workflows/trail.rs
+++ b/crates/oneiros-engine/src/tests/workflows/trail.rs
@@ -1,0 +1,295 @@
+//! Trail workflow — the events ↔ entities bridge.
+//!
+//! Every entity has at least one event that emitted or touched it; the
+//! `trail` projection records that join. `trail of <ref>` returns the
+//! events that touched an entity; `trail from <event-id>` returns the
+//! entities an event emitted.
+
+use crate::tests::harness::TestApp;
+use crate::*;
+
+#[tokio::test]
+async fn trail_of_entity_returns_emitting_event() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_host()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let client = app.client();
+
+    let agent = match client
+        .agent()
+        .create(
+            &CreateAgent::builder_v1()
+                .name(AgentName::new("governor.process"))
+                .persona(PersonaName::new("process"))
+                .build()
+                .into(),
+        )
+        .await?
+    {
+        AgentResponse::AgentCreated(AgentCreatedResponse::V1(r)) => r.agent,
+        other => panic!("expected AgentCreated, got {other:?}"),
+    };
+
+    let agent_ref = RefToken::new(Ref::agent(agent.id));
+
+    let items = match client
+        .trail()
+        .of(&TrailOf::builder_v1().r#ref(agent_ref).build().into())
+        .await?
+    {
+        TrailResponse::TrailEvents(TrailEventsResponse::V1(r)) => r.items,
+        other => panic!("expected TrailEvents, got {other:?}"),
+    };
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].event_type, "agent-created");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn trail_from_event_returns_emitted_entities() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_host()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let client = app.client();
+
+    let agent = match client
+        .agent()
+        .create(
+            &CreateAgent::builder_v1()
+                .name(AgentName::new("governor.process"))
+                .persona(PersonaName::new("process"))
+                .build()
+                .into(),
+        )
+        .await?
+    {
+        AgentResponse::AgentCreated(AgentCreatedResponse::V1(r)) => r.agent,
+        other => panic!("expected AgentCreated, got {other:?}"),
+    };
+
+    let agent_ref = RefToken::new(Ref::agent(agent.id));
+
+    let event_id = match client
+        .trail()
+        .of(&TrailOf::builder_v1()
+            .r#ref(agent_ref.clone())
+            .build()
+            .into())
+        .await?
+    {
+        TrailResponse::TrailEvents(TrailEventsResponse::V1(r)) => r.items[0].event_id,
+        other => panic!("expected TrailEvents, got {other:?}"),
+    };
+
+    let refs = match client
+        .trail()
+        .from(&TrailFrom::builder_v1().event(event_id).build().into())
+        .await?
+    {
+        TrailResponse::EmittedRefs(EmittedRefsResponse::V1(r)) => r.items,
+        other => panic!("expected EmittedRefs, got {other:?}"),
+    };
+
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0], agent_ref);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn cognition_emits_only_cognition_ref() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_host()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let client = app.client();
+
+    let _agent = match client
+        .agent()
+        .create(
+            &CreateAgent::builder_v1()
+                .name(AgentName::new("governor.process"))
+                .persona(PersonaName::new("process"))
+                .build()
+                .into(),
+        )
+        .await?
+    {
+        AgentResponse::AgentCreated(AgentCreatedResponse::V1(r)) => r.agent,
+        other => panic!("expected AgentCreated, got {other:?}"),
+    };
+
+    let cognition = match client
+        .cognition()
+        .add(
+            &AddCognition::builder_v1()
+                .agent(AgentName::new("governor.process"))
+                .texture(TextureName::new("observation"))
+                .content("a fragment")
+                .build()
+                .into(),
+        )
+        .await?
+    {
+        CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(r)) => r.cognition,
+        other => panic!("expected CognitionAdded, got {other:?}"),
+    };
+
+    let cognition_ref = RefToken::new(Ref::cognition(cognition.id));
+
+    // Find the CognitionAdded event id by walking trail-of for the cognition.
+    let event_id = match client
+        .trail()
+        .of(&TrailOf::builder_v1()
+            .r#ref(cognition_ref.clone())
+            .build()
+            .into())
+        .await?
+    {
+        TrailResponse::TrailEvents(TrailEventsResponse::V1(r)) => {
+            assert_eq!(r.items.len(), 1);
+            assert_eq!(r.items[0].event_type, "cognition-added");
+            r.items[0].event_id
+        }
+        other => panic!("expected TrailEvents, got {other:?}"),
+    };
+
+    // The load-bearing assertion: the cognition event emits ONLY the cognition
+    // ref — not the texture, not the agent. Lineage runs through the cognition
+    // itself, not through sources.
+    let refs = match client
+        .trail()
+        .from(&TrailFrom::builder_v1().event(event_id).build().into())
+        .await?
+    {
+        TrailResponse::EmittedRefs(EmittedRefsResponse::V1(r)) => r.items,
+        other => panic!("expected EmittedRefs, got {other:?}"),
+    };
+
+    assert_eq!(refs, vec![cognition_ref]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn trail_of_unknown_ref_returns_empty() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_host()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let client = app.client();
+
+    // A ref that was never emitted by any event.
+    let stranger = RefToken::new(Ref::agent(AgentId::new()));
+
+    match client
+        .trail()
+        .of(&TrailOf::builder_v1().r#ref(stranger).build().into())
+        .await?
+    {
+        TrailResponse::TrailEvents(TrailEventsResponse::V1(r)) => assert!(r.items.is_empty()),
+        TrailResponse::NoTrail => {}
+        other => panic!("expected empty TrailEvents or NoTrail, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn replay_is_idempotent() -> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_host()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let client = app.client();
+
+    let _agent = match client
+        .agent()
+        .create(
+            &CreateAgent::builder_v1()
+                .name(AgentName::new("governor.process"))
+                .persona(PersonaName::new("process"))
+                .build()
+                .into(),
+        )
+        .await?
+    {
+        AgentResponse::AgentCreated(AgentCreatedResponse::V1(r)) => r.agent,
+        other => panic!("expected AgentCreated, got {other:?}"),
+    };
+
+    let cognition = match client
+        .cognition()
+        .add(
+            &AddCognition::builder_v1()
+                .agent(AgentName::new("governor.process"))
+                .texture(TextureName::new("observation"))
+                .content("a fragment")
+                .build()
+                .into(),
+        )
+        .await?
+    {
+        CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(r)) => r.cognition,
+        other => panic!("expected CognitionAdded, got {other:?}"),
+    };
+
+    let cognition_ref = RefToken::new(Ref::cognition(cognition.id));
+
+    let before = match client
+        .trail()
+        .of(&TrailOf::builder_v1()
+            .r#ref(cognition_ref.clone())
+            .build()
+            .into())
+        .await?
+    {
+        TrailResponse::TrailEvents(TrailEventsResponse::V1(r)) => r.items,
+        other => panic!("expected TrailEvents, got {other:?}"),
+    };
+
+    // Drop the projections and rebuild from the event log.
+    app.command("project replay").await?;
+
+    let after = match client
+        .trail()
+        .of(&TrailOf::builder_v1().r#ref(cognition_ref).build().into())
+        .await?
+    {
+        TrailResponse::TrailEvents(TrailEventsResponse::V1(r)) => r.items,
+        other => panic!("expected TrailEvents, got {other:?}"),
+    };
+
+    assert_eq!(before, after);
+
+    Ok(())
+}

--- a/crates/oneiros-engine/src/values/entity_ref.rs
+++ b/crates/oneiros-engine/src/values/entity_ref.rs
@@ -21,13 +21,6 @@ pub(crate) enum Ref {
     V0(Resource),
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "These methods are meant to be kept, but only exist in tests for now"
-    )
-)]
 impl Ref {
     pub(crate) fn actor(id: ActorId) -> Self {
         Self::V0(Resource::Actor(id))
@@ -72,9 +65,7 @@ impl Ref {
     pub(crate) fn urge(name: UrgeName) -> Self {
         Self::V0(Resource::Urge(name))
     }
-}
 
-impl Ref {
     pub(crate) fn agent(id: AgentId) -> Self {
         Self::V0(Resource::Agent(id))
     }


### PR DESCRIPTION
Trails are a new kind of relational projection that lets us get fundamental attribution of events to the entities they create. This is kind of a helper system that we'll need to power the lens system we spiked out in #273, and in fact one of the reasons why we halted work (not the only reason, though) is that the need for this component became clear.

Trails give you the ability to go from ref to event source, and vice versa, using the new `oneiros trail` commands. Internally, this is powered by a lineage table that just joins events to refs in the bookmarked db.

On continuity events
---

Notably, we don't yet have support for continuity events. That's probably okay _temporarily_ because we don't have lingo for continuity event traversal in lenses, yet. But, we'll need to create a migration of some kind for them so they have ids instead of having names. The alternative is that distributed name collisions can point to the wrong record. That is, if two systems have an "alice" agent, and they merge, which do we want to point at? Right now, the host bookmark would win - and that might be desired, but "we're accidentally doing it right" feels brittle. We should make stuff like that explicit, but there's some work left to get there.