### PR TITLE
Resource requests

### DIFF
--- a/crates/oneiros-engine/src/domains/actor/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/actor/protocol/requests.rs
@@ -16,14 +16,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for CreateActor {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/actors", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetActor {
@@ -31,15 +23,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) key: ResourceKey<ActorId>,
         }
-    }
-}
-
-impl ClientRequest for GetActor {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetActor::V1(lookup) = self;
-        client.get(&format!("/actors/{}", lookup.key)).await
     }
 }
 
@@ -56,11 +39,14 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListActors {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListActors::V1(listing) = self;
+resource_requests! {
+    CreateActor => |this, client| { client.post("/actors", this).await },
+    GetActor => |this, client| {
+        let GetActor::V1(lookup) = this;
+        client.get(&format!("/actors/{}", lookup.key)).await
+    },
+    ListActors => |this, client| {
+        let ListActors::V1(listing) = this;
         let query = format!(
             "limit={}&offset={}",
             listing.filters.limit, listing.filters.offset,

--- a/crates/oneiros-engine/src/domains/agent/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/agent/protocol/requests.rs
@@ -21,14 +21,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for CreateAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/agents", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetAgent {
@@ -36,15 +28,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) key: ResourceKey<AgentName>,
         }
-    }
-}
-
-impl ClientRequest for GetAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetAgent::V1(lookup) = self;
-        client.get(&format!("/agents/{}", lookup.key)).await
     }
 }
 
@@ -73,11 +56,41 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListAgents {
-    type Error = ClientError;
+versioned! {
+    #[derive(JsonSchema)]
+    pub(crate) enum UpdateAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub(crate) name: AgentName,
+            #[builder(into)] pub(crate) persona: PersonaName,
+            #[arg(long, default_value = "")]
+            #[builder(into)]
+            pub(crate) description: Description,
+            #[arg(long, default_value = "")]
+            #[builder(into)]
+            pub(crate) prompt: Prompt,
+        }
+    }
+}
 
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListAgents::V1(listing) = self;
+versioned! {
+    #[derive(JsonSchema)]
+    pub(crate) enum RemoveAgent {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub(crate) name: AgentName,
+        }
+    }
+}
+
+resource_requests! {
+    CreateAgent => |this, client| { client.post("/agents", this).await },
+    GetAgent => |this, client| {
+        let GetAgent::V1(lookup) = this;
+        client.get(&format!("/agents/{}", lookup.key)).await
+    },
+    ListAgents => |this, client| {
+        let ListAgents::V1(listing) = this;
         let mut params: Vec<(&str, String)> = Vec::new();
 
         if let Some(query) = &listing.query {
@@ -97,52 +110,15 @@ impl ClientRequest for ListAgents {
             .collect::<Vec<_>>()
             .join("&");
         client.get(&format!("/agents?{query}")).await
-    }
-}
-
-versioned! {
-    #[derive(JsonSchema)]
-    pub(crate) enum UpdateAgent {
-        #[derive(clap::Args)]
-        V1 => {
-            #[builder(into)] pub(crate) name: AgentName,
-            #[builder(into)] pub(crate) persona: PersonaName,
-            #[arg(long, default_value = "")]
-            #[builder(into)]
-            pub(crate) description: Description,
-            #[arg(long, default_value = "")]
-            #[builder(into)]
-            pub(crate) prompt: Prompt,
-        }
-    }
-}
-
-impl ClientRequest for UpdateAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let UpdateAgent::V1(body) = self;
+    },
+    UpdateAgent => |this, client| {
+        let UpdateAgent::V1(body) = this;
         client
-            .put(&format!("/agents/{name}", name = body.name), self)
+            .put(&format!("/agents/{name}", name = body.name), this)
             .await
-    }
-}
-
-versioned! {
-    #[derive(JsonSchema)]
-    pub(crate) enum RemoveAgent {
-        #[derive(clap::Args)]
-        V1 => {
-            #[builder(into)] pub(crate) name: AgentName,
-        }
-    }
-}
-
-impl ClientRequest for RemoveAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let RemoveAgent::V1(removal) = self;
+    },
+    RemoveAgent => |this, client| {
+        let RemoveAgent::V1(removal) = this;
         client.delete(&format!("/agents/{}", removal.name)).await
     }
 }

--- a/crates/oneiros-engine/src/domains/bookmark/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/bookmark/protocol/requests.rs
@@ -19,14 +19,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for CreateBookmark {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/bookmarks", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum SwitchBookmark {
@@ -37,14 +29,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for SwitchBookmark {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/bookmarks/switch", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum MergeBookmark {
@@ -52,14 +36,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) source: BookmarkName,
         }
-    }
-}
-
-impl ClientRequest for MergeBookmark {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/bookmarks/merge", self).await
     }
 }
 
@@ -83,26 +59,6 @@ versioned! {
             #[builder(default)]
             pub(crate) filters: SearchFilters,
         },
-    }
-}
-
-impl ClientRequest for ListBookmarks {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        match self {
-            ListBookmarks::V2(v2) => {
-                let mut query = format!("limit={}&offset={}", v2.filters.limit, v2.filters.offset,);
-                if let Some(ref from) = v2.from {
-                    query.push_str(&format!("&from={}", from));
-                }
-                client.get(&format!("/bookmarks?{query}")).await
-            }
-            ListBookmarks::V1(v1) => {
-                let query = format!("limit={}&offset={}", v1.filters.limit, v1.filters.offset,);
-                client.get(&format!("/bookmarks?{query}")).await
-            }
-        }
     }
 }
 
@@ -134,14 +90,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for ShareBookmark {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/bookmarks/share", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum FollowBookmark {
@@ -152,14 +100,6 @@ versioned! {
             #[builder(into)]
             pub(crate) name: BookmarkName,
         }
-    }
-}
-
-impl ClientRequest for FollowBookmark {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/bookmarks/follow", self).await
     }
 }
 
