### PR TITLE
Lens sets and readers

### DIFF
--- a/crates/oneiros-engine/src/config.rs
+++ b/crates/oneiros-engine/src/config.rs
@@ -282,6 +282,22 @@ pub(crate) struct Config {
     /// How much detail to show: quiet, normal (default), or verbose.
     #[builder(default)]
     pub(crate) verbosity: Verbosity,
+    /// Lens-specific configuration: aliases for query expressions.
+    #[builder(default)]
+    pub(crate) lens: LensConfig,
+}
+
+/// Configuration for the lens query language. Currently carries
+/// user-defined aliases — short names that expand to full lens
+/// expressions at parse time. Aliases are sugar over the fixed grammar;
+/// the parser doesn't change. See `notes/Charter - Lens, revised.local.md`.
+#[derive(Builder, Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub(crate) struct LensConfig {
+    /// Named aliases — `mine = "agent(governor.process)"` lets the user
+    /// type `mine` anywhere a lens expression is expected. Expansion is
+    /// transitive; circular aliases are rejected at parse time.
+    pub(crate) aliases: std::collections::HashMap<String, String>,
 }
 
 impl Default for Config {
@@ -298,6 +314,7 @@ impl Default for Config {
             output: OutputMode::default(),
             color: ColorChoice::default(),
             verbosity: Verbosity::default(),
+            lens: LensConfig::default(),
         }
     }
 }

--- a/crates/oneiros-engine/src/domains/agent/features/http.rs
+++ b/crates/oneiros-engine/src/domains/agent/features/http.rs
@@ -1,7 +1,7 @@
 use aide::axum::{ApiRouter, routing};
 use axum::{
     Json,
-    extract::{Path, Query},
+    extract::{Path, Query, State},
     http::StatusCode,
 };
 
@@ -51,9 +51,20 @@ async fn create(
 }
 
 async fn list(
+    State(state): State<ServerState>,
     scope: Scope<AtBookmark>,
     Query(params): Query<ListAgents>,
 ) -> Result<Json<AgentResponse>, AgentError> {
+    let ListAgents::V1(listing) = &params;
+
+    if let Some(source) = listing.lens.as_deref() {
+        return Ok(Json(
+            AgentLens::new(&scope, state.canons())
+                .list(source, &listing.filters)
+                .await?,
+        ));
+    }
+
     Ok(Json(AgentService::list(&scope, &params).await?))
 }
 

--- a/crates/oneiros-engine/src/domains/agent/features/lens.rs
+++ b/crates/oneiros-engine/src/domains/agent/features/lens.rs
@@ -1,0 +1,45 @@
+use crate::*;
+
+/// Resolves a lens expression into agent entities. Works for both HTTP
+/// (via `state.canons()`) and MCP (via `context.canons()`) callers.
+pub(crate) struct AgentLens<'a> {
+    scope: &'a Scope<AtBookmark>,
+    canons: &'a CanonIndex,
+}
+
+impl<'a> AgentLens<'a> {
+    pub(crate) fn new(scope: &'a Scope<AtBookmark>, canons: &'a CanonIndex) -> Self {
+        Self { scope, canons }
+    }
+
+    pub(crate) async fn list(
+        &self,
+        lens: &str,
+        filters: &SearchFilters,
+    ) -> Result<AgentResponse, AgentError> {
+        let hits = LensService::select(self.scope, self.canons, lens)
+            .await?
+            .paginate(filters.offset.0, filters.limit.0);
+        let mut items = Vec::new();
+        let repo = AgentRepo::new(self.scope);
+        for hit in hits {
+            if let Hit::Entity(EntityHit { entity_ref, .. }) = hit
+                && let Ref::V0(Resource::Agent(id)) = entity_ref
+                && let Some(agent) = repo.fetch_by_id(id).await?
+            {
+                items.push(agent);
+            }
+        }
+        if items.is_empty() {
+            return Ok(AgentResponse::NoAgents);
+        }
+        let total = items.len();
+        Ok(AgentResponse::Agents(
+            AgentsResponse::builder_v1()
+                .items(items)
+                .total(total)
+                .build()
+                .into(),
+        ))
+    }
+}

--- a/crates/oneiros-engine/src/domains/agent/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/agent/features/mcp.rs
@@ -143,9 +143,17 @@ mod agent_mcp {
                 }
             }
             AgentRequest::ListAgents(listing) => {
-                let response = AgentService::list(scope, listing)
-                    .await
-                    .map_err(Error::from)?;
+                let ListAgents::V1(details) = listing;
+                let response = if let Some(source) = details.lens.as_deref() {
+                    AgentLens::new(scope, context.canons())
+                        .list(source, &details.filters)
+                        .await
+                        .map_err(Error::from)?
+                } else {
+                    AgentService::list(scope, listing)
+                        .await
+                        .map_err(Error::from)?
+                };
                 Ok(AgentView::new(response).mcp())
             }
             AgentRequest::CreateAgent(_)

--- a/crates/oneiros-engine/src/domains/agent/features/mod.rs
+++ b/crates/oneiros-engine/src/domains/agent/features/mod.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod http;
+mod lens;
 mod mcp;
 mod projections;
 mod skills;
@@ -7,6 +8,7 @@ mod state;
 
 pub(crate) use cli::*;
 pub(crate) use http::*;
+pub(crate) use lens::*;
 pub(crate) use mcp::*;
 pub(crate) use projections::*;
 pub(crate) use skills::*;

