### PR TITLE
Use dream prompt in mcp.

### DIFF
--- a/crates/oneiros-engine/src/mcp.rs
+++ b/crates/oneiros-engine/src/mcp.rs
@@ -467,23 +467,16 @@ impl ServerHandler for EngineToolBox {
                 .await
                 .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
 
-                match response {
-                    ContinuityResponse::Dreaming(DreamingResponse::V1(details)) => {
-                        let dream = details.context;
-                        let text = DreamTemplate::new(&dream).to_string();
-                        Ok(
-                            GetPromptResult::new(vec![rmcp::model::PromptMessage::new_text(
-                                rmcp::model::PromptMessageRole::User,
-                                text,
-                            )])
-                            .with_description(format!("Dream context for {agent_name}")),
-                        )
-                    }
-                    _ => Err(ErrorData::internal_error(
-                        "Unexpected response from dream",
-                        None,
-                    )),
-                }
+                let rendered = ContinuityPresenter::new(response).render();
+                let text = rendered.prompt().to_owned();
+
+                Ok(
+                    GetPromptResult::new(vec![rmcp::model::PromptMessage::new_text(
+                        rmcp::model::PromptMessageRole::User,
+                        text,
+                    )])
+                    .with_description(format!("Dream context for {agent_name}")),
+                )
             }
             _ => Err(ErrorData::invalid_params(
                 format!("Unknown prompt: {}", request.name),


### PR DESCRIPTION
We forgot to update our MCP setup to use the view layer components, and that felt like an issue we should resolve sooner rather than later. That's what this commit does.

Release-Type: fix