### PR TITLE
Oh, database, you scoundrel.

### DIFF
--- a/crates/oneiros-engine/src/config.rs
+++ b/crates/oneiros-engine/src/config.rs
@@ -335,16 +335,50 @@ impl Config {
         Platform::new(&self.data_dir)
     }
 
+    // ── Database openers ────────────────────────────────────────────
+    //
+    // All database connections flow through these methods so that every
+    // pragma is applied from a single source. Callers should use these
+    // instead of reaching for `rusqlite::Connection::open` directly.
+
+    /// Apply every pragma from [`DatabaseConfig`] to a connection.
+    fn apply_pragmas(&self, conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
+        let db = &self.database;
+        conn.pragma_update(None, "journal_mode", &db.journal_mode)?;
+        conn.pragma_update(None, "synchronous", &db.synchronous)?;
+        conn.pragma_update(None, "cache_size", db.cache_size.to_string())?;
+        conn.pragma_update(None, "temp_store", &db.temp_store)?;
+        conn.pragma_update(None, "mmap_size", db.mmap_size.to_string())?;
+        conn.pragma_update(None, "limit_attached", db.limit_attached.to_string())?;
+        Ok(())
+    }
+
+    /// Open a connection and apply pragmas from [`DatabaseConfig`].
+    /// The `name` parameter is reserved for future in-memory database
+    /// support (connection lifecycle refactor).
+    pub(crate) fn open_database(
+        &self,
+        path: &std::path::Path,
+        _name: &str,
+    ) -> Result<rusqlite::Connection, rusqlite::Error> {
+        let conn = rusqlite::Connection::open(path)?;
+        self.apply_pragmas(&conn)?;
+        Ok(conn)
+    }
+
     /// Open the host database.
     pub(crate) fn host_db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
-        let conn = rusqlite::Connection::open(self.platform().host_db_path())?;
-        conn.pragma_update(None, "journal_mode", "wal")?;
-        Ok(conn)
+        self.open_database(&self.platform().host_db_path(), "host")
     }
 
     /// Path to the project's event log database.
     pub(crate) fn events_db_path(&self) -> PathBuf {
         self.platform().events_db_path(&self.project)
+    }
+
+    /// Open the project's event log database.
+    pub(crate) fn open_events_db(&self) -> Result<rusqlite::Connection, rusqlite::Error> {
+        self.open_database(&self.events_db_path(), "events")
     }
 
     /// Path to the bookmark's projection database.
