### PR TITLE
Remove dist from nested app .gitignore

### DIFF
--- a/apps/dashboard/.gitignore
+++ b/apps/dashboard/.gitignore
@@ -1,5 +1,4 @@
-# build output
-dist/
+# build output: committed as a generated artifact (see root .gitignore)
 # generated types
 .astro/
 


### PR DESCRIPTION
We think that this was giving us errors in CI when we were trying to conduct builds for the PR update workflow. Removing dist should unblock that workflow?

Release-Type: fix