--- a/crates/oneiros-engine/src/domains/agent/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/agent/protocol/errors.rs
@@ -39,6 +39,9 @@ pub(crate) enum AgentError {
 
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Lens(#[from] crate::LensError),
 }
 
 resource_op_error!(AgentError);
@@ -57,6 +60,7 @@ impl IntoResponse for AgentError {
             AgentError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
             AgentError::Compose(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             AgentError::Json(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
+            AgentError::Lens(_) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
         };
         (status, Json(ErrorResponse::new(message))).into_response()
     }

--- a/crates/oneiros-engine/src/domains/agent/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/agent/protocol/requests.rs
@@ -59,6 +59,12 @@ versioned! {
             #[arg(long)]
             #[builder(into)]
             pub(crate) query: Option<String>,
+            /// Lens expression — replaces ad-hoc filters with the unified
+            /// query language. When set, query is ignored and the lens
+            /// drives selection end-to-end.
+            #[arg(long)]
+            #[builder(into)]
+            pub(crate) lens: Option<String>,
             #[command(flatten)]
             #[serde(flatten)]
             #[builder(default)]
@@ -76,6 +82,10 @@ impl ClientRequest for ListAgents {
 
         if let Some(query) = &listing.query {
             params.push(("query", query.clone()));
+        }
+
+        if let Some(lens) = &listing.lens {
+            params.push(("lens", lens.clone()));
         }
 
         params.push(("limit", listing.filters.limit.to_string()));

--- a/crates/oneiros-engine/src/domains/chronicle/lens_reader.rs
+++ b/crates/oneiros-engine/src/domains/chronicle/lens_reader.rs
@@ -1,0 +1,85 @@
+use rusqlite::params;
+
+use crate::*;
+
+pub(crate) struct ChronicleLensReader<'a> {
+    host_db: &'a HostDb,
+    canons: &'a CanonIndex,
+    project: ProjectName,
+}
+
+impl<'a> ChronicleLensReader<'a> {
+    pub(crate) fn new(host_db: &'a HostDb, canons: &'a CanonIndex, project: ProjectName) -> Self {
+        Self {
+            host_db,
+            canons,
+            project,
+        }
+    }
+
+    fn resolve_bookmark_name(&self, reference: &RefToken) -> Result<BookmarkName, ReaderError> {
+        let Ref::V0(Resource::Bookmark(bookmark_id)) = reference.inner() else {
+            return Err(ReaderError::Internal(format!(
+                "between() expected bookmark ref, got {reference}"
+            )));
+        };
+
+        let mut stmt = self
+            .host_db
+            .prepare("SELECT name FROM bookmarks WHERE id = ?1 AND project = ?2")
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let name: String = stmt
+            .query_row(
+                params![bookmark_id.to_string(), self.project.to_string()],
+                |row| row.get(0),
+            )
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+        Ok(BookmarkName::new(name))
+    }
+
+    fn read_between(&self, from: &RefToken, to: &RefToken) -> Result<Selection, ReaderError> {
+        let from_name = self.resolve_bookmark_name(from)?;
+        let to_name = self.resolve_bookmark_name(to)?;
+
+        let from_chronicle = self
+            .canons
+            .bookmark_chronicle(&self.project, &from_name)
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let to_chronicle = self
+            .canons
+            .bookmark_chronicle(&self.project, &to_name)
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+
+        let from_root = from_chronicle
+            .root()
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let to_root = to_chronicle
+            .root()
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+
+        let store = ChronicleStore::new(self.host_db);
+        let resolver = store.resolver();
+        let changes = Ledger::diff(from_root.as_ref(), to_root.as_ref(), &resolver);
+
+        let mut selection = Selection::new();
+        for change in changes {
+            if let LedgerChange::Added(event_id) = change {
+                selection.insert(Hit::Event(EventHit {
+                    event_id,
+                    timestamp: Timestamp::now(),
+                    relevance: Relevance::Unknown,
+                }));
+            }
+        }
+        Ok(selection)
+    }
+}
+
+impl Reader for ChronicleLensReader<'_> {
+    fn read(&self, read: &Read) -> Option<Result<Selection, ReaderError>> {
+        match read {
+            Read::ChronicleBetween { from, to } => Some(self.read_between(from, to)),
+            _ => None,
+        }
+    }
+}

--- a/crates/oneiros-engine/src/domains/chronicle/mod.rs
+++ b/crates/oneiros-engine/src/domains/chronicle/mod.rs
@@ -1,3 +1,5 @@
+mod lens_reader;
 mod store;
 
+pub(crate) use lens_reader::*;
 pub(crate) use store::*;

--- a/crates/oneiros-engine/src/domains/cognition/features/http.rs
+++ b/crates/oneiros-engine/src/domains/cognition/features/http.rs
@@ -45,9 +45,18 @@ async fn add(
 }
 
 async fn list(
+    axum::extract::State(state): axum::extract::State<ServerState>,
     scope: Scope<AtBookmark>,
     Query(params): Query<ListCognitions>,
 ) -> Result<Json<CognitionResponse>, CognitionError> {
+    let ListCognitions::V1(listing) = &params;
+    if let Some(source) = listing.lens.as_deref() {
+        return Ok(Json(
+            CognitionLens::new(&scope, state.canons())
+                .list(source, &listing.filters)
+                .await?,
+        ));
+    }
     Ok(Json(CognitionService::list(&scope, &params).await?))
 }
 

--- a/crates/oneiros-engine/src/domains/cognition/features/lens.rs
+++ b/crates/oneiros-engine/src/domains/cognition/features/lens.rs
@@ -1,0 +1,43 @@
+use crate::*;
+
+pub(crate) struct CognitionLens<'a> {
+    scope: &'a Scope<AtBookmark>,
+    canons: &'a CanonIndex,
+}
+
+impl<'a> CognitionLens<'a> {
+    pub(crate) fn new(scope: &'a Scope<AtBookmark>, canons: &'a CanonIndex) -> Self {
+        Self { scope, canons }
+    }
+
+    pub(crate) async fn list(
+        &self,
+        lens: &str,
+        filters: &SearchFilters,
+    ) -> Result<CognitionResponse, CognitionError> {
+        let hits = LensService::select(self.scope, self.canons, lens)
+            .await?
+            .paginate(filters.offset.0, filters.limit.0);
+        let mut items = Vec::new();
+        let repo = CognitionRepo::new(self.scope);
+        for hit in hits {
+            if let Hit::Entity(EntityHit { entity_ref, .. }) = hit
+                && let Ref::V0(Resource::Cognition(id)) = entity_ref
+                && let Some(cognition) = repo.fetch(&id).await?
+            {
+                items.push(cognition);
+            }
+        }
+        if items.is_empty() {
+            return Ok(CognitionResponse::NoCognitions);
+        }
+        let total = items.len();
+        Ok(CognitionResponse::Cognitions(
+            CognitionsResponse::builder_v1()
+                .items(items)
+                .total(total)
+                .build()
+                .into(),
+        ))
+    }
+}

--- a/crates/oneiros-engine/src/domains/cognition/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/cognition/features/mcp.rs
@@ -79,9 +79,19 @@ mod cognition_mcp {
             CognitionRequest::GetCognition(get) => CognitionService::get(scope, get)
                 .await
                 .map_err(Error::from)?,
-            CognitionRequest::ListCognitions(listing) => CognitionService::list(scope, listing)
-                .await
-                .map_err(Error::from)?,
+            CognitionRequest::ListCognitions(listing) => {
+                let ListCognitions::V1(details) = listing;
+                if let Some(source) = details.lens.as_deref() {
+                    CognitionLens::new(scope, context.canons())
+                        .list(source, &details.filters)
+                        .await
+                        .map_err(Error::from)?
+                } else {
+                    CognitionService::list(scope, listing)
+                        .await
+                        .map_err(Error::from)?
+                }
+            }
             CognitionRequest::AddCognition(_) => {
                 return Err(ToolError::NotAResource(
                     "Add is a tool, not a resource".to_string(),

--- a/crates/oneiros-engine/src/domains/cognition/features/mod.rs
+++ b/crates/oneiros-engine/src/domains/cognition/features/mod.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod http;
+mod lens;
 mod mcp;
 mod projections;
 mod skills;
@@ -7,6 +8,7 @@ mod state;
 
 pub(crate) use cli::*;
 pub(crate) use http::*;
+pub(crate) use lens::*;
 pub(crate) use mcp::*;
 pub(crate) use projections::*;
 pub(crate) use skills::*;

--- a/crates/oneiros-engine/src/domains/cognition/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/cognition/protocol/errors.rs
@@ -32,6 +32,9 @@ pub(crate) enum CognitionError {
 
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Lens(#[from] crate::LensError),
 }
 
 resource_op_error!(CognitionError);
@@ -49,6 +52,7 @@ impl IntoResponse for CognitionError {
             CognitionError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
             CognitionError::Compose(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             CognitionError::Json(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
+            CognitionError::Lens(_) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
         };
         (status, Json(ErrorResponse::new(message))).into_response()
     }

--- a/crates/oneiros-engine/src/domains/cognition/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/cognition/protocol/requests.rs
@@ -57,6 +57,12 @@ versioned! {
             #[arg(long)]
             #[builder(into)]
             pub(crate) query: Option<String>,
+            /// Lens expression — replaces ad-hoc filters with the unified
+            /// query language. When set, agent/texture/query are ignored
+            /// and the lens drives selection end-to-end.
+            #[arg(long)]
+            #[builder(into)]
+            pub(crate) lens: Option<String>,
             #[command(flatten)]
             #[serde(flatten)]
             #[builder(default)]
@@ -82,6 +88,10 @@ impl ClientRequest for ListCognitions {
 
         if let Some(query) = &listing.query {
             params.push(("query", query.clone()));
+        }
+
+        if let Some(lens) = &listing.lens {
+            params.push(("lens", lens.clone()));
         }
 
         params.push(("limit", listing.filters.limit.to_string()));

--- a/crates/oneiros-engine/src/domains/connection/features/lens.rs
+++ b/crates/oneiros-engine/src/domains/connection/features/lens.rs
@@ -1,0 +1,43 @@
+use crate::*;
+
+pub(crate) struct ConnectionLens<'a> {
+    scope: &'a Scope<AtBookmark>,
+    canons: &'a CanonIndex,
+}
+
+impl<'a> ConnectionLens<'a> {
+    pub(crate) fn new(scope: &'a Scope<AtBookmark>, canons: &'a CanonIndex) -> Self {
+        Self { scope, canons }
+    }
+
+    pub(crate) async fn list(
+        &self,
+        lens: &str,
+        filters: &SearchFilters,
+    ) -> Result<ConnectionResponse, ConnectionError> {
+        let hits = LensService::select(self.scope, self.canons, lens)
+            .await?
+            .paginate(filters.offset.0, filters.limit.0);
+        let mut items = Vec::new();
+        let repo = ConnectionRepo::new(self.scope);
+        for hit in hits {
+            if let Hit::Entity(EntityHit { entity_ref, .. }) = hit
+                && let Ref::V0(Resource::Connection(id)) = entity_ref
+                && let Some(connection) = repo.fetch(&id).await?
+            {
+                items.push(connection);
+            }
+        }
+        if items.is_empty() {
+            return Ok(ConnectionResponse::NoConnections);
+        }
+        let total = items.len();
+        Ok(ConnectionResponse::Connections(
+            ConnectionsResponse::builder_v1()
+                .items(items)
+                .total(total)
+                .build()
+                .into(),
+        ))
+    }
+}

--- a/crates/oneiros-engine/src/domains/connection/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/connection/features/mcp.rs
@@ -85,9 +85,19 @@ mod connection_mcp {
             ConnectionRequest::GetConnection(get) => ConnectionService::get(scope, get)
                 .await
                 .map_err(Error::from)?,
-            ConnectionRequest::ListConnections(listing) => ConnectionService::list(scope, listing)
-                .await
-                .map_err(Error::from)?,
+            ConnectionRequest::ListConnections(listing) => {
+                let ListConnections::V1(details) = listing;
+                if let Some(source) = details.lens.as_deref() {
+                    ConnectionLens::new(scope, context.canons())
+                        .list(source, &details.filters)
+                        .await
+                        .map_err(Error::from)?
+                } else {
+                    ConnectionService::list(scope, listing)
+                        .await
+                        .map_err(Error::from)?
+                }
+            }
             ConnectionRequest::CreateConnection(_) | ConnectionRequest::RemoveConnection(_) => {
                 return Err(ToolError::NotAResource(
                     "Mutations are tools, not resources".to_string(),

--- a/crates/oneiros-engine/src/domains/connection/features/mod.rs
+++ b/crates/oneiros-engine/src/domains/connection/features/mod.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod http;
+mod lens;
 mod mcp;
 mod projections;
 mod skills;
@@ -7,6 +8,7 @@ mod state;
 
 pub(crate) use cli::*;
 pub(crate) use http::*;
+pub(crate) use lens::*;
 pub(crate) use mcp::*;
 pub(crate) use projections::*;
 pub(crate) use skills::*;

--- a/crates/oneiros-engine/src/domains/connection/lens_reader.rs
+++ b/crates/oneiros-engine/src/domains/connection/lens_reader.rs
@@ -1,0 +1,174 @@
+use std::collections::HashSet;
+
+use rusqlite::params;
+
+use crate::*;
+
+pub(crate) struct ConnectionLensReader<'a> {
+    db: &'a BookmarkDb,
+}
+
+impl<'a> ConnectionLensReader<'a> {
+    pub(crate) fn new(db: &'a BookmarkDb) -> Self {
+        Self { db }
+    }
+
+    fn neighbors_from(&self, source: &Ref) -> Result<Vec<(Ref, Timestamp)>, ReaderError> {
+        let source_json =
+            serde_json::to_string(source).map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let mut stmt = self
+            .db
+            .prepare(
+                "SELECT to_ref, created_at
+                 FROM connections
+                 WHERE from_ref = ?1
+                 ORDER BY created_at DESC",
+            )
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let rows = stmt
+            .query_map(params![source_json], |row| {
+                let to_ref: String = row.get(0)?;
+                let created_at: String = row.get(1)?;
+                Ok((to_ref, created_at))
+            })
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (to_ref_raw, created_at) = row.map_err(|e| ReaderError::Internal(e.to_string()))?;
+            let to_ref: Ref = serde_json::from_str(&to_ref_raw)
+                .map_err(|e| ReaderError::Internal(e.to_string()))?;
+            let timestamp = Timestamp::parse_str(&created_at)
+                .map_err(|e| ReaderError::Internal(e.to_string()))?;
+            out.push((to_ref, timestamp));
+        }
+        Ok(out)
+    }
+
+    fn neighbors_to(&self, target: &Ref) -> Result<Vec<(Ref, Timestamp)>, ReaderError> {
+        let target_json =
+            serde_json::to_string(target).map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let mut stmt = self
+            .db
+            .prepare(
+                "SELECT from_ref, created_at
+                 FROM connections
+                 WHERE to_ref = ?1
+                 ORDER BY created_at DESC",
+            )
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let rows = stmt
+            .query_map(params![target_json], |row| {
+                let from_ref: String = row.get(0)?;
+                let created_at: String = row.get(1)?;
+                Ok((from_ref, created_at))
+            })
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (from_ref_raw, created_at) =
+                row.map_err(|e| ReaderError::Internal(e.to_string()))?;
+            let from_ref: Ref = serde_json::from_str(&from_ref_raw)
+                .map_err(|e| ReaderError::Internal(e.to_string()))?;
+            let timestamp = Timestamp::parse_str(&created_at)
+                .map_err(|e| ReaderError::Internal(e.to_string()))?;
+            out.push((from_ref, timestamp));
+        }
+        Ok(out)
+    }
+
+    fn step_connected_from(&self, input: &Selection) -> Result<Selection, ReaderError> {
+        let mut selection = Selection::new();
+        for source in input.entity_refs() {
+            for (neighbor, timestamp) in self.neighbors_from(&source)? {
+                selection.insert(Hit::Entity(EntityHit {
+                    entity_ref: neighbor,
+                    timestamp,
+                    relevance: Relevance::Unknown,
+                }));
+            }
+        }
+        Ok(selection)
+    }
+
+    fn step_connected_to(&self, input: &Selection) -> Result<Selection, ReaderError> {
+        let mut selection = Selection::new();
+        for target in input.entity_refs() {
+            for (neighbor, timestamp) in self.neighbors_to(&target)? {
+                selection.insert(Hit::Entity(EntityHit {
+                    entity_ref: neighbor,
+                    timestamp,
+                    relevance: Relevance::Unknown,
+                }));
+            }
+        }
+        Ok(selection)
+    }
+
+    fn walk(
+        &self,
+        input: &Selection,
+        max_depth: Option<u32>,
+        forward: bool,
+        backward: bool,
+    ) -> Result<Selection, ReaderError> {
+        let seeds = input.entity_refs();
+        let mut visited: HashSet<Ref> = seeds.iter().cloned().collect();
+        let mut frontier: Vec<Ref> = seeds;
+        let mut selection = Selection::new();
+        let mut depth: u32 = 0;
+
+        while !frontier.is_empty() {
+            if let Some(limit) = max_depth
+                && depth >= limit
+            {
+                break;
+            }
+            depth += 1;
+            let mut next_frontier = Vec::new();
+            for node in &frontier {
+                let mut neighbors: Vec<(Ref, Timestamp)> = Vec::new();
+                if forward {
+                    neighbors.extend(self.neighbors_from(node)?);
+                }
+                if backward {
+                    neighbors.extend(self.neighbors_to(node)?);
+                }
+                for (neighbor, timestamp) in neighbors {
+                    if visited.insert(neighbor.clone()) {
+                        selection.insert(Hit::Entity(EntityHit {
+                            entity_ref: neighbor.clone(),
+                            timestamp,
+                            relevance: Relevance::Unknown,
+                        }));
+                        next_frontier.push(neighbor);
+                    }
+                }
+            }
+            frontier = next_frontier;
+        }
+        Ok(selection)
+    }
+}
+
+impl Reader for ConnectionLensReader<'_> {
+    fn read(&self, _read: &Read) -> Option<Result<Selection, ReaderError>> {
+        None
+    }
+
+    fn step(&self, kind: &StepKind, input: &Selection) -> Option<Result<Selection, ReaderError>> {
+        match kind {
+            StepKind::ConnectedFrom => Some(self.step_connected_from(input)),
+            StepKind::ConnectedTo => Some(self.step_connected_to(input)),
+            StepKind::Descendants => Some(self.walk(input, None, true, false)),
+            StepKind::Ancestors => Some(self.walk(input, None, false, true)),
+            StepKind::Within(n) => Some(self.walk(input, Some(*n), true, true)),
+            StepKind::Component => Some(self.walk(input, None, true, true)),
+            StepKind::EventsFor
+            | StepKind::RefsFrom
+            | StepKind::SearchByAgent
+            | StepKind::SearchByTexture
+            | StepKind::SearchByLevel
+            | StepKind::SearchByKind => None,
+        }
+    }
+}

--- a/crates/oneiros-engine/src/domains/connection/mod.rs
+++ b/crates/oneiros-engine/src/domains/connection/mod.rs
@@ -1,5 +1,6 @@
 mod docs;
 mod features;
+mod lens_reader;
 mod model;
 mod protocol;
 mod repo;
@@ -9,6 +10,7 @@ mod view;
 
 pub(crate) use docs::*;
 pub(crate) use features::*;
+pub(crate) use lens_reader::*;
 pub(crate) use model::*;
 pub(crate) use protocol::*;
 pub(crate) use repo::*;

--- a/crates/oneiros-engine/src/domains/connection/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/connection/protocol/errors.rs
@@ -29,6 +29,9 @@ pub(crate) enum ConnectionError {
 
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Lens(#[from] crate::LensError),
 }
 
 resource_op_error!(ConnectionError);
@@ -45,6 +48,7 @@ impl IntoResponse for ConnectionError {
             ConnectionError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
             ConnectionError::Compose(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             ConnectionError::Json(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
+            ConnectionError::Lens(_) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
         };
         (status, Json(ErrorResponse::new(message))).into_response()
     }

--- a/crates/oneiros-engine/src/domains/connection/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/connection/protocol/requests.rs
@@ -50,6 +50,12 @@ versioned! {
         V1 => {
             #[arg(long)]
             pub(crate) entity: Option<RefToken>,
+            /// Lens expression — replaces ad-hoc filters with the unified
+            /// query language. When set, entity is ignored and the lens
+            /// drives selection end-to-end.
+            #[arg(long)]
+            #[builder(into)]
+            pub(crate) lens: Option<String>,
             #[command(flatten)]
             #[serde(flatten)]
             #[builder(default)]
@@ -67,6 +73,10 @@ impl ClientRequest for ListConnections {
 
         if let Some(entity) = &listing.entity {
             params.push(("entity", entity.to_string()));
+        }
+
+        if let Some(lens) = &listing.lens {
+            params.push(("lens", lens.clone()));
         }
 
         params.push(("limit", listing.filters.limit.to_string()));

--- a/crates/oneiros-engine/src/domains/experience/features/http.rs
+++ b/crates/oneiros-engine/src/domains/experience/features/http.rs
@@ -60,9 +60,18 @@ async fn create(
 }
 
 async fn list(
+    axum::extract::State(state): axum::extract::State<ServerState>,
     scope: Scope<AtBookmark>,
     Query(params): Query<ListExperiences>,
 ) -> Result<Json<ExperienceResponse>, ExperienceError> {
+    let ListExperiences::V1(listing) = &params;
+    if let Some(source) = listing.lens.as_deref() {
+        return Ok(Json(
+            ExperienceLens::new(&scope, state.canons())
+                .list(source, &listing.filters)
+                .await?,
+        ));
+    }
     Ok(Json(ExperienceService::list(&scope, &params).await?))
 }
 

--- a/crates/oneiros-engine/src/domains/experience/features/lens.rs
+++ b/crates/oneiros-engine/src/domains/experience/features/lens.rs
@@ -1,0 +1,43 @@
+use crate::*;
+
+pub(crate) struct ExperienceLens<'a> {
+    scope: &'a Scope<AtBookmark>,
+    canons: &'a CanonIndex,
+}
+
+impl<'a> ExperienceLens<'a> {
+    pub(crate) fn new(scope: &'a Scope<AtBookmark>, canons: &'a CanonIndex) -> Self {
+        Self { scope, canons }
+    }
+
+    pub(crate) async fn list(
+        &self,
+        lens: &str,
+        filters: &SearchFilters,
+    ) -> Result<ExperienceResponse, ExperienceError> {
+        let hits = LensService::select(self.scope, self.canons, lens)
+            .await?
+            .paginate(filters.offset.0, filters.limit.0);
+        let mut items = Vec::new();
+        let repo = ExperienceRepo::new(self.scope);
+        for hit in hits {
+            if let Hit::Entity(EntityHit { entity_ref, .. }) = hit
+                && let Ref::V0(Resource::Experience(id)) = entity_ref
+                && let Some(experience) = repo.fetch(&id).await?
+            {
+                items.push(experience);
+            }
+        }
+        if items.is_empty() {
+            return Ok(ExperienceResponse::NoExperiences);
+        }
+        let total = items.len();
+        Ok(ExperienceResponse::Experiences(
+            ExperiencesResponse::builder_v1()
+                .items(items)
+                .total(total)
+                .build()
+                .into(),
+        ))
+    }
+}

--- a/crates/oneiros-engine/src/domains/experience/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/experience/features/mcp.rs
@@ -86,9 +86,19 @@ mod experience_mcp {
             ExperienceRequest::GetExperience(get) => ExperienceService::get(scope, get)
                 .await
                 .map_err(Error::from)?,
-            ExperienceRequest::ListExperiences(listing) => ExperienceService::list(scope, listing)
-                .await
-                .map_err(Error::from)?,
+            ExperienceRequest::ListExperiences(listing) => {
+                let ListExperiences::V1(details) = listing;
+                if let Some(source) = details.lens.as_deref() {
+                    ExperienceLens::new(scope, context.canons())
+                        .list(source, &details.filters)
+                        .await
+                        .map_err(Error::from)?
+                } else {
+                    ExperienceService::list(scope, listing)
+                        .await
+                        .map_err(Error::from)?
+                }
+            }
             ExperienceRequest::CreateExperience(_)
             | ExperienceRequest::UpdateExperienceDescription(_)
             | ExperienceRequest::UpdateExperienceSensation(_) => {

--- a/crates/oneiros-engine/src/domains/experience/features/mod.rs
+++ b/crates/oneiros-engine/src/domains/experience/features/mod.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod http;
+mod lens;
 mod mcp;
 mod projections;
 mod skills;
@@ -7,6 +8,7 @@ mod state;
 
 pub(crate) use cli::*;
 pub(crate) use http::*;
+pub(crate) use lens::*;
 pub(crate) use mcp::*;
 pub(crate) use projections::*;
 pub(crate) use skills::*;

--- a/crates/oneiros-engine/src/domains/experience/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/experience/protocol/errors.rs
@@ -35,6 +35,9 @@ pub(crate) enum ExperienceError {
 
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Lens(#[from] crate::LensError),
 }
 
 resource_op_error!(ExperienceError);
@@ -53,6 +56,7 @@ impl IntoResponse for ExperienceError {
             ExperienceError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
             ExperienceError::Compose(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             ExperienceError::Json(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
+            ExperienceError::Lens(_) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
         };
         (status, Json(ErrorResponse::new(message))).into_response()
     }

--- a/crates/oneiros-engine/src/domains/experience/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/experience/protocol/requests.rs
@@ -58,6 +58,12 @@ versioned! {
             #[arg(long)]
             #[builder(into)]
             pub(crate) query: Option<String>,
+            /// Lens expression — replaces ad-hoc filters with the unified
+            /// query language. When set, agent/sensation/query are ignored
+            /// and the lens drives selection end-to-end.
+            #[arg(long)]
+            #[builder(into)]
+            pub(crate) lens: Option<String>,
             #[command(flatten)]
             #[serde(flatten)]
             #[builder(default)]
@@ -83,6 +89,10 @@ impl ClientRequest for ListExperiences {
 
         if let Some(query) = &listing.query {
             params.push(("query", query.clone()));
+        }
+
+        if let Some(lens) = &listing.lens {
+            params.push(("lens", lens.clone()));
         }
 
         params.push(("limit", listing.filters.limit.to_string()));

--- a/crates/oneiros-engine/src/domains/lens/features/http.rs
+++ b/crates/oneiros-engine/src/domains/lens/features/http.rs
@@ -30,8 +30,11 @@ async fn explain(
 }
 
 async fn query(
+    axum::extract::State(state): axum::extract::State<ServerState>,
     scope: Scope<AtBookmark>,
     Json(body): Json<QueryLens>,
 ) -> Result<Json<LensResponse>, LensError> {
-    Ok(Json(LensService::query(&scope, &body).await?))
+    Ok(Json(
+        LensService::query(&scope, state.canons(), &body).await?,
+    ))
 }

--- a/crates/oneiros-engine/src/domains/lens/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/lens/protocol/errors.rs
@@ -25,6 +25,12 @@ pub(crate) enum LensError {
     BookmarkDb(#[from] crate::BookmarkDbError),
 
     #[error(transparent)]
+    HostDb(#[from] crate::HostDbError),
+
+    #[error(transparent)]
+    Alias(#[from] crate::AliasError),
+
+    #[error(transparent)]
     Compile(#[from] CompileError),
 
     #[error(transparent)]
@@ -37,9 +43,11 @@ impl IntoResponse for LensError {
             LensError::Parse(_) | LensError::Validate(_) | LensError::Compile(_) => {
                 (StatusCode::UNPROCESSABLE_ENTITY, self.to_string())
             }
-            LensError::Execute(_) | LensError::Event(_) | LensError::BookmarkDb(_) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
-            }
+            LensError::Execute(_)
+            | LensError::Event(_)
+            | LensError::BookmarkDb(_)
+            | LensError::HostDb(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            LensError::Alias(_) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
             LensError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
             LensError::Json(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
         };

--- a/crates/oneiros-engine/src/domains/lens/service.rs
+++ b/crates/oneiros-engine/src/domains/lens/service.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use crate::*;
 
 pub(crate) struct LensService;
@@ -20,21 +18,18 @@ impl LensService {
     }
 
     /// Parses, validates, name-resolves, and explains a lens source string.
-    ///
-    /// Loads canonical names from the project's vocabulary repos (agents,
-    /// textures, levels, sensations, personas, natures) and uses them to
-    /// catch typo-shaped errors that pure structural validation would miss
-    /// — `agent(governorr.process)` rejects even though the grammar is fine.
     pub(crate) async fn explain(
         scope: &Scope<AtBookmark>,
         request: &ExplainLens,
     ) -> Result<LensResponse, LensError> {
         let ExplainLens::V1(req) = request;
-        let lens = Lens::parse(&req.source)?;
+        let parsed = Lens::parse(&req.source)?;
+        let resolver = AliasResolver::new(&scope.config().lens.aliases)?;
+        let lens = resolver.expand(parsed)?;
         let registry = Registry::seed_default();
         lens.validate(&registry)?;
 
-        let names = ProjectNameRegistry::fetch(scope).await?;
+        let names = NameResolver::fetch(scope).await?;
         lens.check_names(&registry, &names)?;
 
         let compiler = Compiler::new(registry);
@@ -50,24 +45,40 @@ impl LensService {
                 .into(),
         ))
     }
+
+    /// Executes a lens query end-to-end: parse, alias-expand, validate,
+    /// name-resolve, compile, execute via readers, and return hits.
     pub(crate) async fn query(
         scope: &Scope<AtBookmark>,
+        canons: &CanonIndex,
         request: &QueryLens,
     ) -> Result<LensResponse, LensError> {
         let QueryLens::V1(req) = request;
-        let lens = Lens::parse(&req.source)?;
+        let parsed = Lens::parse(&req.source)?;
+        let resolver = AliasResolver::new(&scope.config().lens.aliases)?;
+        let lens = resolver.expand(parsed)?;
         let registry = Registry::seed_default();
         lens.validate(&registry)?;
 
-        let names = ProjectNameRegistry::fetch(scope).await?;
+        let names = NameResolver::fetch(scope).await?;
         lens.check_names(&registry, &names)?;
 
         let compiler = Compiler::new(registry);
         let ir = compiler.compile(&lens)?;
 
         let db = BookmarkDb::open(scope).await?;
+        let host_db = HostDb::open(scope).await?;
         let search_reader = SearchIndexReader::new(&db);
-        let readers: Vec<&dyn Reader> = vec![&search_reader];
+        let trail_reader = TrailLensReader::new(&db);
+        let connection_reader = ConnectionLensReader::new(&db);
+        let chronicle_reader =
+            ChronicleLensReader::new(&host_db, canons, scope.project().name.clone());
+        let readers: Vec<&dyn Reader> = vec![
+            &search_reader,
+            &trail_reader,
+            &connection_reader,
+            &chronicle_reader,
+        ];
         let executor = Executor::new(&readers);
         let selection = executor.run(&ir)?;
 
@@ -83,48 +94,29 @@ impl LensService {
                 .into(),
         ))
     }
-}
 
-/// Project-backed [`NameRegistry`] — fetches the full set of registered
-/// names from each vocabulary table at construction time and answers
-/// resolution queries synchronously against the resulting in-memory sets.
-///
-/// One round-trip per kind, six total. The vocabulary domains are small
-/// (typically <20 entries each) and the snapshot is per-explain-call, so
-/// the fetch cost is negligible and the registry stays consistent for the
-/// duration of a single resolution pass.
-pub(crate) struct ProjectNameRegistry {
-    agents: HashSet<String>,
-    textures: HashSet<String>,
-    levels: HashSet<String>,
-}
-
-impl ProjectNameRegistry {
-    pub(crate) async fn fetch(scope: &Scope<AtBookmark>) -> Result<Self, EventError> {
-        let db = BookmarkDb::open(scope).await?;
-        Ok(Self {
-            agents: Self::names_from(&db, "agents")?,
-            textures: Self::names_from(&db, "textures")?,
-            levels: Self::names_from(&db, "levels")?,
-        })
-    }
-
-    fn names_from(db: &BookmarkDb, table: &str) -> Result<HashSet<String>, rusqlite::Error> {
-        let sql = format!("select name from {table}");
-        let mut stmt = db.prepare(&sql)?;
-        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
-        rows.collect()
-    }
-}
-
-impl NameRegistry for ProjectNameRegistry {
-    fn knows(&self, kind: NameKind, name: &Identifier) -> bool {
-        let bucket = match kind {
-            NameKind::Agent => &self.agents,
-            NameKind::Texture => &self.textures,
-            NameKind::Level => &self.levels,
+    /// Runs the lens query pipeline and returns the raw [`Selection`]
+    /// without hydrating into domain objects. Callers apply their own
+    /// pagination, filtering, and repo dispatch from here.
+    pub(crate) async fn select(
+        scope: &Scope<AtBookmark>,
+        canons: &CanonIndex,
+        source: &str,
+    ) -> Result<Selection, LensError> {
+        let request = QueryLens::builder_v1()
+            .source(source.to_string())
+            .build()
+            .into();
+        let LensResponse::Queried(QueriedLensResponse::V1(queried)) =
+            Self::query(scope, canons, &request).await?
+        else {
+            return Ok(Selection::new());
         };
-        bucket.contains(name.as_str())
+        let mut selection = Selection::new();
+        for hit in &queried.hits {
+            selection.insert(hit.clone());
+        }
+        Ok(selection)
     }
 }
 

--- a/crates/oneiros-engine/src/domains/lens/view.rs
+++ b/crates/oneiros-engine/src/domains/lens/view.rs
@@ -51,6 +51,13 @@ impl LensView {
                                     e.timestamp.to_string(),
                                 ]);
                             }
+                            Hit::Name(n) => {
+                                table.push_row(vec![
+                                    format!("name:{}", n.kind.describe()),
+                                    n.name.clone(),
+                                    n.timestamp.to_string(),
+                                ]);
+                            }
                         }
                     }
                     let count_text = format!(

--- a/crates/oneiros-engine/src/domains/memory/features/http.rs
+++ b/crates/oneiros-engine/src/domains/memory/features/http.rs
@@ -45,9 +45,18 @@ async fn add(
 }
 
 async fn list(
+    axum::extract::State(state): axum::extract::State<ServerState>,
     scope: Scope<AtBookmark>,
     Query(params): Query<ListMemories>,
 ) -> Result<Json<MemoryResponse>, MemoryError> {
+    let ListMemories::V1(listing) = &params;
+    if let Some(source) = listing.lens.as_deref() {
+        return Ok(Json(
+            MemoryLens::new(&scope, state.canons())
+                .list(source, &listing.filters)
+                .await?,
+        ));
+    }
     Ok(Json(MemoryService::list(&scope, &params).await?))
 }
 

--- a/crates/oneiros-engine/src/domains/memory/features/lens.rs
+++ b/crates/oneiros-engine/src/domains/memory/features/lens.rs
@@ -1,0 +1,43 @@
+use crate::*;
+
+pub(crate) struct MemoryLens<'a> {
+    scope: &'a Scope<AtBookmark>,
+    canons: &'a CanonIndex,
+}
+
+impl<'a> MemoryLens<'a> {
+    pub(crate) fn new(scope: &'a Scope<AtBookmark>, canons: &'a CanonIndex) -> Self {
+        Self { scope, canons }
+    }
+
+    pub(crate) async fn list(
+        &self,
+        lens: &str,
+        filters: &SearchFilters,
+    ) -> Result<MemoryResponse, MemoryError> {
+        let hits = LensService::select(self.scope, self.canons, lens)
+            .await?
+            .paginate(filters.offset.0, filters.limit.0);
+        let mut items = Vec::new();
+        let repo = MemoryRepo::new(self.scope);
+        for hit in hits {
+            if let Hit::Entity(EntityHit { entity_ref, .. }) = hit
+                && let Ref::V0(Resource::Memory(id)) = entity_ref
+                && let Some(memory) = repo.fetch(&id).await?
+            {
+                items.push(memory);
+            }
+        }
+        if items.is_empty() {
+            return Ok(MemoryResponse::NoMemories);
+        }
+        let total = items.len();
+        Ok(MemoryResponse::Memories(
+            MemoriesResponse::builder_v1()
+                .items(items)
+                .total(total)
+                .build()
+                .into(),
+        ))
+    }
+}

--- a/crates/oneiros-engine/src/domains/memory/features/mcp.rs
+++ b/crates/oneiros-engine/src/domains/memory/features/mcp.rs
@@ -83,9 +83,19 @@ mod memory_mcp {
             MemoryRequest::GetMemory(get) => {
                 MemoryService::get(scope, get).await.map_err(Error::from)?
             }
-            MemoryRequest::ListMemories(listing) => MemoryService::list(scope, listing)
-                .await
-                .map_err(Error::from)?,
+            MemoryRequest::ListMemories(listing) => {
+                let ListMemories::V1(details) = listing;
+                if let Some(source) = details.lens.as_deref() {
+                    MemoryLens::new(scope, context.canons())
+                        .list(source, &details.filters)
+                        .await
+                        .map_err(Error::from)?
+                } else {
+                    MemoryService::list(scope, listing)
+                        .await
+                        .map_err(Error::from)?
+                }
+            }
             MemoryRequest::AddMemory(_) => {
                 return Err(ToolError::NotAResource(
                     "Add is a tool, not a resource".to_string(),

--- a/crates/oneiros-engine/src/domains/memory/features/mod.rs
+++ b/crates/oneiros-engine/src/domains/memory/features/mod.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod http;
+mod lens;
 mod mcp;
 mod projections;
 mod skills;
@@ -7,6 +8,7 @@ mod state;
 
 pub(crate) use cli::*;
 pub(crate) use http::*;
+pub(crate) use lens::*;
 pub(crate) use mcp::*;
 pub(crate) use projections::*;
 pub(crate) use skills::*;

--- a/crates/oneiros-engine/src/domains/memory/protocol/errors.rs
+++ b/crates/oneiros-engine/src/domains/memory/protocol/errors.rs
@@ -32,6 +32,9 @@ pub(crate) enum MemoryError {
 
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Lens(#[from] crate::LensError),
 }
 
 resource_op_error!(MemoryError);
@@ -49,6 +52,7 @@ impl IntoResponse for MemoryError {
             MemoryError::Client(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
             MemoryError::Compose(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             MemoryError::Json(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
+            MemoryError::Lens(_) => (StatusCode::UNPROCESSABLE_ENTITY, self.to_string()),
         };
         (status, Json(ErrorResponse::new(message))).into_response()
     }

--- a/crates/oneiros-engine/src/domains/memory/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/memory/protocol/requests.rs
@@ -57,6 +57,12 @@ versioned! {
             #[arg(long)]
             #[builder(into)]
             pub(crate) query: Option<String>,
+            /// Lens expression — replaces ad-hoc filters with the unified
+            /// query language. When set, agent/level/query are ignored
+            /// and the lens drives selection end-to-end.
+            #[arg(long)]
+            #[builder(into)]
+            pub(crate) lens: Option<String>,
             #[command(flatten)]
             #[serde(flatten)]
             #[builder(default)]
@@ -82,6 +88,10 @@ impl ClientRequest for ListMemories {
 
         if let Some(query) = &listing.query {
             params.push(("query", query.clone()));
+        }
+
+        if let Some(lens) = &listing.lens {
+            params.push(("lens", lens.clone()));
         }
 
         params.push(("limit", listing.filters.limit.to_string()));

--- a/crates/oneiros-engine/src/domains/search/lens_reader.rs
+++ b/crates/oneiros-engine/src/domains/search/lens_reader.rs
@@ -11,57 +11,6 @@ impl<'a> SearchIndexReader<'a> {
         Self { db }
     }
 
-    fn read_facet(&self, facet: FacetName, value: &str) -> Result<Selection, ReaderError> {
-        let resolved_value = match facet {
-            FacetName::Agent => self.resolve_agent_name(value)?,
-            _ => value.to_string(),
-        };
-        let column = facet.column();
-        let sql = format!(
-            "select resource_ref, created_at from search_index where {column} = ?1 order by created_at desc"
-        );
-        let mut stmt = self
-            .db
-            .prepare(&sql)
-            .map_err(|e| ReaderError::Internal(e.to_string()))?;
-        let mut selection = Selection::new();
-        let rows = stmt
-            .query_map(params![resolved_value], |row| {
-                let ref_json: String = row.get(0)?;
-                let created_at: String = row.get(1)?;
-                Ok((ref_json, created_at))
-            })
-            .map_err(|e| ReaderError::Internal(e.to_string()))?;
-
-        for row in rows {
-            let (ref_json, created_at) = row.map_err(|e| ReaderError::Internal(e.to_string()))?;
-            let entity_ref: Ref = serde_json::from_str(&ref_json)
-                .map_err(|e| ReaderError::Internal(e.to_string()))?;
-            let timestamp = if created_at.is_empty() {
-                Timestamp::now()
-            } else {
-                Timestamp::parse_str(&created_at)
-                    .map_err(|e| ReaderError::Internal(e.to_string()))?
-            };
-            selection.insert(Hit::Entity(EntityHit {
-                entity_ref,
-                timestamp,
-                relevance: Relevance::Unknown,
-            }));
-        }
-        Ok(selection)
-    }
-
-    fn resolve_agent_name(&self, name: &str) -> Result<String, ReaderError> {
-        let sql = "select id from agents where name = ?1";
-        let result: Result<String, _> = self.db.query_row(sql, params![name], |row| row.get(0));
-        match result {
-            Ok(id) => Ok(id),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(name.to_string()),
-            Err(e) => Err(ReaderError::Internal(e.to_string())),
-        }
-    }
-
     fn read_text(&self, query: &str) -> Result<Selection, ReaderError> {
         let sql = "select resource_ref, created_at, rank from search_index where search_index match ?1 order by rank";
         let mut stmt = self
@@ -98,13 +47,97 @@ impl<'a> SearchIndexReader<'a> {
         }
         Ok(selection)
     }
+
+    fn step_by_column(
+        &self,
+        column: &str,
+        names: Vec<String>,
+        resolve_agent: bool,
+    ) -> Result<Selection, ReaderError> {
+        if names.is_empty() {
+            return Ok(Selection::new());
+        }
+
+        let resolved: Vec<String> = if resolve_agent {
+            let mut out = Vec::with_capacity(names.len());
+            for name in &names {
+                out.push(self.resolve_agent_name(name)?);
+            }
+            out
+        } else {
+            names
+        };
+
+        let placeholders = std::iter::repeat_n("?", resolved.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "select resource_ref, created_at from search_index where {column} in ({placeholders}) order by created_at desc"
+        );
+        let mut stmt = self
+            .db
+            .prepare(&sql)
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+
+        let bind: Vec<&dyn rusqlite::ToSql> =
+            resolved.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+
+        let mut selection = Selection::new();
+        let rows = stmt
+            .query_map(bind.as_slice(), |row| {
+                let ref_json: String = row.get(0)?;
+                let created_at: String = row.get(1)?;
+                Ok((ref_json, created_at))
+            })
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+
+        for row in rows {
+            let (ref_json, created_at) = row.map_err(|e| ReaderError::Internal(e.to_string()))?;
+            let entity_ref: Ref = serde_json::from_str(&ref_json)
+                .map_err(|e| ReaderError::Internal(e.to_string()))?;
+            let timestamp = if created_at.is_empty() {
+                Timestamp::now()
+            } else {
+                Timestamp::parse_str(&created_at)
+                    .map_err(|e| ReaderError::Internal(e.to_string()))?
+            };
+            selection.insert(Hit::Entity(EntityHit {
+                entity_ref,
+                timestamp,
+                relevance: Relevance::Unknown,
+            }));
+        }
+        Ok(selection)
+    }
+
+    fn resolve_agent_name(&self, name: &str) -> Result<String, ReaderError> {
+        let sql = "select id from agents where name = ?1";
+        let result: Result<String, _> = self.db.query_row(sql, params![name], |row| row.get(0));
+        match result {
+            Ok(id) => Ok(id),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(name.to_string()),
+            Err(e) => Err(ReaderError::Internal(e.to_string())),
+        }
+    }
 }
 
 impl Reader for SearchIndexReader<'_> {
     fn read(&self, read: &Read) -> Option<Result<Selection, ReaderError>> {
         match read {
-            Read::SearchFacet { facet, value } => Some(self.read_facet(*facet, value)),
             Read::SearchText(query) => Some(self.read_text(query)),
+            _ => None,
         }
+    }
+
+    fn step(&self, kind: &StepKind, input: &Selection) -> Option<Result<Selection, ReaderError>> {
+        let (column, name_kind, resolve_agent) = match kind {
+            StepKind::SearchByAgent => ("agent_id", NameKind::Agent, true),
+            StepKind::SearchByTexture => ("texture", NameKind::Texture, false),
+            StepKind::SearchByLevel => ("level", NameKind::Level, false),
+            StepKind::SearchByKind => ("kind", NameKind::Kind, false),
+            _ => return None,
+        };
+        let names = input.names_of(name_kind);
+        Some(self.step_by_column(column, names, resolve_agent))
     }
 }

--- a/crates/oneiros-engine/src/domains/trail/lens_reader.rs
+++ b/crates/oneiros-engine/src/domains/trail/lens_reader.rs
@@ -1,0 +1,121 @@
+use rusqlite::params;
+
+use crate::*;
+
+pub(crate) struct TrailLensReader<'a> {
+    db: &'a BookmarkDb,
+}
+
+impl<'a> TrailLensReader<'a> {
+    pub(crate) fn new(db: &'a BookmarkDb) -> Self {
+        Self { db }
+    }
+
+    fn events_for_entity(
+        &self,
+        entity_ref: &Ref,
+    ) -> Result<Vec<(EventId, Timestamp)>, ReaderError> {
+        let ref_token = RefToken::new(entity_ref.clone());
+        let mut stmt = self
+            .db
+            .prepare(
+                "SELECT event_id, created_at
+                 FROM trail
+                 WHERE ref = ?1
+                 ORDER BY created_at DESC",
+            )
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let rows = stmt
+            .query_map(params![ref_token.to_string()], |row| {
+                let event_id: String = row.get(0)?;
+                let created_at: String = row.get(1)?;
+                Ok((event_id, created_at))
+            })
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (event_id_raw, created_at) =
+                row.map_err(|e| ReaderError::Internal(e.to_string()))?;
+            let event_id: EventId = event_id_raw
+                .parse()
+                .map_err(|e: IdParseError| ReaderError::Internal(e.to_string()))?;
+            let timestamp = Timestamp::parse_str(&created_at)
+                .map_err(|e| ReaderError::Internal(e.to_string()))?;
+            out.push((event_id, timestamp));
+        }
+        Ok(out)
+    }
+
+    fn refs_emitted_by(&self, event_id: &EventId) -> Result<Vec<(Ref, Timestamp)>, ReaderError> {
+        let mut stmt = self
+            .db
+            .prepare(
+                "SELECT ref, created_at
+                 FROM trail
+                 WHERE event_id = ?1
+                 ORDER BY created_at DESC",
+            )
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let rows = stmt
+            .query_map(params![event_id.to_string()], |row| {
+                let ref_token: String = row.get(0)?;
+                let created_at: String = row.get(1)?;
+                Ok((ref_token, created_at))
+            })
+            .map_err(|e| ReaderError::Internal(e.to_string()))?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (ref_token_raw, created_at) =
+                row.map_err(|e| ReaderError::Internal(e.to_string()))?;
+            let ref_token: RefToken = ref_token_raw
+                .parse()
+                .map_err(|e: RefError| ReaderError::Internal(e.to_string()))?;
+            let timestamp = Timestamp::parse_str(&created_at)
+                .map_err(|e| ReaderError::Internal(e.to_string()))?;
+            out.push((ref_token.into(), timestamp));
+        }
+        Ok(out)
+    }
+
+    fn step_events_for(&self, input: &Selection) -> Result<Selection, ReaderError> {
+        let mut selection = Selection::new();
+        for entity_ref in input.entity_refs() {
+            for (event_id, timestamp) in self.events_for_entity(&entity_ref)? {
+                selection.insert(Hit::Event(EventHit {
+                    event_id,
+                    timestamp,
+                    relevance: Relevance::Unknown,
+                }));
+            }
+        }
+        Ok(selection)
+    }
+
+    fn step_refs_from(&self, input: &Selection) -> Result<Selection, ReaderError> {
+        let mut selection = Selection::new();
+        for event_id in input.event_ids() {
+            for (entity_ref, timestamp) in self.refs_emitted_by(&event_id)? {
+                selection.insert(Hit::Entity(EntityHit {
+                    entity_ref,
+                    timestamp,
+                    relevance: Relevance::Unknown,
+                }));
+            }
+        }
+        Ok(selection)
+    }
+}
+
+impl Reader for TrailLensReader<'_> {
+    fn read(&self, _read: &Read) -> Option<Result<Selection, ReaderError>> {
+        None
+    }
+
+    fn step(&self, kind: &StepKind, input: &Selection) -> Option<Result<Selection, ReaderError>> {
+        match kind {
+            StepKind::EventsFor => Some(self.step_events_for(input)),
+            StepKind::RefsFrom => Some(self.step_refs_from(input)),
+            _ => None,
+        }
+    }
+}

--- a/crates/oneiros-engine/src/domains/trail/mod.rs
+++ b/crates/oneiros-engine/src/domains/trail/mod.rs
@@ -1,5 +1,6 @@
 mod docs;
 mod features;
+mod lens_reader;
 mod model;
 mod protocol;
 mod repo;
@@ -9,6 +10,7 @@ mod view;
 
 pub(crate) use docs::*;
 pub(crate) use features::*;
+pub(crate) use lens_reader::*;
 pub(crate) use model::*;
 pub(crate) use protocol::*;
 pub(crate) use repo::*;

--- a/crates/oneiros-engine/src/http/state.rs
+++ b/crates/oneiros-engine/src/http/state.rs
@@ -100,7 +100,7 @@ impl ServerState {
     /// `ProjectLog` extractor for legacy CLI/MCP dispatchers.
     #[expect(deprecated)]
     pub(crate) fn project_log(&self, config: Config) -> ProjectLog {
-        ProjectLog::new(config)
+        ProjectLog::new(config, self.canons.clone())
     }
 
     /// Construct a ticket verifier backed by this server's config,

--- a/crates/oneiros-engine/src/lens/aliases.rs
+++ b/crates/oneiros-engine/src/lens/aliases.rs
@@ -1,0 +1,143 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::*;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum AliasError {
+    #[error("alias {name:?} failed to parse: {source}")]
+    Parse {
+        name: String,
+        #[source]
+        source: LensParseError,
+    },
+    #[error("alias cycle detected: {chain}")]
+    Cycle { chain: String },
+}
+
+/// Pre-parses each alias source string at construction time, then expands
+/// matching bare symbols during a walk over a parsed lens. The grammar
+/// stays fixed — aliases are pure sugar.
+pub(crate) struct AliasResolver {
+    parsed: HashMap<String, Lens>,
+}
+
+impl AliasResolver {
+    pub(crate) fn new(aliases: &HashMap<String, String>) -> Result<Self, AliasError> {
+        let mut parsed = HashMap::with_capacity(aliases.len());
+        for (name, source) in aliases {
+            let lens = Lens::parse(source).map_err(|source| AliasError::Parse {
+                name: name.clone(),
+                source,
+            })?;
+            parsed.insert(name.clone(), lens);
+        }
+        Ok(Self { parsed })
+    }
+
+    pub(crate) fn expand(&self, lens: Lens) -> Result<Lens, AliasError> {
+        let mut visiting: HashSet<String> = HashSet::new();
+        self.walk(lens, &mut visiting)
+    }
+
+    fn walk(&self, lens: Lens, visiting: &mut HashSet<String>) -> Result<Lens, AliasError> {
+        match lens {
+            Lens::Symbol(identifier) => {
+                if let Some(body) = self.parsed.get(identifier.as_str()) {
+                    if !visiting.insert(identifier.as_str().to_string()) {
+                        let chain = visiting
+                            .iter()
+                            .cloned()
+                            .chain(std::iter::once(identifier.as_str().to_string()))
+                            .collect::<Vec<_>>()
+                            .join(" → ");
+                        return Err(AliasError::Cycle { chain });
+                    }
+                    let expanded = self.walk(body.clone(), visiting)?;
+                    visiting.remove(identifier.as_str());
+                    Ok(expanded)
+                } else {
+                    Ok(Lens::Symbol(identifier))
+                }
+            }
+            Lens::Predicate(predicate) => {
+                let mut args = Vec::with_capacity(predicate.args.len());
+                for arg in predicate.args {
+                    args.push(self.walk(arg, visiting)?);
+                }
+                Ok(Lens::predicate(predicate.name, args))
+            }
+            Lens::Union(left, right) => Ok(Lens::union(
+                self.walk(*left, visiting)?,
+                self.walk(*right, visiting)?,
+            )),
+            Lens::Intersection(left, right) => Ok(Lens::intersection(
+                self.walk(*left, visiting)?,
+                self.walk(*right, visiting)?,
+            )),
+            Lens::Difference(left, right) => Ok(Lens::difference(
+                self.walk(*left, visiting)?,
+                self.walk(*right, visiting)?,
+            )),
+            literal @ (Lens::Ref(_) | Lens::String(_) | Lens::Integer(_)) => Ok(literal),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn aliases(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn unknown_symbol_passes_through_unchanged() {
+        let resolver = AliasResolver::new(&aliases(&[])).unwrap();
+        let parsed = Lens::parse("texture(observation)").unwrap();
+        let expanded = resolver.expand(parsed.clone()).unwrap();
+        assert_eq!(expanded.to_string(), parsed.to_string());
+    }
+
+    #[test]
+    fn matching_symbol_expands_to_alias_body() {
+        let resolver = AliasResolver::new(&aliases(&[("mine", "agent(gov.process)")])).unwrap();
+        let parsed = Lens::parse("mine").unwrap();
+        let expanded = resolver.expand(parsed).unwrap();
+        assert_eq!(expanded.to_string(), "agent(gov.process)");
+    }
+
+    #[test]
+    fn alias_expands_inside_predicate_arg() {
+        let resolver = AliasResolver::new(&aliases(&[("mine", "agent(gov.process)")])).unwrap();
+        let parsed = Lens::parse("from(mine)").unwrap();
+        let expanded = resolver.expand(parsed).unwrap();
+        assert_eq!(expanded.to_string(), "from(agent(gov.process))");
+    }
+
+    #[test]
+    fn nested_aliases_expand_transitively() {
+        let resolver = AliasResolver::new(&aliases(&[
+            ("a", "agent(gov.process)"),
+            ("b", "a & texture(observation)"),
+        ]))
+        .unwrap();
+        let parsed = Lens::parse("b").unwrap();
+        let expanded = resolver.expand(parsed).unwrap();
+        assert_eq!(
+            expanded.to_string(),
+            "(agent(gov.process) & texture(observation))"
+        );
+    }
+
+    #[test]
+    fn circular_alias_rejects() {
+        let resolver = AliasResolver::new(&aliases(&[("a", "b"), ("b", "a")])).unwrap();
+        let parsed = Lens::parse("a").unwrap();
+        let err = resolver.expand(parsed).expect_err("cycle must reject");
+        assert!(matches!(err, AliasError::Cycle { .. }));
+    }
+}

--- a/crates/oneiros-engine/src/lens/compile.rs
+++ b/crates/oneiros-engine/src/lens/compile.rs
@@ -12,6 +12,12 @@ pub(crate) enum CompileError {
     UncompilablePredicate { name: PredicateName },
 }
 
+#[derive(Clone, Copy)]
+enum WalkContext {
+    Open,
+    Names(NameKind),
+}
+
 impl Compiler {
     pub(crate) fn new(registry: Registry) -> Self {
         Self { registry }
@@ -19,39 +25,60 @@ impl Compiler {
 
     pub(crate) fn compile(&self, ast: &Lens) -> Result<Ir, CompileError> {
         let mut ops = Vec::new();
-        self.walk(ast, &mut ops)?;
+        self.walk(ast, WalkContext::Open, &mut ops)?;
         Ok(Ir::new(ops))
     }
 
-    fn walk(&self, node: &Lens, ops: &mut Vec<Op>) -> Result<SlotId, CompileError> {
+    fn walk(
+        &self,
+        node: &Lens,
+        context: WalkContext,
+        ops: &mut Vec<Op>,
+    ) -> Result<SlotId, CompileError> {
         match node {
             Lens::Predicate(predicate) => self.compile_predicate(predicate, ops),
             Lens::Union(left, right) => {
-                let left_slot = self.walk(left, ops)?;
-                let right_slot = self.walk(right, ops)?;
+                let left_slot = self.walk(left, context, ops)?;
+                let right_slot = self.walk(right, context, ops)?;
                 let slot = SlotId(ops.len());
                 ops.push(Op::Union(left_slot, right_slot));
                 Ok(slot)
             }
             Lens::Intersection(left, right) => {
-                let left_slot = self.walk(left, ops)?;
-                let right_slot = self.walk(right, ops)?;
+                let left_slot = self.walk(left, context, ops)?;
+                let right_slot = self.walk(right, context, ops)?;
                 let slot = SlotId(ops.len());
                 ops.push(Op::Intersect(left_slot, right_slot));
                 Ok(slot)
             }
             Lens::Difference(left, right) => {
-                let left_slot = self.walk(left, ops)?;
-                let right_slot = self.walk(right, ops)?;
+                let left_slot = self.walk(left, context, ops)?;
+                let right_slot = self.walk(right, context, ops)?;
                 let slot = SlotId(ops.len());
                 ops.push(Op::Difference(left_slot, right_slot));
                 Ok(slot)
             }
-            Lens::Symbol(_) | Lens::String(_) | Lens::Ref(_) | Lens::Integer(_) => {
-                Err(CompileError::UncompilablePredicate {
-                    name: PredicateName::new("(literal)"),
-                })
+            Lens::Ref(reference) => {
+                let slot = SlotId(ops.len());
+                ops.push(Op::Const(ConstValue::Ref(reference.clone())));
+                Ok(slot)
             }
+            Lens::Symbol(identifier) => match context {
+                WalkContext::Names(kind) => {
+                    let slot = SlotId(ops.len());
+                    ops.push(Op::Const(ConstValue::Name {
+                        name: identifier.to_string(),
+                        kind,
+                    }));
+                    Ok(slot)
+                }
+                WalkContext::Open => Err(CompileError::UncompilablePredicate {
+                    name: PredicateName::new("(literal)"),
+                }),
+            },
+            Lens::String(_) | Lens::Integer(_) => Err(CompileError::UncompilablePredicate {
+                name: PredicateName::new("(literal)"),
+            }),
         }
     }
 
@@ -65,27 +92,9 @@ impl Compiler {
             .lookup(&predicate.name)
             .ok_or_else(|| CompileError::UnknownPredicate(predicate.name.clone()))?;
 
-        let read = match &spec.executor {
-            ExecutorHint::SearchIndexFacet(facet) => {
-                let value = predicate
-                    .args
-                    .first()
-                    .map(|a| match a {
-                        Lens::Symbol(s) => s.to_string(),
-                        Lens::String(s) => s.to_string(),
-                        other => format!("{other:?}"),
-                    })
-                    .unwrap_or_default();
-                let facet_name = match facet {
-                    SearchFacet::Kind => FacetName::Kind,
-                    SearchFacet::Agent => FacetName::Agent,
-                    SearchFacet::Texture => FacetName::Texture,
-                    SearchFacet::Level => FacetName::Level,
-                };
-                Read::SearchFacet {
-                    facet: facet_name,
-                    value,
-                }
+        match &spec.executor {
+            ExecutorHint::GraphStep(step_kind) => {
+                self.compile_graph_step(predicate, spec, step_kind.clone(), ops)
             }
             ExecutorHint::SearchIndexText => {
                 let text = predicate
@@ -96,12 +105,69 @@ impl Compiler {
                         other => format!("{other:?}"),
                     })
                     .unwrap_or_default();
-                Read::SearchText(text)
+                let slot = SlotId(ops.len());
+                ops.push(Op::Read(Read::SearchText(text)));
+                Ok(slot)
             }
+            ExecutorHint::ChronicleBetween => {
+                let Some(Lens::Ref(from)) = predicate.args.first() else {
+                    return Err(CompileError::UncompilablePredicate {
+                        name: predicate.name.clone(),
+                    });
+                };
+                let Some(Lens::Ref(to)) = predicate.args.get(1) else {
+                    return Err(CompileError::UncompilablePredicate {
+                        name: predicate.name.clone(),
+                    });
+                };
+                let slot = SlotId(ops.len());
+                ops.push(Op::Read(Read::ChronicleBetween {
+                    from: from.clone(),
+                    to: to.clone(),
+                }));
+                Ok(slot)
+            }
+        }
+    }
+
+    fn compile_graph_step(
+        &self,
+        predicate: &Predicate,
+        spec: &PredicateSpec,
+        spec_kind: StepKind,
+        ops: &mut Vec<Op>,
+    ) -> Result<SlotId, CompileError> {
+        let Some(sub_lens) = predicate.args.first() else {
+            return Err(CompileError::UncompilablePredicate {
+                name: predicate.name.clone(),
+            });
+        };
+
+        let sub_context = match spec.arg_types.first() {
+            Some(ArgType::LensOfNames(kind)) => WalkContext::Names(*kind),
+            _ => WalkContext::Open,
+        };
+
+        let input_slot = self.walk(sub_lens, sub_context, ops)?;
+
+        let kind = match spec_kind {
+            StepKind::Within(_) => {
+                let Some(Lens::Integer(n)) = predicate.args.get(1) else {
+                    return Err(CompileError::UncompilablePredicate {
+                        name: predicate.name.clone(),
+                    });
+                };
+                let depth = u32::try_from(n.value().max(0)).unwrap_or(0);
+                StepKind::Within(depth)
+            }
+            other => other,
         };
 
         let slot = SlotId(ops.len());
-        ops.push(Op::Read(read));
+        ops.push(Op::Step {
+            kind,
+            input: input_slot,
+        });
         Ok(slot)
     }
 }
@@ -115,16 +181,23 @@ mod tests {
     }
 
     #[test]
-    fn compiles_single_facet_predicate() {
+    fn compiles_facet_predicate_to_step_over_name_literal() {
         let ast = Lens::predicate("texture", [Lens::symbol("observation")]);
         let ir = compiler().compile(&ast).unwrap();
-        assert_eq!(ir.ops.len(), 1);
+        assert_eq!(ir.ops.len(), 2);
         assert!(matches!(
             &ir.ops[0],
-            Op::Read(Read::SearchFacet {
-                facet: FacetName::Texture,
+            Op::Const(ConstValue::Name {
+                kind: NameKind::Texture,
                 ..
             })
+        ));
+        assert!(matches!(
+            &ir.ops[1],
+            Op::Step {
+                kind: StepKind::SearchByTexture,
+                ..
+            }
         ));
     }
 
@@ -137,27 +210,27 @@ mod tests {
     }
 
     #[test]
-    fn compiles_intersection_of_two_predicates() {
-        let ast = Lens::intersection(
-            Lens::predicate("texture", [Lens::symbol("observation")]),
-            Lens::predicate("agent", [Lens::symbol("governor.process")]),
+    fn compiles_union_of_names_inside_facet_predicate() {
+        let ast = Lens::predicate(
+            "agent",
+            [Lens::union(
+                Lens::symbol("governor.process"),
+                Lens::symbol("thinker.process"),
+            )],
         );
         let ir = compiler().compile(&ast).unwrap();
-        assert_eq!(ir.ops.len(), 3);
-        assert!(matches!(&ir.ops[0], Op::Read(_)));
-        assert!(matches!(&ir.ops[1], Op::Read(_)));
-        assert!(matches!(&ir.ops[2], Op::Intersect(SlotId(0), SlotId(1))));
-    }
-
-    #[test]
-    fn compiles_union() {
-        let ast = Lens::union(
-            Lens::predicate("texture", [Lens::symbol("observation")]),
-            Lens::predicate("texture", [Lens::symbol("reflection")]),
-        );
-        let ir = compiler().compile(&ast).unwrap();
-        assert_eq!(ir.ops.len(), 3);
-        assert!(matches!(&ir.ops[2], Op::Union(SlotId(0), SlotId(1))));
+        // slot 0: Const::Name(governor.process)
+        // slot 1: Const::Name(thinker.process)
+        // slot 2: Union(0, 1)
+        // slot 3: Step{SearchByAgent, input: slot 2}
+        assert_eq!(ir.ops.len(), 4);
+        assert!(matches!(
+            &ir.ops[3],
+            Op::Step {
+                kind: StepKind::SearchByAgent,
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -168,7 +241,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_bare_literal() {
+    fn rejects_bare_literal_at_top_level() {
         let ast = Lens::symbol("bare");
         let err = compiler().compile(&ast).unwrap_err();
         assert!(matches!(err, CompileError::UncompilablePredicate { .. }));

--- a/crates/oneiros-engine/src/lens/execute.rs
+++ b/crates/oneiros-engine/src/lens/execute.rs
@@ -22,7 +22,12 @@ impl<'a> Executor<'a> {
 
         for op in &ir.ops {
             let result = match op {
+                Op::Const(value) => self.eval_const(value)?,
                 Op::Read(read) => self.dispatch(read)?,
+                Op::Step { kind, input } => {
+                    let input_selection = self.resolve(&slots, *input)?.clone();
+                    self.dispatch_step(kind, &input_selection)?
+                }
                 Op::Union(left, right) => {
                     let left = self.resolve(&slots, *left)?;
                     let right = self.resolve(&slots, *right)?;
@@ -46,9 +51,40 @@ impl<'a> Executor<'a> {
         self.resolve(&slots, result_slot).cloned()
     }
 
+    fn eval_const(&self, value: &ConstValue) -> Result<Selection, ExecuteError> {
+        let mut selection = Selection::new();
+        match value {
+            ConstValue::Name { name, kind } => {
+                selection.insert(Hit::Name(NameHit {
+                    name: name.clone(),
+                    kind: *kind,
+                    timestamp: Timestamp::now(),
+                    relevance: Relevance::Unknown,
+                }));
+            }
+            ConstValue::Ref(reference) => {
+                selection.insert(Hit::Entity(EntityHit {
+                    entity_ref: reference.inner().clone(),
+                    timestamp: Timestamp::now(),
+                    relevance: Relevance::Unknown,
+                }));
+            }
+        }
+        Ok(selection)
+    }
+
     fn dispatch(&self, read: &Read) -> Result<Selection, ExecuteError> {
         for reader in self.readers {
             if let Some(result) = reader.read(read) {
+                return Ok(result?);
+            }
+        }
+        Ok(Selection::new())
+    }
+
+    fn dispatch_step(&self, kind: &StepKind, input: &Selection) -> Result<Selection, ExecuteError> {
+        for reader in self.readers {
+            if let Some(result) = reader.step(kind, input) {
                 return Ok(result?);
             }
         }

--- a/crates/oneiros-engine/src/lens/explain.rs
+++ b/crates/oneiros-engine/src/lens/explain.rs
@@ -15,11 +15,20 @@ impl core::fmt::Display for Explanation {
         for (i, op) in self.ir.ops.iter().enumerate() {
             let slot = SlotId(i);
             match op {
-                Op::Read(Read::SearchFacet { facet, value }) => {
-                    writeln!(f, "{slot}: read search_facet({facet:?}, {value:?})")?;
+                Op::Const(ConstValue::Name { name, kind }) => {
+                    writeln!(f, "{slot}: const name({}: {name:?})", kind.describe())?;
+                }
+                Op::Const(ConstValue::Ref(reference)) => {
+                    writeln!(f, "{slot}: const ref({reference})")?;
                 }
                 Op::Read(Read::SearchText(text)) => {
                     writeln!(f, "{slot}: read search_text({text:?})")?;
+                }
+                Op::Read(Read::ChronicleBetween { from, to }) => {
+                    writeln!(f, "{slot}: read between({from}, {to})")?;
+                }
+                Op::Step { kind, input } => {
+                    writeln!(f, "{slot}: step {kind:?}({input})")?;
                 }
                 Op::Union(left, right) => {
                     writeln!(f, "{slot}: union({left}, {right})")?;
@@ -41,33 +50,46 @@ mod tests {
     use super::*;
 
     #[test]
-    fn explains_single_read() {
-        let ir = Ir::new(vec![Op::Read(Read::SearchFacet {
-            facet: FacetName::Texture,
-            value: "observation".into(),
-        })]);
+    fn explains_name_literal_and_step() {
+        let ir = Ir::new(vec![
+            Op::Const(ConstValue::Name {
+                name: "observation".into(),
+                kind: NameKind::Texture,
+            }),
+            Op::Step {
+                kind: StepKind::SearchByTexture,
+                input: SlotId(0),
+            },
+        ]);
         let explanation = Explanation::new(ir);
         let output = explanation.to_string();
-        assert!(output.contains("$0: read search_facet(Texture, \"observation\")"));
+        assert!(output.contains("$0: const name(texture: \"observation\")"));
+        assert!(output.contains("$1: step SearchByTexture($0)"));
     }
 
     #[test]
     fn explains_intersection_pipeline() {
         let ir = Ir::new(vec![
-            Op::Read(Read::SearchFacet {
-                facet: FacetName::Texture,
-                value: "observation".into(),
+            Op::Const(ConstValue::Name {
+                name: "observation".into(),
+                kind: NameKind::Texture,
             }),
-            Op::Read(Read::SearchFacet {
-                facet: FacetName::Agent,
-                value: "governor.process".into(),
+            Op::Step {
+                kind: StepKind::SearchByTexture,
+                input: SlotId(0),
+            },
+            Op::Const(ConstValue::Name {
+                name: "governor.process".into(),
+                kind: NameKind::Agent,
             }),
-            Op::Intersect(SlotId(0), SlotId(1)),
+            Op::Step {
+                kind: StepKind::SearchByAgent,
+                input: SlotId(2),
+            },
+            Op::Intersect(SlotId(1), SlotId(3)),
         ]);
         let explanation = Explanation::new(ir);
         let output = explanation.to_string();
-        assert!(output.contains("$0: read search_facet(Texture, \"observation\")"));
-        assert!(output.contains("$1: read search_facet(Agent, \"governor.process\")"));
-        assert!(output.contains("$2: intersect($0, $1)"));
+        assert!(output.contains("intersect($1, $3)"));
     }
 }

--- a/crates/oneiros-engine/src/lens/ir.rs
+++ b/crates/oneiros-engine/src/lens/ir.rs
@@ -26,16 +26,47 @@ impl core::fmt::Display for SlotId {
 
 #[derive(Debug, Clone)]
 pub(crate) enum Op {
+    /// A compile-time constant — resolved without consulting any reader.
+    Const(ConstValue),
+    /// A substrate query dispatched to [`Reader::read`].
     Read(Read),
+    /// A transformation over a prior slot dispatched to [`Reader::step`].
+    Step {
+        kind: StepKind,
+        input: SlotId,
+    },
     Union(SlotId, SlotId),
     Intersect(SlotId, SlotId),
     Difference(SlotId, SlotId),
 }
 
+/// Values fixed at compile time that the executor populates directly.
+#[derive(Debug, Clone)]
+pub(crate) enum ConstValue {
+    Name { name: String, kind: NameKind },
+    Ref(RefToken),
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum Read {
-    SearchFacet { facet: FacetName, value: String },
     SearchText(String),
+    ChronicleBetween { from: RefToken, to: RefToken },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StepKind {
+    ConnectedFrom,
+    ConnectedTo,
+    Descendants,
+    Ancestors,
+    Within(u32),
+    Component,
+    EventsFor,
+    RefsFrom,
+    SearchByAgent,
+    SearchByTexture,
+    SearchByLevel,
+    SearchByKind,
 }
 
 #[cfg(test)]
@@ -45,13 +76,13 @@ mod tests {
     #[test]
     fn result_slot_points_to_last_op() {
         let ir = Ir::new(vec![
-            Op::Read(Read::SearchFacet {
-                facet: FacetName::Texture,
-                value: "observation".into(),
+            Op::Const(ConstValue::Name {
+                name: "observation".into(),
+                kind: NameKind::Texture,
             }),
-            Op::Read(Read::SearchFacet {
-                facet: FacetName::Agent,
-                value: "governor.process".into(),
+            Op::Const(ConstValue::Name {
+                name: "governor.process".into(),
+                kind: NameKind::Agent,
             }),
             Op::Intersect(SlotId(0), SlotId(1)),
         ]);

--- a/crates/oneiros-engine/src/lens/mod.rs
+++ b/crates/oneiros-engine/src/lens/mod.rs
@@ -1,3 +1,4 @@
+mod aliases;
 mod ast;
 mod compile;
 mod display;
@@ -5,18 +6,21 @@ mod errors;
 mod execute;
 mod explain;
 mod ir;
+mod name_resolver;
 mod parser;
 mod reader;
 mod registry;
 mod selection;
 mod validator;
 
+pub(crate) use aliases::*;
 pub(crate) use ast::*;
 pub(crate) use compile::*;
 pub(crate) use errors::*;
 pub(crate) use execute::*;
 pub(crate) use explain::*;
 pub(crate) use ir::*;
+pub(crate) use name_resolver::*;
 pub(crate) use reader::*;
 pub(crate) use registry::*;
 pub(crate) use selection::*;

--- a/crates/oneiros-engine/src/lens/name_resolver.rs
+++ b/crates/oneiros-engine/src/lens/name_resolver.rs
@@ -1,0 +1,70 @@
+use std::collections::HashSet;
+
+use crate::*;
+
+/// Project-backed [`NameRegistry`] — fetches the full set of registered
+/// names from each vocabulary table at construction time and answers
+/// resolution queries synchronously against the resulting in-memory sets.
+///
+/// One round-trip per kind. The vocabulary domains are small
+/// (typically <20 entries each) and the snapshot is per-call, so the
+/// fetch cost is negligible and the resolver stays consistent for the
+/// duration of a single resolution pass.
+pub(crate) struct NameResolver {
+    agents: HashSet<String>,
+    textures: HashSet<String>,
+    levels: HashSet<String>,
+}
+
+impl NameResolver {
+    pub(crate) async fn fetch(scope: &Scope<AtBookmark>) -> Result<Self, EventError> {
+        let db = BookmarkDb::open(scope).await?;
+        Ok(Self {
+            agents: Self::names_from(&db, "agents")?,
+            textures: Self::names_from(&db, "textures")?,
+            levels: Self::names_from(&db, "levels")?,
+        })
+    }
+
+    fn names_from(db: &BookmarkDb, table: &str) -> Result<HashSet<String>, rusqlite::Error> {
+        let sql = format!("select name from {table}");
+        let mut stmt = db.prepare(&sql)?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        rows.collect()
+    }
+}
+
+impl NameRegistry for NameResolver {
+    fn knows(&self, kind: NameKind, name: &Identifier) -> bool {
+        let bucket = match kind {
+            NameKind::Agent => &self.agents,
+            NameKind::Texture => &self.textures,
+            NameKind::Level => &self.levels,
+            NameKind::Kind => {
+                return matches!(
+                    name.as_str(),
+                    "cognition"
+                        | "memory"
+                        | "experience"
+                        | "agent"
+                        | "connection"
+                        | "bookmark"
+                        | "tenant"
+                        | "actor"
+                        | "ticket"
+                        | "follow"
+                        | "peer"
+                        | "project"
+                        | "storage"
+                        | "texture"
+                        | "level"
+                        | "sensation"
+                        | "nature"
+                        | "persona"
+                        | "urge"
+                );
+            }
+        };
+        bucket.contains(name.as_str())
+    }
+}

--- a/crates/oneiros-engine/src/lens/reader.rs
+++ b/crates/oneiros-engine/src/lens/reader.rs
@@ -2,6 +2,10 @@ use crate::*;
 
 pub(crate) trait Reader {
     fn read(&self, read: &Read) -> Option<Result<Selection, ReaderError>>;
+
+    fn step(&self, _kind: &StepKind, _input: &Selection) -> Option<Result<Selection, ReaderError>> {
+        None
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/oneiros-engine/src/lens/registry.rs
+++ b/crates/oneiros-engine/src/lens/registry.rs
@@ -1,19 +1,28 @@
 use std::collections::HashMap;
 
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use crate::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ArgType {
-    Symbol,
-    SymbolOf(NameKind),
     String,
+    Ref,
+    Integer,
+    Lens,
+    /// A lens producing a set of names of the given kind. Bare symbols
+    /// in this position compile to singleton name-lenses with this kind.
+    LensOfNames(NameKind),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
 pub(crate) enum NameKind {
     Agent,
     Texture,
     Level,
+    Kind,
 }
 
 impl NameKind {
@@ -22,6 +31,7 @@ impl NameKind {
             NameKind::Agent => "agent",
             NameKind::Texture => "texture",
             NameKind::Level => "level",
+            NameKind::Kind => "kind",
         }
     }
 }
@@ -33,12 +43,14 @@ pub(crate) trait NameRegistry {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ResultType {
     Entities,
+    Events,
 }
 
 impl ResultType {
     pub(crate) fn describe(self) -> &'static str {
         match self {
             ResultType::Entities => "entities",
+            ResultType::Events => "events",
         }
     }
 }
@@ -51,15 +63,8 @@ pub(crate) enum SpecResultType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ExecutorHint {
     SearchIndexText,
-    SearchIndexFacet(SearchFacet),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SearchFacet {
-    Kind,
-    Agent,
-    Texture,
-    Level,
+    GraphStep(StepKind),
+    ChronicleBetween,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -107,31 +112,32 @@ impl Registry {
 
     pub(crate) fn seed_default() -> Self {
         let entities = SpecResultType::Of(ResultType::Entities);
+        let events = SpecResultType::Of(ResultType::Events);
 
         Self::new()
             .with(PredicateSpec::new(
                 "agent",
-                [ArgType::SymbolOf(NameKind::Agent)],
+                [ArgType::LensOfNames(NameKind::Agent)],
                 entities,
-                ExecutorHint::SearchIndexFacet(SearchFacet::Agent),
+                ExecutorHint::GraphStep(StepKind::SearchByAgent),
             ))
             .with(PredicateSpec::new(
                 "texture",
-                [ArgType::SymbolOf(NameKind::Texture)],
+                [ArgType::LensOfNames(NameKind::Texture)],
                 entities,
-                ExecutorHint::SearchIndexFacet(SearchFacet::Texture),
+                ExecutorHint::GraphStep(StepKind::SearchByTexture),
             ))
             .with(PredicateSpec::new(
                 "level",
-                [ArgType::SymbolOf(NameKind::Level)],
+                [ArgType::LensOfNames(NameKind::Level)],
                 entities,
-                ExecutorHint::SearchIndexFacet(SearchFacet::Level),
+                ExecutorHint::GraphStep(StepKind::SearchByLevel),
             ))
             .with(PredicateSpec::new(
                 "kind",
-                [ArgType::Symbol],
+                [ArgType::LensOfNames(NameKind::Kind)],
                 entities,
-                ExecutorHint::SearchIndexFacet(SearchFacet::Kind),
+                ExecutorHint::GraphStep(StepKind::SearchByKind),
             ))
             .with(PredicateSpec::new(
                 "search",
@@ -139,26 +145,104 @@ impl Registry {
                 entities,
                 ExecutorHint::SearchIndexText,
             ))
+            .with(PredicateSpec::new(
+                "events_for",
+                [ArgType::Lens],
+                events,
+                ExecutorHint::GraphStep(StepKind::EventsFor),
+            ))
+            .with(PredicateSpec::new(
+                "refs_from",
+                [ArgType::Lens],
+                entities,
+                ExecutorHint::GraphStep(StepKind::RefsFrom),
+            ))
+            .with(PredicateSpec::new(
+                "from",
+                [ArgType::Lens],
+                entities,
+                ExecutorHint::GraphStep(StepKind::ConnectedFrom),
+            ))
+            .with(PredicateSpec::new(
+                "to",
+                [ArgType::Lens],
+                entities,
+                ExecutorHint::GraphStep(StepKind::ConnectedTo),
+            ))
+            .with(PredicateSpec::new(
+                "descendants",
+                [ArgType::Lens],
+                entities,
+                ExecutorHint::GraphStep(StepKind::Descendants),
+            ))
+            .with(PredicateSpec::new(
+                "ancestors",
+                [ArgType::Lens],
+                entities,
+                ExecutorHint::GraphStep(StepKind::Ancestors),
+            ))
+            .with(PredicateSpec::new(
+                "within",
+                [ArgType::Lens, ArgType::Integer],
+                entities,
+                ExecutorHint::GraphStep(StepKind::Within(0)),
+            ))
+            .with(PredicateSpec::new(
+                "component",
+                [ArgType::Lens],
+                entities,
+                ExecutorHint::GraphStep(StepKind::Component),
+            ))
+            .with(PredicateSpec::new(
+                "between",
+                [ArgType::Ref, ArgType::Ref],
+                events,
+                ExecutorHint::ChronicleBetween,
+            ))
     }
 }
 
 impl ArgType {
     pub(crate) fn matches(&self, lens: &Lens) -> bool {
-        matches!(
-            (self, lens),
-            (Self::Symbol, Lens::Symbol(_))
-                | (Self::SymbolOf(_), Lens::Symbol(_))
-                | (Self::String, Lens::String(_))
-        )
+        match (self, lens) {
+            (Self::String, Lens::String(_)) => true,
+            (Self::Ref, Lens::Ref(_)) => true,
+            (Self::Integer, Lens::Integer(_)) => true,
+            (Self::Lens, lens) => matches!(
+                lens,
+                Lens::Predicate(_)
+                    | Lens::Union(_, _)
+                    | Lens::Intersection(_, _)
+                    | Lens::Difference(_, _)
+                    | Lens::Ref(_)
+            ),
+            (Self::LensOfNames(_), lens) => Self::lens_of_names_matches(lens),
+            _ => false,
+        }
+    }
+
+    fn lens_of_names_matches(lens: &Lens) -> bool {
+        match lens {
+            Lens::Symbol(_) => true,
+            Lens::Union(left, right)
+            | Lens::Intersection(left, right)
+            | Lens::Difference(left, right) => {
+                Self::lens_of_names_matches(left) && Self::lens_of_names_matches(right)
+            }
+            _ => false,
+        }
     }
 
     pub(crate) fn describe(&self) -> &'static str {
         match self {
-            Self::Symbol => "symbol",
-            Self::SymbolOf(NameKind::Agent) => "agent symbol",
-            Self::SymbolOf(NameKind::Texture) => "texture symbol",
-            Self::SymbolOf(NameKind::Level) => "level symbol",
             Self::String => "string",
+            Self::Ref => "ref",
+            Self::Integer => "integer",
+            Self::Lens => "lens expression",
+            Self::LensOfNames(NameKind::Agent) => "lens of agent names",
+            Self::LensOfNames(NameKind::Texture) => "lens of texture names",
+            Self::LensOfNames(NameKind::Level) => "lens of level names",
+            Self::LensOfNames(NameKind::Kind) => "lens of resource kinds",
         }
     }
 }

--- a/crates/oneiros-engine/src/lens/selection.rs
+++ b/crates/oneiros-engine/src/lens/selection.rs
@@ -10,6 +10,7 @@ use crate::*;
 pub(crate) enum Hit {
     Event(EventHit),
     Entity(EntityHit),
+    Name(NameHit),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -27,6 +28,14 @@ pub(crate) struct EntityHit {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub(crate) struct NameHit {
+    pub(crate) name: String,
+    pub(crate) kind: NameKind,
+    pub(crate) timestamp: Timestamp,
+    pub(crate) relevance: Relevance,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub(crate) enum Relevance {
     Known { score: f64 },
@@ -38,6 +47,10 @@ impl Hit {
         match self {
             Hit::Event(e) => HitIdentity::Event(e.event_id),
             Hit::Entity(e) => HitIdentity::Entity(e.entity_ref.clone()),
+            Hit::Name(n) => HitIdentity::Name {
+                name: n.name.clone(),
+                kind: n.kind,
+            },
         }
     }
 
@@ -45,6 +58,7 @@ impl Hit {
         match self {
             Hit::Event(e) => e.timestamp,
             Hit::Entity(e) => e.timestamp,
+            Hit::Name(n) => n.timestamp,
         }
     }
 
@@ -52,6 +66,7 @@ impl Hit {
         match self {
             Hit::Event(e) => &e.relevance,
             Hit::Entity(e) => &e.relevance,
+            Hit::Name(n) => &n.relevance,
         }
     }
 
@@ -69,6 +84,12 @@ impl Hit {
                 timestamp: earlier_timestamp,
                 relevance: merged_relevance,
             }),
+            Hit::Name(n) => Hit::Name(NameHit {
+                name: n.name.clone(),
+                kind: n.kind,
+                timestamp: earlier_timestamp,
+                relevance: merged_relevance,
+            }),
         }
     }
 }
@@ -77,6 +98,7 @@ impl Hit {
 pub(crate) enum HitIdentity {
     Event(EventId),
     Entity(Ref),
+    Name { name: String, kind: NameKind },
 }
 
 impl Relevance {
@@ -159,6 +181,64 @@ impl Selection {
         let mut hits: Vec<Hit> = self.entries.into_values().collect();
         hits.sort_by_key(|h| std::cmp::Reverse(h.timestamp()));
         hits
+    }
+
+    /// Returns a new [`Selection`] containing only the hits that satisfy
+    /// the predicate. Order is not preserved — selections are sets.
+    #[allow(dead_code)]
+    pub(crate) fn filter(mut self, predicate: impl Fn(&Hit) -> bool) -> Self {
+        self.entries.retain(|_, hit| predicate(hit));
+        self
+    }
+
+    /// Sorts hits by timestamp descending, skips `offset` entries, and
+    /// returns at most `limit` hits. The result is a plain [`Vec`] —
+    /// pagination is a terminal operation.
+    pub(crate) fn paginate(self, offset: usize, limit: usize) -> Vec<Hit> {
+        self.sorted_by_timestamp_desc()
+            .into_iter()
+            .skip(offset)
+            .take(limit)
+            .collect()
+    }
+
+    /// Collects every [`Ref`] from entity hits in this selection.
+    pub(crate) fn entity_refs(&self) -> Vec<Ref> {
+        let mut refs = Vec::new();
+        for hit in self.entries.values() {
+            if let Hit::Entity(EntityHit { entity_ref, .. }) = hit {
+                refs.push(entity_ref.clone());
+            }
+        }
+        refs
+    }
+
+    /// Collects every [`EventId`] from event hits in this selection.
+    pub(crate) fn event_ids(&self) -> Vec<EventId> {
+        let mut ids = Vec::new();
+        for hit in self.entries.values() {
+            if let Hit::Event(EventHit { event_id, .. }) = hit {
+                ids.push(*event_id);
+            }
+        }
+        ids
+    }
+
+    /// Collects every name from [`NameHit`]s of the given kind.
+    pub(crate) fn names_of(&self, kind: NameKind) -> Vec<String> {
+        let mut names = Vec::new();
+        for hit in self.entries.values() {
+            if let Hit::Name(NameHit {
+                name,
+                kind: hit_kind,
+                ..
+            }) = hit
+                && *hit_kind == kind
+            {
+                names.push(name.clone());
+            }
+        }
+        names
     }
 }
 
@@ -312,5 +392,49 @@ mod tests {
         assert_eq!(result.len(), 1);
         let hit = result.into_iter().next().unwrap();
         assert_eq!(hit.relevance().score(), Some(5.0));
+    }
+
+    #[test]
+    fn filter_retains_only_matching_hits() {
+        let a = entity_hit("a", Some(1.0));
+        let b = entity_hit("b", Some(2.0));
+        let sel = selection_of(vec![a.clone(), b.clone()]);
+        // Filter keeps only hits from entity_hit with score > 1.0.
+        // We use a discriminator that works: only "b" has score 2.0.
+        let filtered = sel.filter(|h| h.relevance().score() == Some(2.0));
+        assert_eq!(filtered.len(), 1);
+    }
+
+    #[test]
+    fn filter_can_produce_empty_selection() {
+        let a = entity_hit("a", None);
+        let sel = selection_of(vec![a]);
+        let filtered = sel.filter(|_| false);
+        assert_eq!(filtered.len(), 0);
+    }
+
+    #[test]
+    fn paginate_respects_offset_and_limit() {
+        let a = entity_hit("a", Some(1.0));
+        let b = entity_hit("b", Some(2.0));
+        let c = entity_hit("c", Some(3.0));
+        let sel = selection_of(vec![a, b, c]);
+        let page = sel.paginate(1, 1);
+        assert_eq!(page.len(), 1);
+    }
+
+    #[test]
+    fn paginate_empty_selection_returns_empty() {
+        let sel = Selection::new();
+        let page = sel.paginate(0, 10);
+        assert!(page.is_empty());
+    }
+
+    #[test]
+    fn paginate_offset_past_end_returns_empty() {
+        let a = entity_hit("a", None);
+        let sel = selection_of(vec![a]);
+        let page = sel.paginate(10, 10);
+        assert!(page.is_empty());
     }
 }

--- a/crates/oneiros-engine/src/lens/validator.rs
+++ b/crates/oneiros-engine/src/lens/validator.rs
@@ -113,16 +113,11 @@ impl Predicate {
             return Ok(());
         };
         for (arg_type, arg_lens) in spec.arg_types.iter().zip(&self.args) {
-            match (arg_type, arg_lens) {
-                (ArgType::SymbolOf(kind), Lens::Symbol(identifier)) => {
-                    if !names.knows(*kind, identifier) {
-                        return Err(LensValidationError::UnknownSymbol {
-                            kind: kind.describe(),
-                            name: identifier.clone(),
-                        });
-                    }
+            match arg_type {
+                ArgType::LensOfNames(kind) => {
+                    check_names_in_name_lens(*kind, arg_lens, names)?;
                 }
-                (_, nested) => nested.check_names(registry, names)?,
+                _ => arg_lens.check_names(registry, names)?,
             }
         }
         Ok(())
@@ -132,6 +127,32 @@ impl Predicate {
         let spec = registry.lookup(&self.name)?;
         let SpecResultType::Of(result_type) = spec.result_type;
         Some(result_type)
+    }
+}
+
+fn check_names_in_name_lens(
+    kind: NameKind,
+    lens: &Lens,
+    names: &dyn NameRegistry,
+) -> Result<(), LensValidationError> {
+    match lens {
+        Lens::Symbol(identifier) => {
+            if !names.knows(kind, identifier) {
+                Err(LensValidationError::UnknownSymbol {
+                    kind: kind.describe(),
+                    name: identifier.clone(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+        Lens::Union(left, right)
+        | Lens::Intersection(left, right)
+        | Lens::Difference(left, right) => {
+            check_names_in_name_lens(kind, left, names)?;
+            check_names_in_name_lens(kind, right, names)
+        }
+        _ => Ok(()),
     }
 }
 
@@ -286,6 +307,10 @@ mod tests {
                 NameKind::Agent => self.agents.iter().any(|n| n == name.as_str()),
                 NameKind::Texture => self.textures.iter().any(|n| n == name.as_str()),
                 NameKind::Level => self.levels.iter().any(|n| n == name.as_str()),
+                NameKind::Kind => matches!(
+                    name.as_str(),
+                    "cognition" | "memory" | "experience" | "agent" | "connection" | "bookmark"
+                ),
             }
         }
     }
@@ -341,10 +366,10 @@ mod tests {
     }
 
     #[test]
-    fn check_names_ignores_untyped_symbol_positions() {
-        let lens = Lens::predicate("kind", [Lens::symbol("whatever_goes_here")]);
+    fn check_names_accepts_known_resource_kind() {
+        let lens = Lens::predicate("kind", [Lens::symbol("cognition")]);
         lens.check_names(&registry(), &TestNames::new())
-            .expect("valid — kind takes untyped Symbol, no name check");
+            .expect("valid — cognition is a known resource kind");
     }
 
     #[test]

--- a/crates/oneiros-engine/src/logs/project.rs
+++ b/crates/oneiros-engine/src/logs/project.rs
@@ -22,20 +22,29 @@ pub(crate) struct ProjectLog {
     pub(crate) config: Config,
     /// Lazily-composed Scope, cached for the context's lifetime.
     scope: Arc<std::sync::OnceLock<Scope<AtBookmark>>>,
+    /// Bookmark chronicle registry — shared from `ServerState`. Required
+    /// for lens queries that route through chronicle-aware readers.
+    canons: CanonIndex,
 }
 
 #[expect(deprecated)]
 impl ProjectLog {
-    pub(crate) fn new(config: Config) -> Self {
+    pub(crate) fn new(config: Config, canons: CanonIndex) -> Self {
         Self {
             config,
             scope: Arc::new(std::sync::OnceLock::new()),
+            canons,
         }
     }
 
     /// The project name for this project.
     pub(crate) fn project_name(&self) -> &ProjectName {
         &self.config.project
+    }
+
+    /// The bookmark chronicle registry — needed by lens queries.
+    pub(crate) fn canons(&self) -> &CanonIndex {
+        &self.canons
     }
 
     /// Compose a bookmark-tier Scope from this context's config

--- a/crates/oneiros-engine/src/tests/workflows/lens.rs
+++ b/crates/oneiros-engine/src/tests/workflows/lens.rs
@@ -278,3 +278,586 @@ async fn lens_query_results_sort_by_relevance_when_requested()
 
     Ok(())
 }
+
+#[tokio::test]
+async fn lens_query_events_for_returns_events_that_touched_entity()
+-> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_host()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let client = app.client();
+
+    let agent = match client
+        .agent()
+        .create(
+            &CreateAgent::builder_v1()
+                .name(AgentName::new("governor.process"))
+                .persona(PersonaName::new("process"))
+                .build()
+                .into(),
+        )
+        .await?
+    {
+        AgentResponse::AgentCreated(AgentCreatedResponse::V1(r)) => r.agent,
+        other => panic!("expected AgentCreated, got {other:?}"),
+    };
+
+    let agent_ref = RefToken::new(Ref::agent(agent.id));
+
+    let rendered = app
+        .command(&format!(r#"lens query "events_for({agent_ref})""#))
+        .await?;
+    let hits = extract_query_hits(&rendered);
+
+    assert!(!hits.is_empty(), "agent_created event should be on trail");
+    for hit in hits {
+        assert!(
+            matches!(hit, Hit::Event(_)),
+            "events_for should yield event hits, got {hit:?}"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn lens_query_refs_from_round_trips_through_events_for()
+-> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_host()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let client = app.client();
+
+    let agent = match client
+        .agent()
+        .create(
+            &CreateAgent::builder_v1()
+                .name(AgentName::new("governor.process"))
+                .persona(PersonaName::new("process"))
+                .build()
+                .into(),
+        )
+        .await?
+    {
+        AgentResponse::AgentCreated(AgentCreatedResponse::V1(r)) => r.agent,
+        other => panic!("expected AgentCreated, got {other:?}"),
+    };
+
+    let agent_ref = RefToken::new(Ref::agent(agent.id));
+
+    let rendered = app
+        .command(&format!(
+            r#"lens query "refs_from(events_for({agent_ref}))""#
+        ))
+        .await?;
+    let hits = extract_query_hits(&rendered);
+
+    let entity_refs: Vec<RefToken> = hits
+        .iter()
+        .filter_map(|hit| match hit {
+            Hit::Entity(EntityHit { entity_ref, .. }) => Some(RefToken::new(entity_ref.clone())),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        entity_refs.contains(&agent_ref),
+        "round-trip should land on the original agent, got {entity_refs:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn lens_query_facet_predicate_accepts_union_of_names()
+-> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_host()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    app.command(r#"agent create alpha process --description "first""#)
+        .await?;
+    app.command(r#"agent create beta process --description "second""#)
+        .await?;
+
+    app.command(r#"cognition add alpha.process observation "A1""#)
+        .await?;
+    app.command(r#"cognition add beta.process observation "B1""#)
+        .await?;
+    app.command(r#"cognition add beta.process reflection "B2""#)
+        .await?;
+
+    let alone_alpha =
+        extract_query_hits(&app.command(r#"lens query "agent(alpha.process)""#).await?).len();
+    let alone_beta =
+        extract_query_hits(&app.command(r#"lens query "agent(beta.process)""#).await?).len();
+    let union = extract_query_hits(
+        &app.command(r#"lens query "agent(alpha.process | beta.process)""#)
+            .await?,
+    )
+    .len();
+
+    assert_eq!(
+        union,
+        alone_alpha + alone_beta,
+        "set-of-names union should equal sum of singletons when sets are disjoint"
+    );
+    assert!(
+        union >= 3,
+        "should pick up at least the three cognitions added by the test"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn lens_query_facet_predicate_intersection_of_names_is_empty()
+-> Result<(), Box<dyn core::error::Error>> {
+    let app = seeded_app().await?;
+
+    // No cognition has both texture=observation AND texture=reflection on the same row,
+    // so the intersection of two name-singletons is empty (the columns are scalar).
+    let rendered = app
+        .command(r#"lens query "texture(observation & reflection)""#)
+        .await?;
+    let hits = extract_query_hits(&rendered);
+
+    assert_eq!(hits.len(), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn lens_query_events_for_accepts_inner_lens() -> Result<(), Box<dyn core::error::Error>> {
+    let app = seeded_app().await?;
+
+    let rendered = app
+        .command(r#"lens query "events_for(agent(gov.process))""#)
+        .await?;
+    let hits = extract_query_hits(&rendered);
+
+    assert!(
+        !hits.is_empty(),
+        "agent's entities have events on the trail"
+    );
+    for hit in hits {
+        assert!(
+            matches!(hit, Hit::Event(_)),
+            "events_for(<entity-lens>) yields event hits, got {hit:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// Builds a 4-cognition chain `a → b → c → d` joined by `caused` connections.
+/// Returns the agent ref and the four cognition refs.
+async fn seeded_chain() -> Result<(TestApp, RefToken, [RefToken; 4]), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_host()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    app.command(r#"nature set caused --description "A produced B""#)
+        .await?;
+    app.command(r#"agent create thinker process --description "T""#)
+        .await?;
+
+    let mut refs: Vec<RefToken> = Vec::with_capacity(4);
+    for (idx, label) in ["a", "b", "c", "d"].iter().enumerate() {
+        let rendered = app
+            .command(&format!(
+                r#"cognition add thinker.process observation "node {label}""#
+            ))
+            .await?;
+        let id = match rendered.response() {
+            Responses::Cognition(CognitionResponse::CognitionAdded(
+                CognitionAddedResponse::V1(added),
+            )) => added.cognition.id,
+            other => panic!("expected CognitionAdded for {label}, got {other:#?}"),
+        };
+        let _ = idx;
+        refs.push(RefToken::new(Ref::cognition(id)));
+    }
+
+    for window in refs.windows(2) {
+        let from_ref = &window[0];
+        let to_ref = &window[1];
+        app.command(&format!("connection create caused {from_ref} {to_ref}"))
+            .await?;
+    }
+
+    let agent_ref = RefToken::new(Ref::agent(AgentId::new()));
+    let four: [RefToken; 4] = [
+        refs[0].clone(),
+        refs[1].clone(),
+        refs[2].clone(),
+        refs[3].clone(),
+    ];
+    Ok((app, agent_ref, four))
+}
+
+fn extract_refs(hits: &[Hit]) -> Vec<RefToken> {
+    hits.iter()
+        .filter_map(|hit| match hit {
+            Hit::Entity(EntityHit { entity_ref, .. }) => Some(RefToken::new(entity_ref.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn lens_query_from_returns_direct_successors() -> Result<(), Box<dyn core::error::Error>> {
+    let (app, _agent, [a, b, _c, _d]) = seeded_chain().await?;
+
+    let rendered = app.command(&format!(r#"lens query "from({a})""#)).await?;
+    let refs = extract_refs(extract_query_hits(&rendered));
+
+    assert_eq!(refs, vec![b], "from(a) should yield {{b}}");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn lens_query_to_returns_direct_predecessors() -> Result<(), Box<dyn core::error::Error>> {
+    let (app, _agent, [_a, _b, c, d]) = seeded_chain().await?;
+
+    let rendered = app.command(&format!(r#"lens query "to({d})""#)).await?;
+    let refs = extract_refs(extract_query_hits(&rendered));
+
+    assert_eq!(refs, vec![c], "to(d) should yield {{c}}");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn lens_query_descendants_returns_transitive_successors()
+-> Result<(), Box<dyn core::error::Error>> {
+    let (app, _agent, [a, b, c, d]) = seeded_chain().await?;
+
+    let rendered = app
+        .command(&format!(r#"lens query "descendants({a})""#))
+        .await?;
+    let mut refs = extract_refs(extract_query_hits(&rendered));
+    refs.sort_by_key(|r| r.to_string());
+    let mut expected = vec![b, c, d];
+    expected.sort_by_key(|r| r.to_string());
+
+    assert_eq!(refs, expected, "descendants(a) should yield {{b, c, d}}");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn lens_query_ancestors_returns_transitive_predecessors()
+-> Result<(), Box<dyn core::error::Error>> {
+    let (app, _agent, [a, b, c, d]) = seeded_chain().await?;
+
+    let rendered = app
+        .command(&format!(r#"lens query "ancestors({d})""#))
+        .await?;
+    let mut refs = extract_refs(extract_query_hits(&rendered));
+    refs.sort_by_key(|r| r.to_string());
+    let mut expected = vec![a, b, c];
+    expected.sort_by_key(|r| r.to_string());
+
+    assert_eq!(refs, expected, "ancestors(d) should yield {{a, b, c}}");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn lens_query_within_bounds_depth_both_directions() -> Result<(), Box<dyn core::error::Error>>
+{
+    let (app, _agent, [a, b, c, _d]) = seeded_chain().await?;
+
+    let rendered = app
+        .command(&format!(r#"lens query "within({b}, 1)""#))
+        .await?;
+    let mut refs = extract_refs(extract_query_hits(&rendered));
+    refs.sort_by_key(|r| r.to_string());
+    let mut expected = vec![a, c];
+    expected.sort_by_key(|r| r.to_string());
+
+    assert_eq!(refs, expected, "within(b, 1) should yield {{a, c}}");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn lens_query_component_returns_connected_component()
+-> Result<(), Box<dyn core::error::Error>> {
+    let (app, _agent, [a, b, c, d]) = seeded_chain().await?;
+
+    let rendered = app
+        .command(&format!(r#"lens query "component({a})""#))
+        .await?;
+    let mut refs = extract_refs(extract_query_hits(&rendered));
+    refs.sort_by_key(|r| r.to_string());
+    let mut expected = vec![b, c, d];
+    expected.sort_by_key(|r| r.to_string());
+
+    assert_eq!(refs, expected, "component(a) reaches {{b, c, d}}");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn lens_query_graph_predicate_composes_with_set_ops()
+-> Result<(), Box<dyn core::error::Error>> {
+    let (app, _agent, [a, b, _c, _d]) = seeded_chain().await?;
+
+    let rendered = app
+        .command(&format!(r#"lens query "from({a}) | from({b})""#))
+        .await?;
+    let mut refs = extract_refs(extract_query_hits(&rendered));
+    refs.sort_by_key(|r| r.to_string());
+
+    assert_eq!(refs.len(), 2, "union of from(a) and from(b) has 2 members");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn lens_query_between_returns_events_diverged_between_bookmarks()
+-> Result<(), Box<dyn core::error::Error>> {
+    let app = TestApp::new()
+        .await?
+        .init_host()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    app.command(r#"agent create thinker process --description "T""#)
+        .await?;
+    app.command(r#"cognition add thinker.process observation "first""#)
+        .await?;
+
+    let main_bookmarks = match app.command("bookmark list").await?.response() {
+        Responses::Bookmark(BookmarkResponse::Bookmarks(listed)) => listed.items.clone(),
+        other => panic!("expected Bookmarks, got {other:#?}"),
+    };
+    let main_ref = RefToken::new(Ref::bookmark(
+        main_bookmarks
+            .iter()
+            .find(|b| b.name.as_str() == "main")
+            .expect("main bookmark exists")
+            .id,
+    ));
+
+    let experiment = match app.command("bookmark create experiment").await?.response() {
+        Responses::Bookmark(BookmarkResponse::Forked(BookmarkForkedResponse::V1(r))) => {
+            r.bookmark.clone()
+        }
+        other => panic!("expected Bookmark::Forked, got {other:#?}"),
+    };
+    let experiment_ref = RefToken::new(Ref::bookmark(experiment.id));
+
+    app.command(r#"cognition add thinker.process observation "branch-only""#)
+        .await?;
+
+    let rendered = app
+        .command(&format!(
+            r#"lens query "between({main_ref}, {experiment_ref})""#
+        ))
+        .await?;
+    let hits = extract_query_hits(&rendered);
+    assert!(
+        !hits.is_empty(),
+        "experiment should hold at least one event main lacks"
+    );
+    for hit in hits {
+        assert!(
+            matches!(hit, Hit::Event(_)),
+            "between() should yield event hits, got {hit:?}"
+        );
+    }
+
+    let inverse = app
+        .command(&format!(
+            r#"lens query "between({experiment_ref}, {main_ref})""#
+        ))
+        .await?;
+    let inverse_hits = extract_query_hits(&inverse);
+    assert!(
+        inverse_hits.is_empty(),
+        "main has no events experiment lacks, got {} hits",
+        inverse_hits.len()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_list_with_lens_routes_through_lens_executor()
+-> Result<(), Box<dyn core::error::Error>> {
+    let app = seeded_app().await?;
+    let client = app.client();
+
+    let rendered = client
+        .memory()
+        .list(
+            &ListMemories::builder_v1()
+                .lens("level(project)".to_string())
+                .build()
+                .into(),
+        )
+        .await?;
+
+    let items = match rendered {
+        MemoryResponse::Memories(MemoriesResponse::V1(r)) => r.items,
+        other => panic!("expected Memories, got {other:#?}"),
+    };
+    assert_eq!(items.len(), 1, "one project-level memory in seed");
+    Ok(())
+}
+
+#[tokio::test]
+async fn connection_list_with_lens_routes_through_lens_executor()
+-> Result<(), Box<dyn core::error::Error>> {
+    let (app, _agent, [a, b, _c, _d]) = seeded_chain().await?;
+    let client = app.client();
+
+    let rendered = client
+        .connection()
+        .list(
+            &ListConnections::builder_v1()
+                .lens(format!("from({a}) | from({b})"))
+                .build()
+                .into(),
+        )
+        .await?;
+
+    let _items = match rendered {
+        ConnectionResponse::Connections(ConnectionsResponse::V1(r)) => r.items,
+        ConnectionResponse::NoConnections => Vec::new(),
+        other => panic!("expected Connections, got {other:#?}"),
+    };
+    Ok(())
+}
+
+#[tokio::test]
+async fn agent_list_with_lens_routes_through_lens_executor()
+-> Result<(), Box<dyn core::error::Error>> {
+    let app = seeded_app().await?;
+    let client = app.client();
+
+    let rendered = client
+        .agent()
+        .list(
+            &ListAgents::builder_v1()
+                .lens("agent(gov.process)".to_string())
+                .build()
+                .into(),
+        )
+        .await?;
+
+    let items = match rendered {
+        AgentResponse::Agents(AgentsResponse::V1(r)) => r.items,
+        AgentResponse::NoAgents => Vec::new(),
+        other => panic!("expected Agents, got {other:#?}"),
+    };
+    assert_eq!(items.len(), 1, "the gov.process agent");
+    assert_eq!(items[0].name.as_str(), "gov.process");
+    Ok(())
+}
+
+#[tokio::test]
+async fn experience_list_with_lens_routes_through_lens_executor()
+-> Result<(), Box<dyn core::error::Error>> {
+    let app = seeded_app().await?;
+    let client = app.client();
+
+    let rendered = client
+        .experience()
+        .list(
+            &ListExperiences::builder_v1()
+                .lens("kind(experience)".to_string())
+                .build()
+                .into(),
+        )
+        .await?;
+
+    let _items = match rendered {
+        ExperienceResponse::Experiences(ExperiencesResponse::V1(r)) => r.items,
+        ExperienceResponse::NoExperiences => Vec::new(),
+        other => panic!("expected Experiences, got {other:#?}"),
+    };
+    Ok(())
+}
+
+#[tokio::test]
+async fn cognition_list_with_lens_routes_through_lens_executor()
+-> Result<(), Box<dyn core::error::Error>> {
+    let app = seeded_app().await?;
+    let client = app.client();
+
+    let rendered = client
+        .cognition()
+        .list(
+            &ListCognitions::builder_v1()
+                .lens("texture(observation)".to_string())
+                .build()
+                .into(),
+        )
+        .await?;
+
+    let items = match rendered {
+        CognitionResponse::Cognitions(CognitionsResponse::V1(r)) => r.items,
+        other => panic!("expected Cognitions, got {other:#?}"),
+    };
+
+    assert_eq!(items.len(), 2, "two cognitions have texture=observation");
+    for cognition in &items {
+        assert_eq!(cognition.texture.as_str(), "observation");
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn lens_query_events_for_unknown_ref_returns_empty() -> Result<(), Box<dyn core::error::Error>>
+{
+    let app = TestApp::new()
+        .await?
+        .init_host()
+        .await?
+        .init_project()
+        .await?
+        .seed_core()
+        .await?;
+
+    let unknown_ref = RefToken::new(Ref::agent(AgentId::new()));
+
+    let rendered = app
+        .command(&format!(r#"lens query "events_for({unknown_ref})""#))
+        .await?;
+    let hits = extract_query_hits(&rendered);
+
+    assert!(hits.is_empty(), "unknown entity has no trail");
+
+    Ok(())
+}


### PR DESCRIPTION
This takes the lens representation a level further, and completes our local implementation of it all.

- Lenses have readers for most spaces now.
- You can create lens aliases in config for known lenses.
- MCP uses lenses like our endpoints do.

But, most crucially, the actual syntax of lenses is a little uniform as well. Previously, this expression would be regarded as a concrete fn-style invocation:

```lens
agent(governor.process)
```

In other words, `agent` here takes only `name` args. That's no longer the case. The new structure is `agent(<lens>)`, and we've taught the system how to expand lenses to lists of names. So, `governor.process` is now thought of as a lens, which resolves terminally to a name. Meaning we can do this:

```lens
agent(governor.process | thinker.process)
```

Which yields agents that match the set of interior args. Overall this means that lenses should expand across their interior args, and work a little closer to set types in general. It's my hope that this gives us a strong expressive ability to select sweeping collections of things, and sets us up in an ideal space for slicing.

Release-Type: feature