@@ -367,13 +401,9 @@ impl Config {
         let platform = self.platform();
         let _ = platform.ensure_bookmarks_dir(&self.project);
 
-        let conn =
-            rusqlite::Connection::open(platform.bookmark_db_path(&self.project, &self.bookmark))?;
-        conn.pragma_update(None, "journal_mode", "wal")?;
-        conn.pragma_update(
-            None,
-            "limit_attached",
-            self.database.limit_attached.to_string(),
+        let conn = self.open_database(
+            &platform.bookmark_db_path(&self.project, &self.bookmark),
+            &format!("bookmark_{}", self.bookmark),
         )?;
 
         conn.execute_batch(&format!(
@@ -468,11 +498,6 @@ pub(crate) trait FromConfig: Sized {
 mod tests {
     use super::*;
 
-    /// Build overrides with everything at default (all `None`).
-    fn empty_overrides() -> CliOverrides {
-        CliOverrides::default()
-    }
-
     /// Build a Config pointing at a tempdir for isolated file tests.
     fn config_in(dir: &std::path::Path) -> Config {
         Config::builder()
@@ -499,7 +524,7 @@ mod tests {
     #[test]
     fn missing_file_returns_defaults() {
         let dir = tempfile::tempdir().unwrap();
-        let config = resolve_in(dir.path(), &empty_overrides());
+        let config = resolve_in(dir.path(), &CliOverrides::default());
 
         let expected = config_in(dir.path());
         assert_eq!(config.service.address, expected.service.address);
@@ -511,7 +536,7 @@ mod tests {
     fn empty_file_returns_defaults() {
         let dir = tempfile::tempdir().unwrap();
         write_config(dir.path(), "");
-        let config = resolve_in(dir.path(), &empty_overrides());
+        let config = resolve_in(dir.path(), &CliOverrides::default());
 
         let expected = config_in(dir.path());
         assert_eq!(config.service.address, expected.service.address);
@@ -521,7 +546,7 @@ mod tests {
     fn malformed_file_falls_back_to_defaults() {
         let dir = tempfile::tempdir().unwrap();
         write_config(dir.path(), "this is not valid toml {{{{");
-        let config = resolve_in(dir.path(), &empty_overrides());
+        let config = resolve_in(dir.path(), &CliOverrides::default());
 
         let expected = config_in(dir.path());
         assert_eq!(config.service.address, expected.service.address);
@@ -537,7 +562,7 @@ mod tests {
 address = "127.0.0.1:3000"
 "#,
         );
-        let config = resolve_in(dir.path(), &empty_overrides());
+        let config = resolve_in(dir.path(), &CliOverrides::default());
 
         assert_eq!(
             config.service.address,
@@ -556,7 +581,7 @@ interval = "50ms"
 timeout = "5s"
 "#,
         );
-        let config = resolve_in(dir.path(), &empty_overrides());
+        let config = resolve_in(dir.path(), &CliOverrides::default());
 
         assert_eq!(config.fetch.interval, std::time::Duration::from_millis(50));
         assert_eq!(config.fetch.timeout, std::time::Duration::from_secs(5));
@@ -573,7 +598,7 @@ cognition_size = 50
 dream_depth = 3
 "#,
         );
-        let config = resolve_in(dir.path(), &empty_overrides());
+        let config = resolve_in(dir.path(), &CliOverrides::default());
 
         assert_eq!(config.dream.cognition_size, 50);
         assert_eq!(config.dream.dream_depth, 3);
@@ -651,7 +676,7 @@ dream_depth = 3
     fn file_overrides_output_mode() {
         let dir = tempfile::tempdir().unwrap();
         write_config(dir.path(), r#"output = "json""#);
-        let config = resolve_in(dir.path(), &empty_overrides());
+        let config = resolve_in(dir.path(), &CliOverrides::default());
 
         assert_eq!(config.output, OutputMode::Json);
     }
@@ -666,7 +691,7 @@ dream_depth = 3
 health_check_delays_ms = [100, 200]
 "#,
         );
-        let config = resolve_in(dir.path(), &empty_overrides());
+        let config = resolve_in(dir.path(), &CliOverrides::default());
 
         assert_eq!(config.service.health_check_delays_ms, vec![100, 200]);
     }
@@ -681,7 +706,7 @@ health_check_delays_ms = [100, 200]
 experience_size = 25
 "#,
         );
-        let config = resolve_in(dir.path(), &empty_overrides());
+        let config = resolve_in(dir.path(), &CliOverrides::default());
 
         assert_eq!(config.dream.experience_size, 25);
         assert_eq!(config.dream.cognition_size, 20); // default preserved
@@ -692,7 +717,7 @@ experience_size = 25
     fn file_overrides_color_choice() {
         let dir = tempfile::tempdir().unwrap();
         write_config(dir.path(), r#"color = "never""#);
-        let config = resolve_in(dir.path(), &empty_overrides());
+        let config = resolve_in(dir.path(), &CliOverrides::default());
 
         assert_eq!(config.color, ColorChoice::Never);
     }
@@ -701,7 +726,7 @@ experience_size = 25
     fn file_overrides_verbosity() {
         let dir = tempfile::tempdir().unwrap();
         write_config(dir.path(), r#"verbosity = "verbose""#);
-        let config = resolve_in(dir.path(), &empty_overrides());
+        let config = resolve_in(dir.path(), &CliOverrides::default());
 
         assert_eq!(config.verbosity, Verbosity::Verbose);
     }
@@ -767,7 +792,7 @@ address = "127.0.0.1:4000"
                 .merge(Serialized::defaults(Config::default()))
                 .merge(Toml::file("config.toml"))
                 .merge(Env::prefixed("ONEIROS_").split("__"))
-                .merge(Serialized::defaults(empty_overrides()));
+                .merge(Serialized::defaults(CliOverrides::default()));
 
             let config: Config = figment.extract()?;
             assert_eq!(config.output, OutputMode::Prompt);

--- a/crates/oneiros-engine/src/db.rs
+++ b/crates/oneiros-engine/src/db.rs
@@ -1,9 +1,10 @@
 //! Typed database primitives.
 //!
-//! Each DB the engine opens has its own type that owns a connection,
-//! handles its own pragmas, and reports its own errors. Types deref to
-//! `rusqlite::Connection` so existing query code keeps working while
-//! the seams migrate.
+//! Each DB the engine opens has its own type that owns a connection and
+//! derefs to `rusqlite::Connection` so existing query code keeps working.
+//! All connection opens route through [`Config`] methods so that every
+//! pragma is applied from a single source — no more scattered
+//! `rusqlite::Connection::open` calls with ad-hoc pragma strings.
 //!
 //! `open` methods are `async fn` even though their bodies are sync —
 //! the signature is the migration seam for sqlx.
@@ -54,16 +55,15 @@ impl HostDb {
     /// public entry — services and actors at any tier reach the
     /// host db this way.
     pub(crate) async fn open<S: HasHost>(scope: &S) -> Result<Self, HostDbError> {
-        Self::open_with(&scope.config().platform()).await
+        Self::open_with(scope.config()).await
     }
 
-    /// Open directly from a `Platform`. Underlying primitive — used by
-    /// the scope-form above and by tests / hydration paths that don't
-    /// have a scope handy.
-    pub(crate) async fn open_with(platform: &Platform) -> Result<Self, HostDbError> {
-        platform.ensure_data_dir()?;
-        let connection = rusqlite::Connection::open(platform.host_db_path())?;
-        connection.pragma_update(None, "journal_mode", "wal")?;
+    /// Open directly from a `Config`. Underlying primitive — used by
+    /// the scope-form above and by paths that have a `Config` but no
+    /// scope.
+    pub(crate) async fn open_with(config: &Config) -> Result<Self, HostDbError> {
+        config.platform().ensure_data_dir()?;
+        let connection = config.host_db()?;
         Ok(Self { connection })
     }
 }
@@ -86,17 +86,19 @@ pub(crate) struct EventsDb {
 impl EventsDb {
     /// Open from any scope tier that carries project info.
     pub(crate) async fn open<S: HasProject>(scope: &S) -> Result<Self, EventsDbError> {
-        Self::open_with(&scope.config().platform(), &scope.project().name).await
+        Self::open_with(scope.config(), &scope.project().name).await
     }
 
-    /// Open directly from a `Platform` + project. Underlying primitive.
+    /// Open directly from a `Config` + project. Underlying primitive.
     pub(crate) async fn open_with(
-        platform: &Platform,
+        config: &Config,
         project: &ProjectName,
     ) -> Result<Self, EventsDbError> {
-        platform.ensure_project_dir(project)?;
-        let connection = rusqlite::Connection::open(platform.events_db_path(project))?;
-        connection.pragma_update(None, "journal_mode", "wal")?;
+        config.platform().ensure_project_dir(project)?;
+        // Clone the config with the project name so events_db_path resolves.
+        let mut project_config = config.clone();
+        project_config.project = project.clone();
+        let connection = project_config.open_events_db()?;
         Ok(Self { connection })
     }
 }
@@ -121,32 +123,27 @@ pub(crate) struct BookmarkDb {
 impl BookmarkDb {
     /// Open from a bookmark-tier scope.
     pub(crate) async fn open<S: HasBookmark>(scope: &S) -> Result<Self, BookmarkDbError> {
-        let config = scope.config();
         Self::open_with(
-            &config.platform(),
+            scope.config(),
             &scope.project().name,
             &scope.bookmark().name,
-            config.database.limit_attached,
         )
         .await
     }
 
-    /// Open directly from a `Platform` + project + bookmark. Underlying
-    /// primitive — used by the scope-form above and by tests.
+    /// Open directly from config + project + bookmark. Underlying
+    /// primitive — used by the scope-form above and by paths that have
+    /// a `Config` but no scope.
     pub(crate) async fn open_with(
-        platform: &Platform,
+        config: &Config,
         project: &ProjectName,
         bookmark: &BookmarkName,
-        limit_attached: u32,
     ) -> Result<Self, BookmarkDbError> {
-        platform.ensure_bookmarks_dir(project)?;
-        let connection = rusqlite::Connection::open(platform.bookmark_db_path(project, bookmark))?;
-        connection.pragma_update(None, "journal_mode", "wal")?;
-        connection.pragma_update(None, "limit_attached", limit_attached.to_string())?;
-        connection.execute_batch(&format!(
-            "ATTACH DATABASE '{}' AS events",
-            platform.events_db_path(project).display(),
-        ))?;
+        config.platform().ensure_bookmarks_dir(project)?;
+        let mut project_config = config.clone();
+        project_config.project = project.clone();
+        project_config.bookmark = bookmark.clone();
+        let connection = project_config.bookmark_conn()?;
         Ok(Self { connection })
     }
 }
@@ -162,43 +159,52 @@ impl Deref for BookmarkDb {
 mod tests {
     use super::*;
 
-    fn test_platform() -> (tempfile::TempDir, Platform) {
-        let dir = tempfile::tempdir().unwrap();
-        let platform = Platform::new(dir.path());
-        (dir, platform)
+    fn test_config() -> (tempfile::TempDir, Config) {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let config = Config::builder()
+            .data_dir(dir.path().to_path_buf())
+            .project(ProjectName::new("test"))
+            .output(OutputMode::Json)
+            .service(
+                ServiceConfig::builder()
+                    .address("127.0.0.1:0".parse().unwrap())
+                    .build(),
+            )
+            .build();
+        (dir, config)
     }
 
     #[tokio::test]
     async fn host_db_opens_and_creates_host_db() {
-        let (_dir, platform) = test_platform();
-        let _db = HostDb::open_with(&platform).await.unwrap();
-        assert!(platform.host_db_path().exists());
+        let (_dir, config) = test_config();
+        let _db = HostDb::open_with(&config).await.unwrap();
+        assert!(config.platform().host_db_path().exists());
     }
 
     #[tokio::test]
     async fn events_db_opens_and_creates_project_dir() {
-        let (_dir, platform) = test_platform();
+        let (_dir, config) = test_config();
         let project = ProjectName::new("alpha");
-        let _db = EventsDb::open_with(&platform, &project).await.unwrap();
-        assert!(platform.project_dir(&project).is_dir());
-        assert!(platform.events_db_path(&project).exists());
+        let _db = EventsDb::open_with(&config, &project).await.unwrap();
+        assert!(config.platform().project_dir(&project).is_dir());
+        assert!(config.platform().events_db_path(&project).exists());
     }
 
     #[tokio::test]
     async fn bookmark_db_opens_with_events_attached() {
-        let (_dir, platform) = test_platform();
+        let (_dir, config) = test_config();
         let project = ProjectName::new("alpha");
         let bookmark = BookmarkName::main();
 
         // Pre-create events db so ATTACH points at a real file.
-        let _events = EventsDb::open_with(&platform, &project).await.unwrap();
-        let db = BookmarkDb::open_with(&platform, &project, &bookmark, 125)
+        let _events = EventsDb::open_with(&config, &project).await.unwrap();
+        let db = BookmarkDb::open_with(&config, &project, &bookmark)
             .await
             .unwrap();
 
-        // Attached schema is queryable.
+        // Verify the ATTACH worked — events schema should be queryable.
         let count: i64 = db
-            .query_row("select count(*) from events.sqlite_master", [], |row| {
+            .query_row("SELECT count(*) FROM events.sqlite_master", [], |row| {
                 row.get(0)
             })
             .unwrap();

--- a/crates/oneiros-engine/src/domains/host/service.rs
+++ b/crates/oneiros-engine/src/domains/host/service.rs
@@ -29,7 +29,7 @@ impl HostService {
 
         config.platform().ensure_dir(&config.data_dir)?;
         HostKey::new(config.platform()).ensure()?;
-        let host_db = HostDb::open_with(&config.platform()).await?;
+        let host_db = HostDb::open_with(config).await?;
         EventLog::new(&host_db).init()?;
         Projections::host().migrate(&host_db)?;
         drop(host_db);

--- a/crates/oneiros-engine/src/domains/project/service.rs
+++ b/crates/oneiros-engine/src/domains/project/service.rs
@@ -79,13 +79,16 @@ impl ProjectService {
         let bookmarks_dir = project_dir.join("bookmarks");
         platform.ensure_dir(&bookmarks_dir)?;
 
-        let events_db = rusqlite::Connection::open(project_dir.join("events.db"))?;
-        events_db.pragma_update(None, "journal_mode", "wal")?;
+        // Build a config for the new project so we can use the unified openers.
+        let mut project_config = scope.config().clone();
+        project_config.project = project_name.clone();
+        project_config.bookmark = BookmarkName::main();
+
+        let events_db = project_config.open_events_db()?;
         EventLog::new(&events_db).init()?;
         drop(events_db);
 
-        let bookmark_db = rusqlite::Connection::open(bookmarks_dir.join("main.db"))?;
-        bookmark_db.pragma_update(None, "journal_mode", "wal")?;
+        let bookmark_db = project_config.bookmark_conn()?;
         Projections::project().migrate(&bookmark_db)?;
         drop(bookmark_db);
 
@@ -243,13 +246,7 @@ impl ProjectService {
         let reader = std::io::BufReader::new(file);
         let mut imported = 0usize;
 
-        let db = BookmarkDb::open_with(
-            &config.platform(),
-            &config.project,
-            &config.bookmark,
-            config.database.limit_attached,
-        )
-        .await?;
+        let db = BookmarkDb::open_with(config, &config.project, &config.bookmark).await?;
         let log = EventLog::attached(&db);
         let projections = Projections::<ProjectCanon>::project();
 
@@ -312,13 +309,7 @@ impl ProjectService {
         let _ = platform.remove_file(db_path.with_extension("db-wal"));
         let _ = platform.remove_file(db_path.with_extension("db-shm"));
 
-        let db = BookmarkDb::open_with(
-            &config.platform(),
-            &config.project,
-            &config.bookmark,
-            config.database.limit_attached,
-        )
-        .await?;
+        let db = BookmarkDb::open_with(config, &config.project, &config.bookmark).await?;
         let projections = Projections::<ProjectCanon>::project();
         projections.migrate(&db)?;
         let log = EventLog::attached(&db);

--- a/crates/oneiros-engine/src/migrations/brains_to_projects.rs
+++ b/crates/oneiros-engine/src/migrations/brains_to_projects.rs
@@ -20,7 +20,7 @@ impl Migration for BrainsToProjects {
             return Ok(false);
         }
 
-        let conn = rusqlite::Connection::open(&host_db)?;
+        let conn = config.host_db()?;
         let needs_rename = table_exists(&conn, "brains")?
             || column_exists(&conn, "bookmarks", "brain")?
             || column_exists(&conn, "follows", "brain")?
@@ -31,8 +31,7 @@ impl Migration for BrainsToProjects {
     }
 
     fn apply(&self, config: &Config) -> Result<(), MigrationError> {
-        let host_db = config.platform().host_db_path();
-        let mut conn = rusqlite::Connection::open(&host_db)?;
+        let mut conn = config.host_db()?;
         let tx = conn.transaction()?;
 
         if table_exists(&tx, "brains")? && !table_exists(&tx, "projects")? {

--- a/crates/oneiros-engine/src/tests/acceptance/mod.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/mod.rs
@@ -137,6 +137,10 @@ impl Backend for EngineBackend {
         let mut config = Config::builder()
             .data_dir(dir.path().to_path_buf())
             .project(ProjectName::new("test-project"))
+            .fetch(Fetch {
+                interval: std::time::Duration::from_millis(2),
+                timeout: std::time::Duration::from_millis(100),
+            })
             .service(
                 ServiceConfig::builder()
                     .address("127.0.0.1:0".parse()?)

--- a/crates/oneiros-engine/src/values/canon_index.rs
+++ b/crates/oneiros-engine/src/values/canon_index.rs
@@ -246,13 +246,12 @@ impl CanonIndex {
         let mut project_config = config.clone();
         project_config.project = name.clone();
 
-        // Events DB — standalone (no ATTACH).
-        let events_path = project_config.events_db_path();
-        if !events_path.exists() {
+        // Events DB — standalone (no ATTACH). Bail early if the file
+        // doesn't exist — `open_database` would create it otherwise.
+        if !project_config.events_db_path().exists() {
             return Ok(());
         }
-        let events_db = rusqlite::Connection::open(&events_path)?;
-        events_db.pragma_update(None, "journal_mode", "wal")?;
+        let events_db = project_config.open_events_db()?;
         let log = EventLog::new(&events_db);
 
         // Ensure projection schema exists in the bookmark DB.

--- a/crates/oneiros-engine/src/values/database_config.rs
+++ b/crates/oneiros-engine/src/values/database_config.rs
@@ -3,12 +3,40 @@ use serde::{Deserialize, Serialize};
 
 /// Database tuning knobs.
 ///
-/// Lives inside [`Config`] as the `[database]` section. Currently
-/// holds the SQLite `limit_attached` pragma — the ceiling on
-/// concurrently-attached databases per connection.
+/// Lives inside [`Config`] as the `[database]` section. Carries every
+/// SQLite pragma the engine needs so that all open sites go through one
+/// config-driven path instead of scattered `rusqlite::Connection::open`
+/// calls with ad-hoc pragma strings.
 #[derive(Builder, Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub(crate) struct DatabaseConfig {
+    // ── SQLite pragmas ──────────────────────────────────────────────
+    /// Journal mode. Always `"wal"` — write-ahead log for concurrency.
+    #[builder(default = String::from("wal"))]
+    pub(crate) journal_mode: String,
+
+    /// Synchronous setting. `"normal"` (2) balances safety and speed —
+    /// fsyncs at critical moments but not every write. `"full"` (2 fsyncs
+    /// per transaction) is safer but much slower; `"off"` is dangerous.
+    #[builder(default = String::from("normal"))]
+    pub(crate) synchronous: String,
+
+    /// SQLite page cache size in KB. Negative means kibibytes (e.g.
+    /// `-2000` = 2 MiB). Positive means number of pages.
+    #[builder(default = -2000i64)]
+    pub(crate) cache_size: i64,
+
+    /// Where SQLite stores temp tables and indices. `"memory"` (2)
+    /// keeps them in RAM; `"file"` (1) writes to disk.
+    #[builder(default = String::from("memory"))]
+    pub(crate) temp_store: String,
+
+    /// Memory-mapped I/O size in bytes. `0` disables mmap. Setting this
+    /// to a large value (e.g. `268435456` = 256 MiB) can improve read
+    /// performance but keeps the database pinned in virtual memory.
+    #[builder(default = 0u64)]
+    pub(crate) mmap_size: u64,
+
     /// Maximum number of concurrently-attached databases per connection
     /// (SQLite `limit_attached` pragma). Defaults to 125 — the SQLite
     /// compile-time default.


### PR DESCRIPTION
We dove into test slowdown and found that the biggest culprit was our handling of our database. It's always been sort of lacksadaisical by design, but in a real sense it's begun to complicate the application and slow down tests, specifically. Mainly, we're opening up connections a ton, and doing a lot of boilerplate-like work around that.

The real fix is to actually reduce database operations to single cached moments where we bootstrap a connection at maximum once, and then pool it. But, we aren't there yet, architecturally - it'll take a thorough databse refactor to get there. The upshot of doing that is we'll be able to configure database modes and adapters, so we're definitely going there, and soon. But, for now, we wanted to roll the test improvements out on their own.

Release-Type: fix