### PR TITLE
Add project to requests.

### DIFF
--- a/crates/oneiros-engine/src/protocol/requests.rs
+++ b/crates/oneiros-engine/src/protocol/requests.rs
@@ -51,6 +51,7 @@ collects_enum!(
     Requests::Level => LevelRequest,
     Requests::Memory => MemoryRequest,
     Requests::Nature => NatureRequest,
+    Requests::Project => ProjectRequest,
     Requests::Peer => PeerRequest,
     Requests::Persona => PersonaRequest,
     Requests::Pressure => PressureRequest,


### PR DESCRIPTION
Whoops! We missed this one. We want project requests in the requests super enum so the protocol can actually route to this part of our request space.

Release-Type: fix