### PR TITLE
Tolerate refs in CLI.

### DIFF
--- a/crates/oneiros-engine/src/tests/acceptance/cases/cognition.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/cognition.rs
@@ -174,6 +174,41 @@ pub(crate) async fn show_by_id<B: Backend>() -> TestResult {
     Ok(())
 }
 
+pub(crate) async fn show_by_bare_ref<B: Backend>() -> TestResult {
+    let harness = with_agent::<B>().await?;
+
+    let add_response = harness
+        .exec_json("cognition add thinker.process observation 'Show me this'")
+        .await?;
+
+    let ref_token = match add_response {
+        Responses::Cognition(CognitionResponse::CognitionAdded(CognitionAddedResponse::V1(
+            added,
+        ))) => RefToken::new(Ref::cognition(added.cognition.id)),
+        other => panic!("expected CognitionAdded, got {other:#?}"),
+    };
+
+    // Strip the "ref:" prefix — exercise the bare-token fallback in ResourceKey::from_str.
+    let bare = ref_token
+        .to_string()
+        .strip_prefix("ref:")
+        .unwrap()
+        .to_string();
+
+    let show_response = harness.exec_json(&format!("cognition show {bare}")).await?;
+
+    match show_response {
+        Responses::Cognition(CognitionResponse::CognitionDetails(
+            CognitionDetailsResponse::V1(details),
+        )) => {
+            assert_eq!(details.cognition.content.as_str(), "Show me this");
+        }
+        other => panic!("expected CognitionDetails via bare ref, got {other:#?}"),
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn show_prompt<B: Backend>() -> TestResult {
     let harness = with_agent::<B>().await?;
 

--- a/crates/oneiros-engine/src/tests/acceptance/cases/connection.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/cases/connection.rs
@@ -58,6 +58,27 @@ pub(crate) async fn create<B: Backend>() -> TestResult {
     Ok(())
 }
 
+pub(crate) async fn create_with_bare_refs<B: Backend>() -> TestResult {
+    let (harness, from_ref, to_ref) = with_connectable_entities::<B>().await?;
+
+    // Strip the "ref:" prefix from both tokens to exercise the bare-token fallback.
+    let bare_from = from_ref.strip_prefix("ref:").unwrap();
+    let bare_to = to_ref.strip_prefix("ref:").unwrap();
+
+    let cmd = format!("connection create caused {bare_from} {bare_to}");
+    let response = harness.exec_json(&cmd).await?;
+
+    assert!(
+        matches!(
+            response,
+            Responses::Connection(ConnectionResponse::ConnectionCreated(_))
+        ),
+        "expected ConnectionCreated with bare refs, got {response:#?}"
+    );
+
+    Ok(())
+}
+
 pub(crate) async fn list_empty<B: Backend>() -> TestResult {
     let harness = Harness::<B>::init_project().await?;
 

--- a/crates/oneiros-engine/src/tests/acceptance/mod.rs
+++ b/crates/oneiros-engine/src/tests/acceptance/mod.rs
@@ -358,6 +358,7 @@ async fn agent_show_returns_details() -> TestResult {
 async fn agent_show_by_ref() -> TestResult {
     cases::agent::show_by_ref::<EngineBackend>().await
 }
+
 #[tokio::test]
 async fn agent_show_by_wrong_kind_ref_errors() -> TestResult {
     cases::agent::show_by_wrong_kind_ref_errors::<EngineBackend>().await
@@ -407,6 +408,10 @@ async fn agent_remove_prompt() -> TestResult {
 #[tokio::test]
 async fn connection_create() -> TestResult {
     cases::connection::create::<EngineBackend>().await
+}
+#[tokio::test]
+async fn connection_create_with_bare_refs() -> TestResult {
+    cases::connection::create_with_bare_refs::<EngineBackend>().await
 }
 #[tokio::test]
 async fn connection_list_empty() -> TestResult {
@@ -481,6 +486,10 @@ async fn memory_list_filters_by_query() -> TestResult {
 #[tokio::test]
 async fn cognition_show_by_id() -> TestResult {
     cases::cognition::show_by_id::<EngineBackend>().await
+}
+#[tokio::test]
+async fn cognition_show_by_bare_ref() -> TestResult {
+    cases::cognition::show_by_bare_ref::<EngineBackend>().await
 }
 #[tokio::test]
 async fn cognition_add_prompt_confirms_creation() -> TestResult {

--- a/crates/oneiros-engine/src/values/resource_key.rs
+++ b/crates/oneiros-engine/src/values/resource_key.rs
@@ -59,28 +59,25 @@ pub(crate) enum ResolveError {
     },
 }
 
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum ResourceKeyParseError<E: fmt::Debug + fmt::Display> {
-    #[error("{0}")]
-    Key(E),
-    #[error(transparent)]
-    Ref(#[from] RefError),
-}
-
 impl<K> FromStr for ResourceKey<K>
 where
     K: FromStr,
     K::Err: fmt::Debug + fmt::Display,
 {
-    type Err = ResourceKeyParseError<K::Err>;
+    type Err = RefError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.starts_with(REF_PREFIX) {
             Ok(Self::Ref(s.parse::<RefToken>()?))
         } else {
-            s.parse::<K>()
-                .map(Self::Key)
-                .map_err(ResourceKeyParseError::Key)
+            // Try native key first. On failure, fall back to bare ref token.
+            // Models occasionally omit the "ref:" prefix when passing tokens
+            // from dream output — the base64url string doesn't look like a UUID
+            // or name, so the fallback catches it and recovers.
+            match s.parse::<K>() {
+                Ok(key) => Ok(Self::Key(key)),
+                Err(_key_err) => s.parse::<RefToken>().map(Self::Ref),
+            }
         }
     }
 }
@@ -240,15 +237,30 @@ mod tests {
     }
 
     #[test]
-    fn malformed_id_fails_as_key_parse_error() {
+    fn malformed_id_falls_through_to_ref_error() {
+        // "not-a-uuid" fails both the native key parse and the bare-ref
+        // fallback. The ref error surfaces because it's more descriptive
+        // ("invalid base64") than the key error ("invalid UUID").
         let result: Result<ResourceKey<ExperienceId>, _> = "not-a-uuid".parse();
-        assert!(matches!(result, Err(ResourceKeyParseError::Key(_))));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parses_bare_base64url_as_ref_when_not_a_valid_key() {
+        // Models sometimes omit the "ref:" prefix. The bare base64url
+        // should fall through the native-key parse and succeed as a Ref.
+        let id = ExperienceId::new();
+        let full_token = RefToken::new(Ref::experience(id)).to_string();
+        let bare = full_token.strip_prefix("ref:").unwrap();
+        let parsed: ResourceKey<ExperienceId> = bare.parse().unwrap();
+        assert!(matches!(parsed, ResourceKey::Ref(_)));
+        assert_eq!(parsed.resolve().unwrap(), id);
     }
 
     #[test]
     fn malformed_ref_fails_as_ref_parse_error() {
         let result: Result<ResourceKey<ExperienceId>, _> = "ref:!!!bad!!!".parse();
-        assert!(matches!(result, Err(ResourceKeyParseError::Ref(_))));
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
We _did_ have this at one point so I think this is a bug fix on a regression, but we want to be able to permit non-ref usage of the CLI. We'll just assume it's there if it gets omitted.

Release-Type: fix