### PR TITLE
Use MCP init compositionally in setup.

### DIFF
--- a/crates/oneiros-engine/src/domains/setup/features/cli.rs
+++ b/crates/oneiros-engine/src/domains/setup/features/cli.rs
@@ -7,8 +7,55 @@ impl SetupCli {
         config: &Config,
         request: &SetupRequest,
     ) -> Result<Rendered<Responses>, SetupError> {
-        let response = SetupService::run(config, request).await?;
+        let request = Self::resolve(config, request).await;
+        let response = SetupService::run(config, &request).await?;
 
         Ok(SetupView::new(response).render().map(Into::into))
+    }
+
+    async fn resolve(config: &Config, request: &SetupRequest) -> SetupRequest {
+        let SetupRequest::V1(details) = request;
+
+        let mut install_host = details.install_host || details.accept_all;
+        let mut init_mcp = details.init_mcp || details.accept_all;
+
+        if install_host && init_mcp {
+            return SetupRequest::V1(SetupRequestV1 {
+                name: details.name.clone(),
+                install_host,
+                init_mcp,
+                accept_all: false,
+            });
+        }
+
+        if !install_host {
+            let server_ready = matches!(
+                HostService::status(config).await,
+                HostResponse::ServiceRunning(_)
+            );
+
+            if !server_ready {
+                install_host = inquire::Confirm::new(
+                    "The oneiros service isn't running. Install and start it now?",
+                )
+                .with_default(true)
+                .prompt()
+                .unwrap_or(false);
+            }
+        }
+
+        if !init_mcp {
+            init_mcp = inquire::Confirm::new("Set up MCP config for Claude Code?")
+                .with_default(true)
+                .prompt()
+                .unwrap_or(false);
+        }
+
+        SetupRequest::V1(SetupRequestV1 {
+            name: details.name.clone(),
+            install_host,
+            init_mcp,
+            accept_all: false,
+        })
     }
 }

--- a/crates/oneiros-engine/src/domains/setup/features/skills/setup.md
+++ b/crates/oneiros-engine/src/domains/setup/features/skills/setup.md
@@ -1,6 +1,6 @@
 ---
 description: Guided first-run setup — initializes host, project, vocabulary, agents, MCP config, and service in one flow.
-argument-hint: "[--name <name>] [--yes]"
+argument-hint: "[--name <name>] [--accept-all] [--install-host] [--init-mcp]"
 ---
 
 Run `oneiros setup` for a guided first-run experience. It walks through each step of setting up oneiros for a project:
@@ -12,6 +12,6 @@ Run `oneiros setup` for a guided first-run experience. It walks through each ste
 5. MCP config (Claude Code integration)
 6. Service installation and start
 
-Use `--yes` to accept all defaults without prompting. Use `--name` to set the host name.
+Use `--accept-all` (`-y`) to accept all optional steps without prompting. Use `--install-host` or `--init-mcp` to opt into specific optional steps. Use `--name` to set the host name.
 
 Each step is idempotent — running setup again skips what's already done.

--- a/crates/oneiros-engine/src/domains/setup/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/setup/protocol/requests.rs
@@ -11,11 +11,21 @@ versioned! {
             #[arg(long)]
             #[builder(into)]
             pub(crate) name: Option<String>,
-            /// Skip all confirmation prompts.
-            #[arg(long, short)]
+            /// Install and start the host service if it isn't running.
+            #[arg(long)]
             #[serde(default)]
             #[builder(default)]
-            pub(crate) yes: bool,
+            pub(crate) install_host: bool,
+            /// Write .mcp.json for Claude Code integration.
+            #[arg(long)]
+            #[serde(default)]
+            #[builder(default)]
+            pub(crate) init_mcp: bool,
+            /// Accept all optional steps without prompting.
+            #[arg(long, short = 'y')]
+            #[serde(default)]
+            #[builder(default)]
+            pub(crate) accept_all: bool,
         }
     }
 }

