### PR TITLE
Deprecation of project log, versionable APIs.

### DIFF
--- a/crates/oneiros-engine/src/domains/agent/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/agent/features/mcp.rs
@@ -7,6 +7,7 @@ impl AgentMcp {
         agent_mcp::tool_defs()
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn dispatch(
         &self,
         context: &ProjectLog,
@@ -32,6 +33,7 @@ impl AgentMcp {
         ]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,
@@ -44,6 +46,7 @@ impl AgentMcp {
     /// without I/O. Currently only `AgentConnections`, which requires an
     /// agent lookup to resolve a `RefToken` before building a
     /// `ConnectionRequest`.
+    #[expect(deprecated)]
     pub(crate) async fn read_resource_special(
         &self,
         context: &ProjectLog,
@@ -81,6 +84,7 @@ mod agent_mcp {
         ]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn dispatch(
         context: &ProjectLog,
         mailbox: &Mailbox,
@@ -122,6 +126,7 @@ mod agent_mcp {
         }
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         context: &ProjectLog,
         request: &AgentRequest,
@@ -151,6 +156,7 @@ mod agent_mcp {
         }
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn read_agent_connections(
         context: &ProjectLog,
         name: &AgentName,

--- a/crates/oneiros-engine/src/domains/bookmark/features/http.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/features/http.rs
@@ -65,6 +65,7 @@ impl BookmarkRouter {
     }
 }
 
+#[expect(deprecated)]
 async fn create(
     context: ProjectLog,
     State(state): State<ServerState>,
@@ -74,6 +75,7 @@ async fn create(
     Ok((StatusCode::CREATED, Json(response)))
 }
 
+#[expect(deprecated)]
 async fn switch(
     context: ProjectLog,
     State(state): State<ServerState>,
@@ -84,6 +86,7 @@ async fn switch(
     ))
 }
 
+#[expect(deprecated)]
 async fn merge(
     context: ProjectLog,
     State(state): State<ServerState>,
@@ -94,6 +97,7 @@ async fn merge(
     ))
 }
 
+#[expect(deprecated)]
 async fn list(
     context: ProjectLog,
     State(state): State<ServerState>,
@@ -104,6 +108,7 @@ async fn list(
     ))
 }
 
+#[expect(deprecated)]
 async fn share(
     context: ProjectLog,
     State(state): State<ServerState>,
@@ -114,6 +119,7 @@ async fn share(
     ))
 }
 
+#[expect(deprecated)]
 async fn follow(
     context: ProjectLog,
     State(state): State<ServerState>,
@@ -124,6 +130,7 @@ async fn follow(
     ))
 }
 
+#[expect(deprecated)]
 async fn unfollow(
     context: ProjectLog,
     State(state): State<ServerState>,
@@ -134,6 +141,7 @@ async fn unfollow(
     ))
 }
 