@@ -184,14 +124,6 @@ versioned! {
             /// For follow-based collect: the local bookmark name.
             #[builder(into)] pub(crate) name: BookmarkName,
         },
-    }
-}
-
-impl ClientRequest for CollectBookmark {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/bookmarks/collect", self).await
     }
 }
 
@@ -222,29 +154,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for UnfollowBookmark {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/bookmarks/unfollow", self).await
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]
-#[serde(tag = "type", content = "data", rename_all = "kebab-case")]
-#[kinded(kind = BookmarkRequestType, display = "kebab-case")]
-pub(crate) enum BookmarkRequest {
-    CreateBookmark(CreateBookmark),
-    SwitchBookmark(SwitchBookmark),
-    MergeBookmark(MergeBookmark),
-    ListBookmarks(ListBookmarks),
-    ShareBookmark(ShareBookmark),
-    FollowBookmark(FollowBookmark),
-    CollectBookmark(CollectBookmark),
-    UnfollowBookmark(UnfollowBookmark),
-    SubmitBookmark(SubmitBookmark),
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum SubmitBookmark {
@@ -269,12 +178,45 @@ versioned! {
     }
 }
 
-impl ClientRequest for SubmitBookmark {
-    type Error = ClientError;
+resource_requests! {
+    CreateBookmark => |this, client| { client.post("/bookmarks", this).await },
+    SwitchBookmark => |this, client| { client.post("/bookmarks/switch", this).await },
+    MergeBookmark => |this, client| { client.post("/bookmarks/merge", this).await },
+    ListBookmarks => |this, client| {
+        match this {
+            ListBookmarks::V2(v2) => {
+                let mut query = format!("limit={}&offset={}", v2.filters.limit, v2.filters.offset,);
+                if let Some(ref from) = v2.from {
+                    query.push_str(&format!("&from={}", from));
+                }
+                client.get(&format!("/bookmarks?{query}")).await
+            }
+            ListBookmarks::V1(v1) => {
+                let query = format!("limit={}&offset={}", v1.filters.limit, v1.filters.offset,);
+                client.get(&format!("/bookmarks?{query}")).await
+            }
+        }
+    },
+    ShareBookmark => |this, client| { client.post("/bookmarks/share", this).await },
+    FollowBookmark => |this, client| { client.post("/bookmarks/follow", this).await },
+    CollectBookmark => |this, client| { client.post("/bookmarks/collect", this).await },
+    UnfollowBookmark => |this, client| { client.post("/bookmarks/unfollow", this).await },
+    SubmitBookmark => |this, client| { client.post("/bookmarks/submit", this).await }
+}
 
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/bookmarks/submit", self).await
-    }
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]
+#[serde(tag = "type", content = "data", rename_all = "kebab-case")]
+#[kinded(kind = BookmarkRequestType, display = "kebab-case")]
+pub(crate) enum BookmarkRequest {
+    CreateBookmark(CreateBookmark),
+    SwitchBookmark(SwitchBookmark),
+    MergeBookmark(MergeBookmark),
+    ListBookmarks(ListBookmarks),
+    ShareBookmark(ShareBookmark),
+    FollowBookmark(FollowBookmark),
+    CollectBookmark(CollectBookmark),
+    UnfollowBookmark(UnfollowBookmark),
+    SubmitBookmark(SubmitBookmark),
 }
 
 impl TryFrom<SubmitBookmarkV1> for SubmitBookmarkV2 {

--- a/crates/oneiros-engine/src/domains/cognition/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/cognition/protocol/requests.rs
@@ -16,14 +16,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for AddCognition {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/cognitions", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetCognition {
@@ -31,15 +23,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) key: ResourceKey<CognitionId>,
         }
-    }
-}
-
-impl ClientRequest for GetCognition {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetCognition::V1(lookup) = self;
-        client.get(&format!("/cognitions/{}", lookup.key)).await
     }
 }
 
@@ -71,11 +54,14 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListCognitions {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListCognitions::V1(listing) = self;
+resource_requests! {
+    AddCognition => |this, client| { client.post("/cognitions", this).await },
+    GetCognition => |this, client| {
+        let GetCognition::V1(lookup) = this;
+        client.get(&format!("/cognitions/{}", lookup.key)).await
+    },
+    ListCognitions => |this, client| {
+        let ListCognitions::V1(listing) = this;
         let mut params: Vec<(&str, String)> = Vec::new();
 
         if let Some(agent_name) = &listing.agent {

--- a/crates/oneiros-engine/src/domains/connection/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/connection/protocol/requests.rs
@@ -16,14 +16,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for CreateConnection {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/connections", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetConnection {
@@ -31,15 +23,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) key: ResourceKey<ConnectionId>,
         }
-    }
-}
-
-impl ClientRequest for GetConnection {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetConnection::V1(lookup) = self;
-        client.get(&format!("/connections/{}", lookup.key)).await
     }
 }
 