--- a/crates/oneiros-engine/src/domains/setup/service.rs
+++ b/crates/oneiros-engine/src/domains/setup/service.rs
@@ -10,23 +10,14 @@ impl SetupService {
         let details = request.current()?;
         let mut steps = Vec::new();
 
-        // 1. Server reachability is the precondition. Setup talks to a running
-        //    server; if there isn't one, offer to install and start it.
+        // 1. Service install — gated by `install_host`.
         let server_ready = matches!(
             HostService::status(config).await,
             HostResponse::ServiceRunning(_)
         );
 
         if !server_ready {
-            let do_service = details.yes
-                || inquire::Confirm::new(
-                    "The oneiros service isn't running. Install and start it now?",
-                )
-                .with_default(true)
-                .prompt()
-                .unwrap_or(false);
-
-            if !do_service {
+            if !details.install_host {
                 steps.push(SetupStep::ServiceSkipped);
                 return Ok(SetupResponse::SetupComplete(
                     SetupCompleteResponse::builder_v1()
@@ -69,20 +60,14 @@ impl SetupService {
             }
         }
 
-        // 2. Host init (always, idempotent) — over HTTP with a host
-        //    token. The host key was created at server startup.
+        // 2. Host init (always, idempotent).
         let host_secret = HostKey::new(config.platform()).load()?;
         let host_client = match host_secret {
             Some(secret) => {
                 let host_token = HostToken::generate(&secret);
                 Client::with_bearer(config.base_url(), &host_token.to_string())
             }
-            None => {
-                // Host key not yet generated — server may not have
-                // started. Use anonymous client; the request will fail
-                // with a clear 401 if auth is required.
-                Ok(Client::new(config.base_url()))
-            }
+            None => Ok(Client::new(config.base_url())),
         }?;
         let host_request: InitHost = InitHost::builder_v1()
             .maybe_name(details.name.clone())
@@ -129,8 +114,7 @@ impl SetupService {
             }
         }
 
-        // 3. Project create (always, idempotent) — over HTTP. Capture the token
-        //    from the response so the seed calls can authenticate.
+        // 3. Project create (always, idempotent).
         let project_request: CreateProject = CreateProject::builder_v1()
             .name(config.project.clone())
             .yes(true)
@@ -169,8 +153,6 @@ impl SetupService {
             }
         };
 
-        // Resolve the token for the seed calls: prefer a freshly-issued one,
-        // fall back to whatever's already on disk (for repeat runs).
         let token = project_token.or_else(|| config.token());
 
         let Some(token) = token else {
@@ -202,7 +184,7 @@ impl SetupService {
             }
         };
 
-        // 4. Seed core (always, idempotent) — over HTTP.
+        // 4. Seed core (always, idempotent).
         match project_client.post("/seed/core", &()).await {
             Ok(_) => steps.push(SetupStep::VocabularySeeded),
             Err(e) => {
@@ -213,7 +195,7 @@ impl SetupService {
             }
         }
 
-        // 5. Seed agents (always, idempotent) — over HTTP.
+        // 5. Seed agents (always, idempotent).
         match project_client.post("/seed/agents", &()).await {
             Ok(_) => steps.push(SetupStep::AgentsSeeded),
             Err(e) => {
@@ -224,14 +206,8 @@ impl SetupService {
             }
         }
 
-        // 6. MCP config (prompt unless --yes) — local file write.
-        let do_mcp = details.yes
-            || inquire::Confirm::new("Set up MCP config for Claude Code?")
-                .with_default(true)
-                .prompt()
-                .unwrap_or(false);
-
-        if do_mcp {
+        // 6. MCP config — gated by `init_mcp`.
+        if details.init_mcp {
             let mcp_request: InitMcp = InitMcp::builder_v1().yes(true).build().into();
             match McpConfigService::init(config, &mcp_request) {
                 Ok(McpResponses::McpConfigWritten(_)) => {

--- a/crates/oneiros-engine/src/tests/workflows/bootstrap.rs
+++ b/crates/oneiros-engine/src/tests/workflows/bootstrap.rs
@@ -118,14 +118,13 @@ async fn host_init_twice_returns_already_initialized() -> Result<(), Box<dyn cor
 /// Setup orchestrates the full bootstrap through HTTP. With the server
 /// already running, setup discovers it (no install prompt), drives the
 /// init / seed sequence over HTTP, and the token issued by project create
-/// authenticates the subsequent seed calls. The MCP step prompts in an
-/// interactive shell; in a non-interactive test it falls through to
-/// McpSkipped, leaving no `.mcp.json` side-effect.
+/// authenticates the subsequent seed calls. `--accept-all` opts into every
+/// optional step without interactive prompts.
 #[tokio::test]
 async fn setup_drives_bootstrap_through_http() -> Result<(), Box<dyn core::error::Error>> {
     let app = TestApp::new().await?;
 
-    let result = app.command("setup").await?;
+    let result = app.command("setup --accept-all").await?;
     let response = match result.response() {
         Responses::Setup(setup) => setup.clone(),
         other => panic!("expected Setup response, got {other:?}"),


### PR DESCRIPTION
We weren't using MCP init as a directly composed service in our setup command, which meant that there were some contexts in which odd behavior would crop up. We'd stall some, but not all, tests, for example, with a "Do you want to install MCP json config?" style prompts. Not great!

This commit updates this so that we leverage the existing plumbing with some defaults instead of duplicating the logic.

Release-Type: fix