+#[expect(deprecated)]
 async fn collect(
     context: ProjectLog,
     State(state): State<ServerState>,

--- a/crates/oneiros-engine/src/domains/cognition/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/cognition/features/mcp.rs
@@ -7,6 +7,7 @@ impl CognitionMcp {
         cognition_mcp::tool_defs()
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn dispatch(
         &self,
         context: &ProjectLog,
@@ -21,6 +22,7 @@ impl CognitionMcp {
         vec![ResourcePathKind::Cognition.template_def("A specific cognition")]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,
@@ -39,6 +41,7 @@ mod cognition_mcp {
         ]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn dispatch(
         context: &ProjectLog,
         mailbox: &Mailbox,
@@ -66,6 +69,7 @@ mod cognition_mcp {
         }
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         context: &ProjectLog,
         request: &CognitionRequest,

--- a/crates/oneiros-engine/src/domains/connection/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/connection/features/mcp.rs
@@ -7,6 +7,7 @@ impl ConnectionMcp {
         connection_mcp::tool_defs()
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn dispatch(
         &self,
         context: &ProjectLog,
@@ -21,6 +22,7 @@ impl ConnectionMcp {
         vec![ResourcePathKind::Connection.template_def("A specific connection")]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,
@@ -43,6 +45,7 @@ mod connection_mcp {
         ]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn dispatch(
         context: &ProjectLog,
         mailbox: &Mailbox,
@@ -72,6 +75,7 @@ mod connection_mcp {
         }
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         context: &ProjectLog,
         request: &ConnectionRequest,

--- a/crates/oneiros-engine/src/domains/continuity/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/continuity/features/mcp.rs
@@ -7,6 +7,7 @@ impl ContinuityMcp {
         vec![ResourcePathKind::Status.resource_def("Cross-agent activity table")]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,

--- a/crates/oneiros-engine/src/domains/experience/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/experience/features/mcp.rs
@@ -7,6 +7,7 @@ impl ExperienceMcp {
         experience_mcp::tool_defs()
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn dispatch(
         &self,
         context: &ProjectLog,
@@ -21,6 +22,7 @@ impl ExperienceMcp {
         vec![ResourcePathKind::Experience.template_def("A specific experience")]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,
@@ -43,6 +45,7 @@ mod experience_mcp {
         ]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn dispatch(
         context: &ProjectLog,
         mailbox: &Mailbox,
@@ -73,6 +76,7 @@ mod experience_mcp {
         }
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         context: &ProjectLog,
         request: &ExperienceRequest,

--- a/crates/oneiros-engine/src/domains/level/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/level/features/mcp.rs
@@ -7,6 +7,7 @@ impl LevelMcp {
         vec![ResourcePathKind::Levels.resource_def("Memory retention tiers")]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,

--- a/crates/oneiros-engine/src/domains/memory/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/memory/features/mcp.rs
@@ -7,6 +7,7 @@ impl MemoryMcp {
         memory_mcp::tool_defs()
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn dispatch(
         &self,
         context: &ProjectLog,
@@ -21,6 +22,7 @@ impl MemoryMcp {
         vec![ResourcePathKind::Memory.template_def("A specific memory")]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,
@@ -43,6 +45,7 @@ mod memory_mcp {
         ]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn dispatch(
         context: &ProjectLog,
         mailbox: &Mailbox,
@@ -70,6 +73,7 @@ mod memory_mcp {
         }
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         context: &ProjectLog,
         request: &MemoryRequest,

--- a/crates/oneiros-engine/src/domains/mod.rs
+++ b/crates/oneiros-engine/src/domains/mod.rs
@@ -1,3 +1,16 @@
+//! Domain modules — one domain ≈ one event type ≈ one service ≈ one feature set.
+//!
+//! Most domains follow this isomorphism exactly. Four are named exceptions:
+//!
+//! - **Bookmark** — host-scoped at the service boundary, not bookmark-scoped,
+//!   because bookmarks define the scope that other domains operate within.
+//! - **Search** — strangler at the service signature; will evolve with the
+//!   lens work. Currently couples to multiple domain projections.
+//! - **Follow** — handles foreign events (`BookmarkEvents`) rather than its
+//!   own event type, because follows react to bookmark lifecycle.
+//! - **Trail** — aggregates events from nearly every domain to produce
+//!   cross-cutting activity views.
+
 mod actor;
 mod agent;
 mod bookmark;

--- a/crates/oneiros-engine/src/domains/nature/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/nature/features/mcp.rs
@@ -7,6 +7,7 @@ impl NatureMcp {
         vec![ResourcePathKind::Natures.resource_def("Connection natures")]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,

--- a/crates/oneiros-engine/src/domains/persona/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/persona/features/mcp.rs
@@ -7,6 +7,7 @@ impl PersonaMcp {
         vec![ResourcePathKind::Personas.resource_def("Agent personas")]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,

--- a/crates/oneiros-engine/src/domains/pressure/features/http.rs
+++ b/crates/oneiros-engine/src/domains/pressure/features/http.rs
@@ -26,6 +26,7 @@ impl PressureRouter {
     }
 }
 
+#[expect(deprecated)]
 async fn get(
     context: ProjectLog,
     Path(agent): Path<AgentName>,
@@ -39,6 +40,7 @@ async fn get(
     ))
 }
 
+#[expect(deprecated)]
 async fn list(context: ProjectLog) -> Result<Json<PressureResponse>, PressureError> {
     Ok(Json(PressureService::list(&context).await?))
 }

--- a/crates/oneiros-engine/src/domains/pressure/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/pressure/features/mcp.rs
@@ -7,6 +7,7 @@ impl PressureMcp {
         vec![ResourcePathKind::Pressure.resource_def("All agents' pressure readings")]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,
@@ -19,6 +20,7 @@ impl PressureMcp {
 mod pressure_mcp {
     use crate::*;
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         context: &ProjectLog,
         request: &PressureRequest,

--- a/crates/oneiros-engine/src/domains/pressure/service.rs
+++ b/crates/oneiros-engine/src/domains/pressure/service.rs
@@ -3,6 +3,7 @@ use crate::*;
 pub(crate) struct PressureService;
 
 impl PressureService {
+    #[expect(deprecated)]
     pub(crate) async fn get(
         context: &ProjectLog,
         selector: &GetPressure,
@@ -20,6 +21,7 @@ impl PressureService {
         ))
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn list(context: &ProjectLog) -> Result<PressureResponse, PressureError> {
         let pressures = PressureRepo::new(context.scope()?).list().await?;
         Ok(PressureResponse::AllReadings(

--- a/crates/oneiros-engine/src/domains/search/features/http.rs
+++ b/crates/oneiros-engine/src/domains/search/features/http.rs
@@ -19,6 +19,7 @@ impl SearchRouter {
     }
 }
 
+#[expect(deprecated)]
 async fn search(
     context: ProjectLog,
     Query(params): Query<SearchQuery>,

--- a/crates/oneiros-engine/src/domains/search/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/search/features/mcp.rs
@@ -7,6 +7,7 @@ impl SearchMcp {
         search_mcp::tool_defs()
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn dispatch(
         &self,
         context: &ProjectLog,
@@ -30,6 +31,7 @@ mod search_mcp {
         ]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn dispatch(
         context: &ProjectLog,
         tool_name: &ToolName,

--- a/crates/oneiros-engine/src/domains/search/service.rs
+++ b/crates/oneiros-engine/src/domains/search/service.rs
@@ -5,6 +5,7 @@ use crate::*;
 pub(crate) struct SearchService;
 
 impl SearchService {
+    #[expect(deprecated)]
     pub(crate) async fn search(
         context: &ProjectLog,
         request: &SearchQuery,
@@ -43,6 +44,7 @@ impl SearchService {
 /// reassemble [`Hit`]s in the original FTS5 order. Drops refs whose
 /// underlying row has been removed since the index was queried — search
 /// shouldn't surface ghosts.
+#[expect(deprecated)]
 pub(crate) async fn hydrate_hits(
     context: &ProjectLog,
     ranked: Vec<RankedHit>,

--- a/crates/oneiros-engine/src/domains/sensation/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/sensation/features/mcp.rs
@@ -7,6 +7,7 @@ impl SensationMcp {
         vec![ResourcePathKind::Sensations.resource_def("Experience sensations")]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,

--- a/crates/oneiros-engine/src/domains/texture/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/texture/features/mcp.rs
@@ -7,6 +7,7 @@ impl TextureMcp {
         vec![ResourcePathKind::Textures.resource_def("Thought textures")]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,

--- a/crates/oneiros-engine/src/domains/urge/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/urge/features/mcp.rs
@@ -7,6 +7,7 @@ impl UrgeMcp {
         vec![ResourcePathKind::Urges.resource_def("Cognitive drives")]
     }
 
+    #[expect(deprecated)]
     pub(crate) async fn resource(
         &self,
         context: &ProjectLog,

--- a/crates/oneiros-engine/src/http/state.rs
+++ b/crates/oneiros-engine/src/http/state.rs
@@ -98,6 +98,7 @@ impl ServerState {
 
     /// Build a project context for a request. Strangler — used by the
     /// `ProjectLog` extractor for legacy CLI/MCP dispatchers.
+    #[expect(deprecated)]
     pub(crate) fn project_log(&self, config: Config) -> ProjectLog {
         ProjectLog::new(config)
     }
@@ -218,6 +219,7 @@ impl FromRequestParts<ServerState> for Scope<AtBookmark> {
     }
 }
 
+#[expect(deprecated)]
 impl FromRequestParts<ServerState> for ProjectLog {
     type Rejection = AuthError;
 

--- a/crates/oneiros-engine/src/logs/mod.rs
+++ b/crates/oneiros-engine/src/logs/mod.rs
@@ -1,3 +1,4 @@
 mod project;
 
+#[expect(deprecated)]
 pub(crate) use project::ProjectLog;

--- a/crates/oneiros-engine/src/logs/project.rs
+++ b/crates/oneiros-engine/src/logs/project.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::*;
 
+#[expect(deprecated)]
 impl aide::operation::OperationInput for ProjectLog {}
 
 /// Strangler — request-shaped context for legacy bookmark-tier callers.
@@ -12,6 +13,10 @@ impl aide::operation::OperationInput for ProjectLog {}
 /// `Scope<AtBookmark>` + `Mailbox` directly; this remains for CLI
 /// commands and MCP dispatchers that derive their scope from the
 /// request context during the bus migration.
+#[deprecated(
+    since = "0.0.11",
+    note = "Strangler: use Scope<AtBookmark> + Mailbox directly. See logs/project.rs doc-comment."
+)]
 #[derive(Clone)]
 pub(crate) struct ProjectLog {
     pub(crate) config: Config,
@@ -19,6 +24,7 @@ pub(crate) struct ProjectLog {
     scope: Arc<std::sync::OnceLock<Scope<AtBookmark>>>,
 }
 
+#[expect(deprecated)]
 impl ProjectLog {
     pub(crate) fn new(config: Config) -> Self {
         Self {

--- a/crates/oneiros-engine/src/macros/versioned.rs
+++ b/crates/oneiros-engine/src/macros/versioned.rs
@@ -180,6 +180,7 @@ macro_rules! versioned {
             )*
 
             impl $name {
+                /// Upcast to the latest version by reference, cloning the inner value.
                 #[allow(dead_code)]
                 pub(crate) fn current(
                     &self,
@@ -190,12 +191,25 @@ macro_rules! versioned {
                     })
                 }
 
+                /// Upcast to the latest version, consuming self to avoid cloning.
+                #[allow(dead_code)]
+                pub(crate) fn into_current(
+                    self,
+                ) -> ::std::result::Result<[<$name $latest_variant>], $crate::UpcastError> {
+                    Ok(match self {
+                        Self::$latest_variant(v) => v,
+                        $(Self::$variant(v) => v.try_into()?,)*
+                    })
+                }
+
+                /// Build the latest version directly.
                 #[allow(dead_code)]
                 pub(crate) fn [<builder_ $latest_variant:lower>]() -> [<$name $latest_variant Builder>] {
                     [<$name $latest_variant>]::builder()
                 }
 
                 $(
+                    #[doc = concat!("Build the ", stringify!($variant), " version directly.")]
                     #[allow(dead_code)]
                     pub(crate) fn [<builder_ $variant:lower>]() -> [<$name $variant Builder>] {
                         [<$name $variant>]::builder()
@@ -203,6 +217,7 @@ macro_rules! versioned {
                 )*
             }
 
+            /// Wrap the latest version struct into the versioned enum.
             impl ::std::convert::From<[<$name $latest_variant>]> for $name {
                 fn from(v: [<$name $latest_variant>]) -> Self {
                     Self::$latest_variant(v)
@@ -273,14 +288,24 @@ macro_rules! versioned {
         }
 
         impl $name {
+            /// Upcast to the latest version by reference, cloning the inner value.
             #[allow(dead_code)]
             pub(crate) fn current(&self) -> ::std::result::Result<$v1_type, $crate::UpcastError> {
                 Ok(match self {
                     Self::V1(v) => v.clone(),
                 })
             }
+
+            /// Upcast to the latest version, consuming self to avoid cloning.
+            #[allow(dead_code)]
+            pub(crate) fn into_current(self) -> ::std::result::Result<$v1_type, $crate::UpcastError> {
+                Ok(match self {
+                    Self::V1(v) => v,
+                })
+            }
         }
 
+        /// Wrap the latest version struct into the versioned enum.
         impl ::std::convert::From<$v1_type> for $name {
             fn from(v: $v1_type) -> Self {
                 Self::V1(v)

--- a/crates/oneiros-engine/src/mcp.rs
+++ b/crates/oneiros-engine/src/mcp.rs
@@ -150,6 +150,7 @@ fn all_resource_templates() -> Vec<ResourceTemplateDef> {
     .collect()
 }
 
+#[expect(deprecated)]
 async fn read_resource(context: &ProjectLog, uri: &ResourceUri) -> Result<McpResponse, ToolError> {
     let path = uri.path();
 

--- a/crates/oneiros-engine/src/projections.rs
+++ b/crates/oneiros-engine/src/projections.rs
@@ -174,6 +174,9 @@ impl Projections<ProjectCanon> {
     pub(crate) fn project_with_pipeline(pipeline: ReducerPipeline<ProjectCanon>) -> Self {
         Self::new(
             &[
+                // Vocabulary: idempotent definitions that other projections
+                // reference. These must migrate and apply first so that
+                // foreign-key targets exist before records land.
                 Frames::new(&[
                     Frame::new(LevelProjections.all()),
                     Frame::new(TextureProjections.all()),
@@ -182,6 +185,9 @@ impl Projections<ProjectCanon> {
                     Frame::new(PersonaProjections.all()),
                     Frame::new(UrgeProjections.all()),
                 ]),
+                // Records: the core domain entities. Each projection is
+                // commutative within its own domain — ordering between
+                // domains in this tier is not load-bearing.
                 Frames::new(&[
                     Frame::new(AgentProjections.all()),
                     Frame::new(CognitionProjections.all()),
@@ -190,6 +196,9 @@ impl Projections<ProjectCanon> {
                     Frame::new(ConnectionProjections.all()),
                     Frame::new(StorageProjections.all()),
                 ]),
+                // Aggregations: cross-domain or derived views that read
+                // from records. Applied last so the data they aggregate
+                // is already materialized.
                 Frames::new(&[
                     Frame::new(PressureProjections.all()),
                     Frame::new(SearchProjections.all()),

--- a/crates/oneiros-engine/src/tests/workflows/mod.rs
+++ b/crates/oneiros-engine/src/tests/workflows/mod.rs
@@ -7,6 +7,7 @@ mod errors;
 mod host;
 mod mcp;
 mod migrations;
+mod namespace;
 mod portability;
 mod pressure;
 mod search;

--- a/crates/oneiros-engine/src/tests/workflows/namespace.rs
+++ b/crates/oneiros-engine/src/tests/workflows/namespace.rs
@@ -1,0 +1,77 @@
+// Compile-time guard: values::* and domains::* share the crate-root
+// namespace via glob re-exports. If a new type in either module collides
+// with a name in the other, this file will fail to compile with an
+// "ambiguous import" error, surfacing the collision immediately.
+//
+// To keep this effective, reference at least one type per value module
+// and one response/service type per domain. Add new entries when adding
+// new modules.
+
+use crate::*;
+
+// ── Values ─────────────────────────────────────────────────────────
+#[expect(clippy::too_many_arguments)]
+fn _values(
+    _chronicle: Chronicle,
+    _content: Content,
+    _description: Description,
+    _dream_config: DreamConfig,
+    _entity_index: EntityIndex<(), ()>,
+    _gauge: Gauge,
+    _host_canon: HostCanon,
+    _label: Label,
+    _limit: Limit,
+    _offset: Offset,
+    _output_mode: OutputMode,
+    _palette: Palette,
+    _project_canon: ProjectCanon,
+    _ref_token: RefToken,
+    _rendered: Rendered<()>,
+    _resource_key: ResourceKey<()>,
+    _search_filters: SearchFilters,
+    _source: Source,
+    _timestamp: Timestamp,
+    _tool_name: ToolName,
+) {
+}
+
+// ── Domains ────────────────────────────────────────────────────────
+#[expect(clippy::too_many_arguments)]
+fn _domains(
+    _agent: Agent,
+    _agent_response: AgentResponse,
+    _bookmark: Bookmark,
+    _bookmark_response: BookmarkResponse,
+    _cognition: Cognition,
+    _cognition_response: CognitionResponse,
+    _connection: Connection,
+    _connection_response: ConnectionResponse,
+    _experience: Experience,
+    _experience_response: ExperienceResponse,
+    _follow: Follow,
+    _follow_response: FollowResponse,
+    _level: Level,
+    _level_response: LevelResponse,
+    _memory: Memory,
+    _memory_response: MemoryResponse,
+    _nature: Nature,
+    _nature_response: NatureResponse,
+    _peer: Peer,
+    _peer_response: PeerResponse,
+    _persona: Persona,
+    _persona_response: PersonaResponse,
+    _pressure: Pressure,
+    _pressure_response: PressureResponse,
+    _search_response: SearchResponse,
+    _sensation: Sensation,
+    _sensation_response: SensationResponse,
+    _storage_response: StorageResponse,
+    _tenant: Tenant,
+    _tenant_response: TenantResponse,
+    _texture: Texture,
+    _texture_response: TextureResponse,
+    _trail_response: TrailResponse,
+    _urge: Urge,
+    _urge_response: UrgeResponse,
+) {
+}


### PR DESCRIPTION
This is a custodial pass that adds some doc notation to versioned methods, deprecates project log, and makes sure we don't hit common namespace collisions.

Release-Type: fix