### PR TITLE
Cow town for skills

### DIFF
--- a/crates/oneiros-engine/src/skill.rs
+++ b/crates/oneiros-engine/src/skill.rs
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn all_skill_names_are_unique() {
         let skills = SkillInventory::all();
-        let mut names: Vec<&str> = skills.iter().map(|s| s.name).collect();
+        let mut names: Vec<&str> = skills.iter().map(|s| s.name.as_ref()).collect();
         names.sort();
         names.dedup();
         assert_eq!(names.len(), skills.len(), "duplicate skill names found");
@@ -230,7 +230,7 @@ mod tests {
             .iter()
             .filter(|s| {
                 matches!(
-                    s.name,
+                    s.name.as_ref(),
                     "wake"
                         | "dream"
                         | "introspect"

--- a/crates/oneiros-engine/src/tests/workflows/skills.rs
+++ b/crates/oneiros-engine/src/tests/workflows/skills.rs
@@ -16,7 +16,7 @@ fn skill_docs_reference_valid_commands() {
     let mut stale: Vec<StaleRef> = Vec::new();
 
     for skill in SkillInventory::all() {
-        for invocation in extract_invocations(skill.content) {
+        for invocation in extract_invocations(skill.content.as_ref()) {
             // The captured invocation already starts with "oneiros" — clap
             // expects argv[0] to be the binary name, so we feed it as-is.
             let Some(argv) = shlex::split(invocation) else {
@@ -26,7 +26,7 @@ fn skill_docs_reference_valid_commands() {
             match Cli::try_parse_from(&argv) {
                 Err(err) if err.kind() == ErrorKind::InvalidSubcommand => {
                     stale.push(StaleRef {
-                        skill: skill.name,
+                        skill: skill.name.to_string(),
                         invocation: invocation.to_string(),
                     });
                 }
@@ -52,7 +52,7 @@ fn skill_docs_reference_valid_commands() {
 }
 
 struct StaleRef {
-    skill: &'static str,
+    skill: String,
     invocation: String,
 }
 

--- a/crates/oneiros-engine/src/values/skill.rs
+++ b/crates/oneiros-engine/src/values/skill.rs
@@ -1,18 +1,25 @@
+use std::borrow::Cow;
+
 /// A skill command document — markdown describing one CLI operation.
 ///
 /// Each domain produces its skills via `include_str!`, making missing
 /// files a compile error. The root collector gathers all domain skills
 /// into a complete inventory for the build-to-dist pipeline.
-#[derive(Debug, Clone)]
+#[derive(bon::Builder, Debug, Clone)]
 pub(crate) struct Skill {
     /// The command name used in the skill file path (e.g. "level-set").
-    pub(crate) name: &'static str,
+    #[builder(into)]
+    pub(crate) name: Cow<'static, str>,
     /// The raw markdown content, loaded at compile time.
-    pub(crate) content: &'static str,
+    #[builder(into)]
+    pub(crate) content: Cow<'static, str>,
 }
 
 impl Skill {
-    pub(crate) const fn new(name: &'static str, content: &'static str) -> Self {
-        Self { name, content }
+    pub(crate) fn new(name: &'static str, content: &'static str) -> Self {
+        Self {
+            name: Cow::Borrowed(name),
+            content: Cow::Borrowed(content),
+        }
     }
 }


### PR DESCRIPTION
We're moving over to `Cow` for our strings in the skill structure, mainly because we want to explore generating these things, and that means we can't rely on exclusively static strings.

Release-Type: refactor