@@ -64,11 +47,24 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListConnections {
-    type Error = ClientError;
+versioned! {
+    #[derive(JsonSchema)]
+    pub(crate) enum RemoveConnection {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub(crate) id: ConnectionId,
+        }
+    }
+}
 
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListConnections::V1(listing) = self;
+resource_requests! {
+    CreateConnection => |this, client| { client.post("/connections", this).await },
+    GetConnection => |this, client| {
+        let GetConnection::V1(lookup) = this;
+        client.get(&format!("/connections/{}", lookup.key)).await
+    },
+    ListConnections => |this, client| {
+        let ListConnections::V1(listing) = this;
         let mut params: Vec<(&str, String)> = Vec::new();
 
         if let Some(entity) = &listing.entity {
@@ -89,24 +85,9 @@ impl ClientRequest for ListConnections {
             .join("&");
 
         client.get(&format!("/connections?{query}")).await
-    }
-}
-
-versioned! {
-    #[derive(JsonSchema)]
-    pub(crate) enum RemoveConnection {
-        #[derive(clap::Args)]
-        V1 => {
-            #[builder(into)] pub(crate) id: ConnectionId,
-        }
-    }
-}
-
-impl ClientRequest for RemoveConnection {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let RemoveConnection::V1(removal) = self;
+    },
+    RemoveConnection => |this, client| {
+        let RemoveConnection::V1(removal) = this;
         client.delete(&format!("/connections/{}", removal.id)).await
     }
 }

--- a/crates/oneiros-engine/src/domains/continuity/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/continuity/protocol/requests.rs
@@ -14,20 +14,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for WakeAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let WakeAgent::V1(wake) = self;
-        client
-            .post(
-                &format!("/continuity/{agent}/wake", agent = wake.agent),
-                &serde_json::Value::Null,
-            )
-            .await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum DreamAgent {
@@ -35,21 +21,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) agent: AgentName,
         }
-    }
-}
-
-impl ClientRequest for DreamAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let DreamAgent::V1(dream) = self;
-        let query = encode_dream_overrides(&DreamOverrides::default());
-        let path = if query.is_empty() {
-            format!("/continuity/{agent}/dream", agent = dream.agent)
-        } else {
-            format!("/continuity/{agent}/dream?{query}", agent = dream.agent)
-        };
-        client.post(&path, &serde_json::Value::Null).await
     }
 }
 
@@ -63,23 +34,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for IntrospectAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let IntrospectAgent::V1(introspecting) = self;
-        client
-            .post(
-                &format!(
-                    "/continuity/{agent}/introspect",
-                    agent = introspecting.agent
-                ),
-                &serde_json::Value::Null,
-            )
-            .await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum ReflectAgent {
@@ -87,20 +41,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) agent: AgentName,
         }
-    }
-}
-
-impl ClientRequest for ReflectAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ReflectAgent::V1(reflecting) = self;
-        client
-            .post(
-                &format!("/continuity/{agent}/reflect", agent = reflecting.agent),
-                &serde_json::Value::Null,
-            )
-            .await
     }
 }
 
@@ -115,20 +55,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for SenseContent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let SenseContent::V1(sense) = self;
-        client
-            .post(
-                &format!("/continuity/{agent}/sense", agent = sense.agent),
-                self,
-            )
-            .await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum SleepAgent {
@@ -139,20 +65,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for SleepAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let SleepAgent::V1(sleeping) = self;
-        client
-            .post(
-                &format!("/continuity/{agent}/sleep", agent = sleeping.agent),
-                &serde_json::Value::Null,
-            )
-            .await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GuidebookAgent {
@@ -160,20 +72,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) agent: AgentName,
         }
-    }
-}
-
-impl ClientRequest for GuidebookAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GuidebookAgent::V1(lookup) = self;
-        client
-            .get(&format!(
-                "/continuity/{agent}/guidebook",
-                agent = lookup.agent
-            ))
-            .await
     }
 }
 
@@ -190,14 +88,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for EmergeAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/continuity", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum RecedeAgent {
@@ -205,17 +95,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) agent: AgentName,
         }
-    }
-}
-
-impl ClientRequest for RecedeAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let RecedeAgent::V1(receding) = self;
-        client
-            .delete(&format!("/continuity/{agent}", agent = receding.agent))
-            .await
     }
 }
 
@@ -229,14 +108,6 @@ versioned! {
             #[builder(default)]
             pub(crate) filters: SearchFilters,
         }
-    }
-}
-
-impl ClientRequest for StatusAgent {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.get("/continuity").await
     }
 }
 
@@ -261,6 +132,89 @@ fn encode_dream_overrides(overrides: &DreamOverrides) -> String {
         parts.push(format!("experience_size={value}"));
     }
     parts.join("&")
+}
+
+resource_requests! {
+    WakeAgent => |this, client| {
+        let WakeAgent::V1(wake) = this;
+        client
+            .post(
+                &format!("/continuity/{agent}/wake", agent = wake.agent),
+                &serde_json::Value::Null,
+            )
+            .await
+    },
+    DreamAgent => |this, client| {
+        let DreamAgent::V1(dream) = this;
+        let query = encode_dream_overrides(&DreamOverrides::default());
+        let path = if query.is_empty() {
+            format!("/continuity/{agent}/dream", agent = dream.agent)
+        } else {
+            format!("/continuity/{agent}/dream?{query}", agent = dream.agent)
+        };
+        client.post(&path, &serde_json::Value::Null).await
+    },
+    IntrospectAgent => |this, client| {
+        let IntrospectAgent::V1(introspecting) = this;
+        client
+            .post(
+                &format!(
+                    "/continuity/{agent}/introspect",
+                    agent = introspecting.agent
+                ),
+                &serde_json::Value::Null,
+            )
+            .await
+    },
+    ReflectAgent => |this, client| {
+        let ReflectAgent::V1(reflecting) = this;
+        client
+            .post(
+                &format!("/continuity/{agent}/reflect", agent = reflecting.agent),
+                &serde_json::Value::Null,
+            )
+            .await
+    },
+    SenseContent => |this, client| {
+        let SenseContent::V1(sense) = this;
+        client
+            .post(
+                &format!("/continuity/{agent}/sense", agent = sense.agent),
+                this,
+            )
+            .await
+    },
+    SleepAgent => |this, client| {
+        let SleepAgent::V1(sleeping) = this;
+        client
+            .post(
+                &format!("/continuity/{agent}/sleep", agent = sleeping.agent),
+                &serde_json::Value::Null,
+            )
+            .await
+    },
+    GuidebookAgent => |this, client| {
+        let GuidebookAgent::V1(lookup) = this;
+        client
+            .get(&format!(
+                "/continuity/{agent}/guidebook",
+                agent = lookup.agent
+            ))
+            .await
+    },
+    EmergeAgent => |this, client| {
+        client.post("/continuity", this).await
+    },
+    RecedeAgent => |this, client| {
+        let RecedeAgent::V1(receding) = this;
+        client
+            .delete(&format!("/continuity/{agent}", agent = receding.agent))
+            .await
+    },
+}
+
+resource_requests! {
+    StatusAgent => |client| { client.get("/continuity").await },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/experience/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/experience/protocol/requests.rs
@@ -16,14 +16,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for CreateExperience {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/experiences", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetExperience {
@@ -31,15 +23,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) key: ResourceKey<ExperienceId>,
         }
-    }
-}
-
-impl ClientRequest for GetExperience {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetExperience::V1(lookup) = self;
-        client.get(&format!("/experiences/{}", lookup.key)).await
     }
 }
 
@@ -72,11 +55,38 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListExperiences {
-    type Error = ClientError;
+versioned! {
+    #[derive(JsonSchema)]
+    pub(crate) enum UpdateExperienceDescription {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub(crate) id: ExperienceId,
+            #[builder(into)] pub(crate) description: Description,
+        }
+    }
+}
 
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListExperiences::V1(listing) = self;
+versioned! {
+    #[derive(JsonSchema)]
+    pub(crate) enum UpdateExperienceSensation {
+        #[derive(clap::Args)]
+        V1 => {
+            #[builder(into)] pub(crate) id: ExperienceId,
+            #[builder(into)] pub(crate) sensation: SensationName,
+        }
+    }
+}
+
+resource_requests! {
+    CreateExperience => |this, client| {
+        client.post("/experiences", this).await
+    },
+    GetExperience => |this, client| {
+        let GetExperience::V1(lookup) = this;
+        client.get(&format!("/experiences/{}", lookup.key)).await
+    },
+    ListExperiences => |this, client| {
+        let ListExperiences::V1(listing) = this;
         let mut params: Vec<(&str, String)> = Vec::new();
 
         if let Some(agent_name) = &listing.agent {
@@ -105,57 +115,25 @@ impl ClientRequest for ListExperiences {
             .join("&");
 
         client.get(&format!("/experiences?{query}")).await
-    }
-}
-
-versioned! {
-    #[derive(JsonSchema)]
-    pub(crate) enum UpdateExperienceDescription {
-        #[derive(clap::Args)]
-        V1 => {
-            #[builder(into)] pub(crate) id: ExperienceId,
-            #[builder(into)] pub(crate) description: Description,
-        }
-    }
-}
-
-impl ClientRequest for UpdateExperienceDescription {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let UpdateExperienceDescription::V1(update) = self;
+    },
+    UpdateExperienceDescription => |this, client| {
+        let UpdateExperienceDescription::V1(update) = this;
         client
             .put(
                 &format!("/experiences/{}/description", update.id),
                 &serde_json::json!({ "description": update.description }),
             )
             .await
-    }
-}
-
-versioned! {
-    #[derive(JsonSchema)]
-    pub(crate) enum UpdateExperienceSensation {
-        #[derive(clap::Args)]
-        V1 => {
-            #[builder(into)] pub(crate) id: ExperienceId,
-            #[builder(into)] pub(crate) sensation: SensationName,
-        }
-    }
-}
-
-impl ClientRequest for UpdateExperienceSensation {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let UpdateExperienceSensation::V1(update) = self;
+    },
+    UpdateExperienceSensation => |this, client| {
+        let UpdateExperienceSensation::V1(update) = this;
         client
             .put(
                 &format!("/experiences/{}/sensation", update.id),
                 &serde_json::json!({ "sensation": update.sensation }),
             )
             .await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/follow/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/follow/protocol/requests.rs
@@ -14,15 +14,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for GetFollow {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetFollow::V1(lookup) = self;
-        client.get(&format!("/follows/{}", lookup.key)).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum ListFollows {
@@ -36,17 +27,19 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListFollows {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListFollows::V1(listing) = self;
+resource_requests! {
+    GetFollow => |this, client| {
+        let GetFollow::V1(lookup) = this;
+        client.get(&format!("/follows/{}", lookup.key)).await
+    },
+    ListFollows => |this, client| {
+        let ListFollows::V1(listing) = this;
         let query = format!(
             "limit={}&offset={}",
             listing.filters.limit, listing.filters.offset,
         );
         client.get(&format!("/follows?{query}")).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/host/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/host/protocol/requests.rs
@@ -20,12 +20,10 @@ versioned! {
     }
 }
 
-impl ClientRequest for InitHost {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/host", self).await
-    }
+resource_requests! {
+    InitHost => |this, client| {
+        client.post("/host", this).await
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/lens/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/lens/protocol/requests.rs
@@ -13,14 +13,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for ParseLens {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/lens/parse", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum ExplainLens {
@@ -29,14 +21,6 @@ versioned! {
             #[builder(into)]
             pub(crate) source: String,
         }
-    }
-}
-
-impl ClientRequest for ExplainLens {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/lens/explain", self).await
     }
 }
 
@@ -51,10 +35,14 @@ versioned! {
     }
 }
 
-impl ClientRequest for QueryLens {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/lens/query", self).await
-    }
+resource_requests! {
+    ParseLens => |this, client| {
+        client.post("/lens/parse", this).await
+    },
+    ExplainLens => |this, client| {
+        client.post("/lens/explain", this).await
+    },
+    QueryLens => |this, client| {
+        client.post("/lens/query", this).await
+    },
 }

--- a/crates/oneiros-engine/src/domains/level/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/level/protocol/requests.rs
@@ -20,15 +20,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for SetLevel {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let SetLevel::V1(body) = self;
-        client.put(&format!("/levels/{}", body.name), self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetLevel {
@@ -39,15 +30,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for GetLevel {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetLevel::V1(lookup) = self;
-        client.get(&format!("/levels/{}", lookup.key)).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum RemoveLevel {
@@ -55,15 +37,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) name: LevelName,
         }
-    }
-}
-
-impl ClientRequest for RemoveLevel {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let RemoveLevel::V1(removal) = self;
-        client.delete(&format!("/levels/{}", removal.name)).await
     }
 }
 
@@ -80,17 +53,27 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListLevels {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListLevels::V1(listing) = self;
+resource_requests! {
+    SetLevel => |this, client| {
+        let SetLevel::V1(body) = this;
+        client.put(&format!("/levels/{}", body.name), this).await
+    },
+    GetLevel => |this, client| {
+        let GetLevel::V1(lookup) = this;
+        client.get(&format!("/levels/{}", lookup.key)).await
+    },
+    RemoveLevel => |this, client| {
+        let RemoveLevel::V1(removal) = this;
+        client.delete(&format!("/levels/{}", removal.name)).await
+    },
+    ListLevels => |this, client| {
+        let ListLevels::V1(listing) = this;
         let query = format!(
             "limit={}&offset={}",
             listing.filters.limit, listing.filters.offset,
         );
         client.get(&format!("/levels?{query}")).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/memory/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/memory/protocol/requests.rs
@@ -16,14 +16,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for AddMemory {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/memories", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetMemory {
@@ -31,15 +23,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) key: ResourceKey<MemoryId>,
         }
-    }
-}
-
-impl ClientRequest for GetMemory {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetMemory::V1(lookup) = self;
-        client.get(&format!("/memories/{}", lookup.key)).await
     }
 }
 
@@ -71,11 +54,16 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListMemories {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListMemories::V1(listing) = self;
+resource_requests! {
+    AddMemory => |this, client| {
+        client.post("/memories", this).await
+    },
+    GetMemory => |this, client| {
+        let GetMemory::V1(lookup) = this;
+        client.get(&format!("/memories/{}", lookup.key)).await
+    },
+    ListMemories => |this, client| {
+        let ListMemories::V1(listing) = this;
         let mut params: Vec<(&str, String)> = Vec::new();
 
         if let Some(agent_name) = &listing.agent {
@@ -104,7 +92,7 @@ impl ClientRequest for ListMemories {
             .join("&");
 
         client.get(&format!("/memories?{query}")).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/nature/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/nature/protocol/requests.rs
@@ -20,15 +20,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for SetNature {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let SetNature::V1(body) = self;
-        client.put(&format!("/natures/{}", body.name), self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetNature {
@@ -39,15 +30,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for GetNature {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetNature::V1(lookup) = self;
-        client.get(&format!("/natures/{}", lookup.key)).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum RemoveNature {
@@ -55,15 +37,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) name: NatureName,
         }
-    }
-}
-
-impl ClientRequest for RemoveNature {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let RemoveNature::V1(removal) = self;
-        client.delete(&format!("/natures/{}", removal.name)).await
     }
 }
 
@@ -80,17 +53,27 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListNatures {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListNatures::V1(listing) = self;
+resource_requests! {
+    SetNature => |this, client| {
+        let SetNature::V1(body) = this;
+        client.put(&format!("/natures/{}", body.name), this).await
+    },
+    GetNature => |this, client| {
+        let GetNature::V1(lookup) = this;
+        client.get(&format!("/natures/{}", lookup.key)).await
+    },
+    RemoveNature => |this, client| {
+        let RemoveNature::V1(removal) = this;
+        client.delete(&format!("/natures/{}", removal.name)).await
+    },
+    ListNatures => |this, client| {
+        let ListNatures::V1(listing) = this;
         let query = format!(
             "limit={}&offset={}",
             listing.filters.limit, listing.filters.offset,
         );
         client.get(&format!("/natures?{query}")).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/peer/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/peer/protocol/requests.rs
@@ -17,14 +17,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for AddPeer {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/peers", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetPeer {
@@ -35,15 +27,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for GetPeer {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetPeer::V1(lookup) = self;
-        client.get(&format!("/peers/{}", lookup.key)).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum RemovePeer {
@@ -51,15 +34,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) id: PeerId,
         }
-    }
-}
-
-impl ClientRequest for RemovePeer {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let RemovePeer::V1(removal) = self;
-        client.delete(&format!("/peers/{}", removal.id)).await
     }
 }
 
@@ -76,17 +50,26 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListPeers {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListPeers::V1(listing) = self;
+resource_requests! {
+    AddPeer => |this, client| {
+        client.post("/peers", this).await
+    },
+    GetPeer => |this, client| {
+        let GetPeer::V1(lookup) = this;
+        client.get(&format!("/peers/{}", lookup.key)).await
+    },
+    RemovePeer => |this, client| {
+        let RemovePeer::V1(removal) = this;
+        client.delete(&format!("/peers/{}", removal.id)).await
+    },
+    ListPeers => |this, client| {
+        let ListPeers::V1(listing) = this;
         let query = format!(
             "limit={}&offset={}",
             listing.filters.limit, listing.filters.offset,
         );
         client.get(&format!("/peers?{query}")).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/persona/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/persona/protocol/requests.rs
@@ -20,17 +20,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for SetPersona {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let SetPersona::V1(body) = self;
-        client
-            .put(&format!("/personas/{name}", name = body.name), self)
-            .await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetPersona {
@@ -41,15 +30,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for GetPersona {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetPersona::V1(lookup) = self;
-        client.get(&format!("/personas/{}", lookup.key)).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum RemovePersona {
@@ -57,15 +37,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) name: PersonaName,
         }
-    }
-}
-
-impl ClientRequest for RemovePersona {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let RemovePersona::V1(removal) = self;
-        client.delete(&format!("/personas/{}", removal.name)).await
     }
 }
 
@@ -82,17 +53,29 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListPersonas {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListPersonas::V1(listing) = self;
+resource_requests! {
+    SetPersona => |this, client| {
+        let SetPersona::V1(body) = this;
+        client
+            .put(&format!("/personas/{name}", name = body.name), this)
+            .await
+    },
+    GetPersona => |this, client| {
+        let GetPersona::V1(lookup) = this;
+        client.get(&format!("/personas/{}", lookup.key)).await
+    },
+    RemovePersona => |this, client| {
+        let RemovePersona::V1(removal) = this;
+        client.delete(&format!("/personas/{}", removal.name)).await
+    },
+    ListPersonas => |this, client| {
+        let ListPersonas::V1(listing) = this;
         let query = format!(
             "limit={}&offset={}",
             listing.filters.limit, listing.filters.offset,
         );
         client.get(&format!("/personas?{query}")).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/pressure/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/pressure/protocol/requests.rs
@@ -14,13 +14,11 @@ versioned! {
     }
 }
 
-impl ClientRequest for GetPressure {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetPressure::V1(lookup) = self;
+resource_requests! {
+    GetPressure => |this, client| {
+        let GetPressure::V1(lookup) = this;
         client.get(&format!("/pressures/{}", lookup.agent)).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/project/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/project/protocol/requests.rs
@@ -22,14 +22,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for CreateProject {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/projects", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetProject {
@@ -37,15 +29,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) key: ResourceKey<ProjectName>,
         }
-    }
-}
-
-impl ClientRequest for GetProject {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetProject::V1(lookup) = self;
-        client.get(&format!("/projects/{}", lookup.key)).await
     }
 }
 
@@ -59,19 +42,6 @@ versioned! {
             #[builder(default)]
             pub(crate) filters: SearchFilters,
         }
-    }
-}
-
-impl ClientRequest for ListProjects {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListProjects::V1(listing) = self;
-        let query = format!(
-            "limit={}&offset={}",
-            listing.filters.limit, listing.filters.offset,
-        );
-        client.get(&format!("/projects?{query}")).await
     }
 }
 
@@ -122,14 +92,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for ShareProject {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/projects/share", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum FollowProject {
@@ -143,12 +105,28 @@ versioned! {
     }
 }
 
-impl ClientRequest for FollowProject {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/projects/follow", self).await
-    }
+resource_requests! {
+    CreateProject => |this, client| {
+        client.post("/projects", this).await
+    },
+    GetProject => |this, client| {
+        let GetProject::V1(lookup) = this;
+        client.get(&format!("/projects/{}", lookup.key)).await
+    },
+    ListProjects => |this, client| {
+        let ListProjects::V1(listing) = this;
+        let query = format!(
+            "limit={}&offset={}",
+            listing.filters.limit, listing.filters.offset,
+        );
+        client.get(&format!("/projects?{query}")).await
+    },
+    ShareProject => |this, client| {
+        client.post("/projects/share", this).await
+    },
+    FollowProject => |this, client| {
+        client.post("/projects/follow", this).await
+    },
 }
 
 #[cfg(test)]

--- a/crates/oneiros-engine/src/domains/search/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/search/protocol/requests.rs
@@ -42,11 +42,9 @@ impl SearchQueryV1 {
     }
 }
 
-impl ClientRequest for SearchQuery {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let SearchQuery::V1(query) = self;
+resource_requests! {
+    SearchQuery => |this, client| {
+        let SearchQuery::V1(query) = this;
         let mut parts: Vec<String> = Vec::new();
         if let Some(q) = &query.query {
             parts.push(format!("query={q}"));
@@ -71,7 +69,7 @@ impl ClientRequest for SearchQuery {
 
         let path = format!("/search?{}", parts.join("&"));
         client.get(&path).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/sensation/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/sensation/protocol/requests.rs
@@ -20,17 +20,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for SetSensation {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let SetSensation::V1(body) = self;
-        client
-            .put(&format!("/sensations/{}", body.name), self)
-            .await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetSensation {
@@ -41,15 +30,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for GetSensation {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetSensation::V1(lookup) = self;
-        client.get(&format!("/sensations/{}", lookup.key)).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum RemoveSensation {
@@ -57,17 +37,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) name: SensationName,
         }
-    }
-}
-
-impl ClientRequest for RemoveSensation {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let RemoveSensation::V1(removal) = self;
-        client
-            .delete(&format!("/sensations/{}", removal.name))
-            .await
     }
 }
 
@@ -84,17 +53,31 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListSensations {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListSensations::V1(listing) = self;
+resource_requests! {
+    SetSensation => |this, client| {
+        let SetSensation::V1(body) = this;
+        client
+            .put(&format!("/sensations/{}", body.name), this)
+            .await
+    },
+    GetSensation => |this, client| {
+        let GetSensation::V1(lookup) = this;
+        client.get(&format!("/sensations/{}", lookup.key)).await
+    },
+    RemoveSensation => |this, client| {
+        let RemoveSensation::V1(removal) = this;
+        client
+            .delete(&format!("/sensations/{}", removal.name))
+            .await
+    },
+    ListSensations => |this, client| {
+        let ListSensations::V1(listing) = this;
         let query = format!(
             "limit={}&offset={}",
             listing.filters.limit, listing.filters.offset,
         );
         client.get(&format!("/sensations?{query}")).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/slice/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/slice/protocol/requests.rs
@@ -4,39 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::*;
 
-impl ClientRequest for CreateSlice {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/slices", self).await
-    }
-}
-
-impl ClientRequest for ListSlices {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.get("/slices").await
-    }
-}
-
-impl ClientRequest for DeleteSlice {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let DeleteSlice::V1(req) = self;
-        client.delete(&format!("/slices/{}", req.name)).await
-    }
-}
-
-impl ClientRequest for DiffSlice {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/slices/diff", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum CreateSlice {
@@ -81,6 +48,19 @@ versioned! {
             pub(crate) target: SliceName,
         }
     }
+}
+
+resource_requests! {
+    CreateSlice => |this, client| { client.post("/slices", this).await },
+    DeleteSlice => |this, client| {
+        let DeleteSlice::V1(req) = this;
+        client.delete(&format!("/slices/{}", req.name)).await
+    },
+    DiffSlice => |this, client| { client.post("/slices/diff", this).await },
+}
+
+resource_requests! {
+    ListSlices => |client| { client.get("/slices").await },
 }
 
 #[allow(dead_code)]

--- a/crates/oneiros-engine/src/domains/storage/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/storage/protocol/requests.rs
@@ -14,19 +14,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for GetStorage {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetStorage::V1(lookup) = self;
-        let path = match &lookup.key {
-            ResourceKey::Key(key) => StorageRef::encode(key).to_string(),
-            ResourceKey::Ref(token) => token.to_string(),
-        };
-        client.get(&format!("/storage/{path}")).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum RemoveStorage {
@@ -34,16 +21,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) key: StorageKey,
         }
-    }
-}
-
-impl ClientRequest for RemoveStorage {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let RemoveStorage::V1(removal) = self;
-        let ref_key = StorageRef::encode(&removal.key);
-        client.delete(&format!("/storage/{ref_key}")).await
     }
 }
 
@@ -62,14 +39,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for UploadStorage {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/storage", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum ListStorage {
@@ -83,17 +52,31 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListStorage {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListStorage::V1(listing) = self;
+resource_requests! {
+    GetStorage => |this, client| {
+        let GetStorage::V1(lookup) = this;
+        let path = match &lookup.key {
+            ResourceKey::Key(key) => StorageRef::encode(key).to_string(),
+            ResourceKey::Ref(token) => token.to_string(),
+        };
+        client.get(&format!("/storage/{path}")).await
+    },
+    RemoveStorage => |this, client| {
+        let RemoveStorage::V1(removal) = this;
+        let ref_key = StorageRef::encode(&removal.key);
+        client.delete(&format!("/storage/{ref_key}")).await
+    },
+    UploadStorage => |this, client| {
+        client.post("/storage", this).await
+    },
+    ListStorage => |this, client| {
+        let ListStorage::V1(listing) = this;
         let query = format!(
             "limit={}&offset={}",
             listing.filters.limit, listing.filters.offset
         );
         client.get(&format!("/storage?{query}")).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/tenant/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/tenant/protocol/requests.rs
@@ -14,14 +14,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for CreateTenant {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/tenants", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetTenant {
@@ -29,15 +21,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) key: ResourceKey<TenantId>,
         }
-    }
-}
-
-impl ClientRequest for GetTenant {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetTenant::V1(lookup) = self;
-        client.get(&format!("/tenants/{}", lookup.key)).await
     }
 }
 
@@ -54,17 +37,22 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListTenants {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListTenants::V1(listing) = self;
+resource_requests! {
+    CreateTenant => |this, client| {
+        client.post("/tenants", this).await
+    },
+    GetTenant => |this, client| {
+        let GetTenant::V1(lookup) = this;
+        client.get(&format!("/tenants/{}", lookup.key)).await
+    },
+    ListTenants => |this, client| {
+        let ListTenants::V1(listing) = this;
         let query = format!(
             "limit={}&offset={}",
             listing.filters.limit, listing.filters.offset,
         );
         client.get(&format!("/tenants?{query}")).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/texture/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/texture/protocol/requests.rs
@@ -20,15 +20,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for SetTexture {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let SetTexture::V1(body) = self;
-        client.put(&format!("/textures/{}", body.name), self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetTexture {
@@ -39,15 +30,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for GetTexture {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetTexture::V1(lookup) = self;
-        client.get(&format!("/textures/{}", lookup.key)).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum RemoveTexture {
@@ -55,15 +37,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) name: TextureName,
         }
-    }
-}
-
-impl ClientRequest for RemoveTexture {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let RemoveTexture::V1(removal) = self;
-        client.delete(&format!("/textures/{}", removal.name)).await
     }
 }
 
@@ -80,17 +53,27 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListTextures {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListTextures::V1(listing) = self;
+resource_requests! {
+    SetTexture => |this, client| {
+        let SetTexture::V1(body) = this;
+        client.put(&format!("/textures/{}", body.name), this).await
+    },
+    GetTexture => |this, client| {
+        let GetTexture::V1(lookup) = this;
+        client.get(&format!("/textures/{}", lookup.key)).await
+    },
+    RemoveTexture => |this, client| {
+        let RemoveTexture::V1(removal) = this;
+        client.delete(&format!("/textures/{}", removal.name)).await
+    },
+    ListTextures => |this, client| {
+        let ListTextures::V1(listing) = this;
         let query = format!(
             "limit={}&offset={}",
             listing.filters.limit, listing.filters.offset,
         );
         client.get(&format!("/textures?{query}")).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/ticket/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/ticket/protocol/requests.rs
@@ -22,14 +22,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for CreateTicket {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/tickets", self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetTicket {
@@ -40,15 +32,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for GetTicket {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetTicket::V1(lookup) = self;
-        client.get(&format!("/tickets/{}", lookup.key)).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum ValidateTicket {
@@ -56,14 +39,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) token: Token,
         }
-    }
-}
-
-impl ClientRequest for ValidateTicket {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        client.post("/tickets/validate", self).await
     }
 }
 
@@ -80,17 +55,21 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListTickets {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListTickets::V1(listing) = self;
+resource_requests! {
+    CreateTicket => |this, client| { client.post("/tickets", this).await },
+    GetTicket => |this, client| {
+        let GetTicket::V1(lookup) = this;
+        client.get(&format!("/tickets/{}", lookup.key)).await
+    },
+    ListTickets => |this, client| {
+        let ListTickets::V1(listing) = this;
         let query = format!(
             "limit={}&offset={}",
             listing.filters.limit, listing.filters.offset,
         );
         client.get(&format!("/tickets?{query}")).await
-    }
+    },
+    ValidateTicket => |this, client| { client.post("/tickets/validate", this).await },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/trail/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/trail/protocol/requests.rs
@@ -18,15 +18,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for TrailOf {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let TrailOf::V1(of) = self;
-        client.get(&format!("/trail/of/{}", of.r#ref)).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum TrailFrom {
@@ -39,13 +30,15 @@ versioned! {
     }
 }
 
-impl ClientRequest for TrailFrom {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let TrailFrom::V1(from) = self;
+resource_requests! {
+    TrailOf => |this, client| {
+        let TrailOf::V1(of) = this;
+        client.get(&format!("/trail/of/{}", of.r#ref)).await
+    },
+    TrailFrom => |this, client| {
+        let TrailFrom::V1(from) = this;
         client.get(&format!("/trail/from/{}", from.event)).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/domains/urge/protocol/requests.rs
+++ b/crates/oneiros-engine/src/domains/urge/protocol/requests.rs
@@ -20,15 +20,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for SetUrge {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let SetUrge::V1(body) = self;
-        client.put(&format!("/urges/{}", body.name), self).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum GetUrge {
@@ -39,15 +30,6 @@ versioned! {
     }
 }
 
-impl ClientRequest for GetUrge {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let GetUrge::V1(lookup) = self;
-        client.get(&format!("/urges/{}", lookup.key)).await
-    }
-}
-
 versioned! {
     #[derive(JsonSchema)]
     pub(crate) enum RemoveUrge {
@@ -55,15 +37,6 @@ versioned! {
         V1 => {
             #[builder(into)] pub(crate) name: UrgeName,
         }
-    }
-}
-
-impl ClientRequest for RemoveUrge {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let RemoveUrge::V1(removal) = self;
-        client.delete(&format!("/urges/{}", removal.name)).await
     }
 }
 
@@ -80,17 +53,27 @@ versioned! {
     }
 }
 
-impl ClientRequest for ListUrges {
-    type Error = ClientError;
-
-    async fn execute_request(&self, client: &Client) -> Result<Vec<u8>, Self::Error> {
-        let ListUrges::V1(listing) = self;
+resource_requests! {
+    SetUrge => |this, client| {
+        let SetUrge::V1(body) = this;
+        client.put(&format!("/urges/{}", body.name), this).await
+    },
+    GetUrge => |this, client| {
+        let GetUrge::V1(lookup) = this;
+        client.get(&format!("/urges/{}", lookup.key)).await
+    },
+    RemoveUrge => |this, client| {
+        let RemoveUrge::V1(removal) = this;
+        client.delete(&format!("/urges/{}", removal.name)).await
+    },
+    ListUrges => |this, client| {
+        let ListUrges::V1(listing) = this;
         let query = format!(
             "limit={}&offset={}",
             listing.filters.limit, listing.filters.offset,
         );
         client.get(&format!("/urges?{query}")).await
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Kinded)]

--- a/crates/oneiros-engine/src/macros/mod.rs
+++ b/crates/oneiros-engine/src/macros/mod.rs
@@ -4,6 +4,7 @@ mod resource_id;
 mod resource_name;
 mod resource_op;
 mod resource_op_error;
+mod resource_requests;
 mod upcast_versions;
 mod versioned;
 
@@ -13,6 +14,7 @@ pub(crate) use resource_id::resource_id;
 pub(crate) use resource_name::resource_name;
 pub(crate) use resource_op::resource_op;
 pub(crate) use resource_op_error::resource_op_error;
+pub(crate) use resource_requests::resource_requests;
 pub(crate) use upcast_versions::upcast_versions;
 pub(crate) use versioned::__versioned_if_args;
 pub(crate) use versioned::versioned;

--- a/crates/oneiros-engine/src/macros/resource_requests.rs
+++ b/crates/oneiros-engine/src/macros/resource_requests.rs
@@ -1,0 +1,35 @@
+macro_rules! resource_requests {
+    ($($request:ident => |$client:ident| { $($inner:tt)* }),* $(,)?) => {
+        $(
+            impl crate::ClientRequest for $request {
+                type Error = crate::ClientError;
+
+                async fn execute_request(
+                    &self,
+                    client: &crate::Client,
+                ) -> Result<Vec<u8>, Self::Error> {
+                    let $client = client;
+                    $($inner)*
+                }
+            }
+        )*
+    };
+    ($($request:ident => |$this:ident, $client:ident| { $($inner:tt)* }),* $(,)?) => {
+        $(
+            impl crate::ClientRequest for $request {
+                type Error = crate::ClientError;
+
+                async fn execute_request(
+                    &self,
+                    client: &crate::Client,
+                ) -> Result<Vec<u8>, Self::Error> {
+                    let $this = self;
+                    let $client = client;
+                    $($inner)*
+                }
+            }
+        )*
+    };
+}
+
+pub(crate) use resource_requests;


### PR DESCRIPTION
This puts a macro in place where we'd been implementing `ClientRequest`, which was a little boilerplate heavy. I'm actually not too terribly sure about this one - it seems like the client request idea is stable enough to toss the boilerplate, but is it? If so, our idea is to let a caller assemble them as if they're closures in a match statement. It feels like a positive move to me, and it tosses around ~420 lines, so that's nice, but every time I do something like this I sit and stare at it much too long, wondering.

Release-Type: refactor